### PR TITLE
Change firstOption implementation

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Foldable.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Foldable.kt
@@ -205,18 +205,14 @@ interface Foldable<F> {
   /**
    * Get the first element of the foldable or none
    */
-  fun <A> Kind<F, A>.firstOption(): Option<A> = get(0)
+  fun <A> Kind<F, A>.firstOption(): Option<A> =
+    find { true }
 
   /**
    * Get the first element of the foldable or none if empty or the predicate does not match
    */
   fun <A> Kind<F, A>.firstOption(predicate: (A) -> Boolean): Option<A> =
-    foldLeft<A, Either<A, Long>>(0L.right()) { i, a ->
-      i.flatMap {
-        if (predicate(a)) Left(a)
-        else Right(it + 1L)
-      }
-    }.swap().toOption()
+    find { predicate(it) }
 
   fun <A> Kind<F, A>.toList(): List<A> = foldRight(Eval.now(emptyList<A>())) { v, acc -> acc.map { listOf(v) + it } }.value()
 

--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Foldable.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Foldable.kt
@@ -209,7 +209,7 @@ interface Foldable<F> {
     find { true }
 
   /**
-   * Get the first element of the foldable or none if empty or the predicate does not match
+   * Get the first element matching the predicate or none
    */
   fun <A> Kind<F, A>.firstOption(predicate: (A) -> Boolean): Option<A> =
     find { predicate(it) }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequenceK.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequenceK.kt
@@ -25,7 +25,6 @@ import arrow.core.extensions.sequencek.monad.monad
 import arrow.core.fix
 import arrow.core.k
 import arrow.core.some
-import arrow.core.toOption
 import arrow.core.toT
 import arrow.extension
 import arrow.typeclasses.Align
@@ -173,11 +172,6 @@ interface SequenceKFoldable : Foldable<ForSequenceK> {
   override fun <A> Kind<ForSequenceK, A>.get(idx: Long): Option<A> =
     if (idx < 0) None
     else fix().drop(idx.toInt()).firstOption()
-
-  override fun <A> Kind<ForSequenceK, A>.firstOption(): Option<A> = fix().firstOrNull().toOption()
-
-  override fun <A> Kind<ForSequenceK, A>.firstOption(predicate: (A) -> Boolean): Option<A> =
-    fix().firstOrNull(predicate).toOption()
 }
 
 @extension


### PR DESCRIPTION
This PR approaches the ticket [#22](https://github.com/arrow-kt/arrow-core/issues/22)

Changed firstOption implementation to be more like stdlib `firstOrNone`.