### PR TITLE
Unify `Foldable` to be more aligned with Kotlin stdlib

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Foldable.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Foldable.kt
@@ -147,7 +147,16 @@ interface Foldable<F> {
    *
    * If there are no elements, the result is true.
    */
+  @Deprecated("In favor of having a more Kotlin idiomatic API", ReplaceWith("all(p)"))
   fun <A> Kind<F, A>.forAll(p: (A) -> Boolean): Boolean =
+    all(p)
+
+  /**
+   * Check whether all elements satisfy the predicate.
+   *
+   * If there are no elements, the result is true.
+   */
+  fun <A> Kind<F, A>.all(p: (A) -> Boolean): Boolean =
     this.foldRight(Eval.True) { a, lb -> if (p(a)) lb else Eval.False }.value()
 
   /**
@@ -156,7 +165,11 @@ interface Foldable<F> {
   fun <A> Kind<F, A>.isEmpty(): Boolean =
     this.foldRight(Eval.True) { _, _ -> Eval.False }.value()
 
+  @Deprecated("In favor of having a more Kotlin idiomatic API", ReplaceWith("isNotEmpty()"))
   fun <A> Kind<F, A>.nonEmpty(): Boolean =
+    isNotEmpty()
+
+  fun <A> Kind<F, A>.isNotEmpty(): Boolean =
     !isEmpty()
 
   /**
@@ -205,13 +218,27 @@ interface Foldable<F> {
   /**
    * Get the first element of the foldable or none
    */
+  @Deprecated("In favor of having a more Kotlin idiomatic API", ReplaceWith("first()"))
   fun <A> Kind<F, A>.firstOption(): Option<A> =
+    first()
+
+  /**
+   * Get the first element matching the predicate or none
+   */
+  @Deprecated("In favor of having a more Kotlin idiomatic API", ReplaceWith("firstOrNone(predicate)"))
+  fun <A> Kind<F, A>.firstOption(predicate: (A) -> Boolean): Option<A> =
+    firstOrNone { predicate(it) }
+
+  /**
+   * Get the first element of the foldable or none
+   */
+  fun <A> Kind<F, A>.first(): Option<A> =
     find { true }
 
   /**
    * Get the first element matching the predicate or none
    */
-  fun <A> Kind<F, A>.firstOption(predicate: (A) -> Boolean): Option<A> =
+  fun <A> Kind<F, A>.firstOrNone(predicate: (A) -> Boolean): Option<A> =
     find { predicate(it) }
 
   fun <A> Kind<F, A>.toList(): List<A> = foldRight(Eval.now(emptyList<A>())) { v, acc -> acc.map { listOf(v) + it } }.value()

--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Foldable.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Foldable.kt
@@ -218,9 +218,9 @@ interface Foldable<F> {
   /**
    * Get the first element of the foldable or none
    */
-  @Deprecated("In favor of having a more Kotlin idiomatic API", ReplaceWith("first()"))
+  @Deprecated("In favor of having a more Kotlin idiomatic API", ReplaceWith("firstOrNone()"))
   fun <A> Kind<F, A>.firstOption(): Option<A> =
-    first()
+    firstOrNone()
 
   /**
    * Get the first element matching the predicate or none
@@ -232,7 +232,7 @@ interface Foldable<F> {
   /**
    * Get the first element of the foldable or none
    */
-  fun <A> Kind<F, A>.first(): Option<A> =
+  fun <A> Kind<F, A>.firstOrNone(): Option<A> =
     find { true }
 
   /**

--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Reducible.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Reducible.kt
@@ -132,9 +132,14 @@ interface NonEmptyReducible<F, G> : Reducible<F> {
     return p(a) || ga.exists(p)
   }
 
+  @Deprecated("In favor of having a more Kotlin idiomatic API", ReplaceWith("all(p)"))
   override fun <A> Kind<F, A>.forAll(p: (A) -> Boolean): Boolean = FG().run {
+    return all(p)
+  }
+
+  override fun <A> Kind<F, A>.all(p: (A) -> Boolean): Boolean = FG().run {
     val (a, ga) = split()
-    return p(a) && ga.forAll(p)
+    return p(a) && ga.all(p)
   }
 
   override fun <A> Kind<F, A>.size(MN: Monoid<Long>): Long = FG().run {


### PR DESCRIPTION
Fixes #4 .
All suggestions are welcome!
Deprecation of:
- forAll -> all
- nonEmpty -> isNotEmpty
- firstOption -> first
- firstOption(predicate) -> firstOrNone(predicate)