### PR TITLE
Removed (almost) all Try examples in documentation/comment blocks

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -601,7 +601,7 @@ import arrow.typeclasses.Show
  * ```
  *
  * Arrow contains `Either` instances for many useful typeclasses that allows you to use and transform right values.
- * Both Option and Try don't require a type parameter with the following functions, but it is specifically used for Either.Left
+ * Option does not require a type parameter with the following functions, but it is specifically used for Either.Left
  *
  * [Functor]({{'/docs/arrow/typeclasses/functor/' | relative_url }})
  *

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -21,7 +21,7 @@ typealias Invalid<E> = Validated.Invalid<E>
  * Passwords need to have at least one capital letter. Change, resubmit. Password needs to have at least one number.
  *
  * Or perhaps you're reading from a configuration file. One could imagine the configuration library
- * you're using returns a `Try`, or maybe a `Either`. Your parsing may look something like:
+ * you're using returns an `Either`. Your parsing may look something like:
  *
  * ```kotlin:ank
  * import arrow.core.Either

--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Functor.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Functor.kt
@@ -30,7 +30,7 @@ import arrow.documented
  * [map] allows us to safely compute over values under the assumption that they'll be there returning the
  * transformation encapsulated in the same context.
  *
- * Consider [arrow.core.Option]:
+ * Consider [arrow.core.Option] and [arrow.core.Either]:
  *
  * `Option<A>` allows us to model absence and has two possible states, `Some(a: A)` if the value is not absent and `None` to represent an empty case.
  * In a similar fashion `Either<L, R>` may have two possible cases `Left(l: L)` and `Right(r: R)`. By convention, `Left` is used to model the exceptional

--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Functor.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Functor.kt
@@ -42,10 +42,10 @@ import arrow.documented
  * import arrow.*
  * import arrow.core.*
  *
- * fun main(args: Array<String>) {
+ * suspend fun main(args: Array<String>) {
  *   val result =
  *   //sampleStart
- *   runBlocking { Either.catch { "1".toInt() }.map { it * 2 } }
+ *   Either.catch { "1".toInt() }.map { it * 2 }
  *   //sampleEnd
  *   println(result)
  * }

--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Functor.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Functor.kt
@@ -30,13 +30,13 @@ import arrow.documented
  * [map] allows us to safely compute over values under the assumption that they'll be there returning the
  * transformation encapsulated in the same context.
  *
- * Consider both [arrow.core.Option] and [arrow.core.Try]:
+ * Consider [arrow.core.Option]:
  *
  * `Option<A>` allows us to model absence and has two possible states, `Some(a: A)` if the value is not absent and `None` to represent an empty case.
- * In a similar fashion `Try<A>` may have two possible cases `Success(a: A)` for computations that succeed and `Failure(e: Throwable)` if they fail
- * with an exception.
+ * In a similar fashion `Either<L, R>` may have two possible cases `Left(l: L)` and `Right(r: R)`. By convention, `Left` is used to model the exceptional
+ * case and `Right` for the successful case.
  *
- * Both [arrow.core.Try] and [arrow.core.Option] are examples of data types that can be computed over transforming their inner results.
+ * Both [arrow.core.Either] and [arrow.core.Option] are examples of data types that can be computed over transforming their inner results.
  *
  * ```kotlin:ank:playground
  * import arrow.*
@@ -45,7 +45,7 @@ import arrow.documented
  * fun main(args: Array<String>) {
  *   val result =
  *   //sampleStart
- *   Try { "1".toInt() }.map { it * 2 }
+ *   runBlocking { Either.catch { "1".toInt() }.map { it * 2 } }
  *   //sampleEnd
  *   println(result)
  * }

--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Monad.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Monad.kt
@@ -18,7 +18,7 @@ import kotlin.coroutines.startCoroutine
  * `Kind<F, ?>` where `?` denotes a value being transformed.
  *
  * This is true for all type constructors that can support the [Monad] type class including and not limited to
- * [IO], [ObservableK], [Option], [Either], [List], [Try] ...
+ * [IO], [ObservableK], [Option], [Either], [List] ...
  *
  * [The Monad Tutorial](https://arrow-kt.io/docs/patterns/monads/)
  *

--- a/arrow-docs/docs/datatypes/intro/README.md
+++ b/arrow-docs/docs/datatypes/intro/README.md
@@ -69,8 +69,6 @@ Data contains the bulk of the datatypes provided by Arrow. We can separate them 
 
 ##### Error handling
 
-- [`Try`]({{ '/apidocs/arrow-core-data/arrow.core/-try/' | relative_url }}) - returns the result of executing a block of code that can fail and throw exceptions
-
 - [`Validated`]({{ '/apidocs/arrow-core-data/arrow.core/-validated/' | relative_url }}) - returns the result of aggregating multiple calculations that can fail, and it also aggregates the errors
 
 ##### Reader/Writer/State

--- a/arrow-docs/docs/integrations/retrofit/README.md
+++ b/arrow-docs/docs/integrations/retrofit/README.md
@@ -9,7 +9,7 @@ permalink: /integrations/retrofit/
 
 
 
-Arrow contains an integration module for Retrofit so you can use any synchronous or asynchronous datatype of your choice, like [`Try`]({{ '/apidocs/arrow-core-data/arrow.core/-try/' | relative_url }}), [`ObservableK`]({{ '/integrations/rx2' | relative_url }}), or [`IO`]({{ '/effects/io' | relative_url }}).
+Arrow contains an integration module for Retrofit so you can use any synchronous or asynchronous datatype of your choice, like [`ObservableK`]({{ '/docs/integrations/rx2' | relative_url }}) or [`IO`]({{ '/docs/effects/io' | relative_url }}).
 
 
 ### Using `Call` directly with extensions functions

--- a/arrow-docs/docs/patterns/dependencyinjection/README.md
+++ b/arrow-docs/docs/patterns/dependencyinjection/README.md
@@ -20,8 +20,8 @@ The technique for writing polymorphic code demonstrated below is available for a
 fun <F> multiplyBy2(FT: Functor<F>, fa: Kind<F, Int>): Kind<F, Int> =
   /* ... */
 
-multiplyBy2(Option.functor(), Option(1))
-// Some(2)
+multiplyBy2(Either.functor(), Either.right(1))
+// Right(2)
 
 multiplyBy2(Try.functor(), Try.just(1))
 // Success(2)
@@ -88,10 +88,10 @@ Option.functor().run {
 ```
 
 ```kotlin:ank
-import arrow.core.extensions.`try`.functor.functor
+import arrow.core.extensions.either.functor.functor
 
-Try.functor().run {
-  multiplyBy2(Try.just(1))
+Either.functor<Throwable>().run {
+  multiplyBy2(Either.right(1))
 }
 ```
 

--- a/arrow-docs/docs/patterns/errorhandling/README.md
+++ b/arrow-docs/docs/patterns/errorhandling/README.md
@@ -95,7 +95,7 @@ public class Throwable {
     * This method records within this Throwable object information
     * about the current state of the stack frames for the current thread.
     */
-    Throwable fillInStackTrace()
+    Throwable fillInStackTrace();
 }
 ```
 
@@ -264,8 +264,7 @@ fun <F> MonadError<F, CookingException>.prepare():Kind<F, Salad> =
 Or, since `takeFoodFromRefrigerator()` and `getKnife()` are operations that do not depend on each other, we don't need the [Monad Comprehensions]({{ '/patterns/monad_comprehensions' | relative_url }}) here, and we can express our logic as:
 
 ```kotlin
-fun <F> MonadError<F, CookingException>.prepare1(): Kind<F, Salad> =
-    tupledN(getKnife(), takeFoodFromRefrigerator()).flatMap({ (nuke, target) -> lunch<F>(nuke, target) })
+ME.tupled(getKnife(), takeFoodFromRefrigerator()).flatMap(ME, { (knife, lettuce) -> lunch<F>(knife, lettuce) })
 
 val result = Either.monadError<CookingException>().prepare()
 result.fix()
@@ -278,7 +277,7 @@ result1.fix()
 Note that `MonadThrow` also has a function `fx.monadThrow` that automatically captures and wraps exceptions in its binding block.
 
 ```kotlin
-fun <F> MonadError<F, CookingException>.lunchImpure(target: Knife, nuke: Lettuce): Salad {
+fun <F> MonadError<F, CookingException>.lunchImpure(knife: Knife, lettuce: Lettuce): Salad {
     throw InsufficientAmountOfLettuce(5)
 }
 

--- a/arrow-docs/docs/patterns/glossary/README.md
+++ b/arrow-docs/docs/patterns/glossary/README.md
@@ -24,7 +24,6 @@ These solutions have a canonical implementation that is generalized for all poss
 
 Some common patterns expressed as datatypes are absence handling with [`Option`]({{ '/apidocs/arrow-core-data/arrow.core/-option/' | relative_url }}),
 branching in code with [`Either`]({{ '/apidocs/arrow-core-data/arrow.core/-either/' | relative_url }}),
-catching exceptions with [`Try`]({{ '/apidocs/arrow-core-data/arrow.core/-try/' | relative_url }}),
 or interacting with the platform the program runs in using [`IO`]({{ '/effects/io' | relative_url }}).
 
 Some of these patterns are implemented using a mix of `sealed` classes, where each inheritor is a `data` class.
@@ -61,7 +60,7 @@ Or, if I know how to aggregate objects together, I can add an extension function
 The number of extra extension functions that you get per typeclass can be from one in `Eq` to 17 (!) in `Foldable`.
 
 * Abstracting over behavior. Like any other interface, you can use them in your functions and classes as a way of talking about the capabilities of the implementation,
-without exposing the details. This way, you can create APIs that work the same for `Option`, `Try`, or `Observable`.
+without exposing the details. This way, you can create APIs that work the same for `Option` or `Observable`.
 
 You can read more about all the [typeclasses]({{ '/typeclasses/intro' | relative_url }}) that Arrow provides in its [section of the docs]({{ '/typeclasses/intro' | relative_url }}).
 
@@ -172,17 +171,17 @@ listOf(Option(1), Option(2), Option(3)).sequence(Option.applicative())
 ```kotlin:ank
 import arrow.core.extensions.fx
 
-Try.fx {
-  val (a) = Try { 1 }
-  val (b) = Try { a + 1 }
-  a + b
+Option.fx {
+    val a = Some(1).bind()
+    val b = Some(a+1).bind()
+    a + b
 }
 ```
 
 ```kotlin:ank:silent
-import arrow.core.extensions.`try`.apply.map
+import arrow.core.extensions.option.apply.map
 
-map(Try { 1 }, Try { 2 }, Try { 3 }) { (one, two, three) ->
+map(Some(1), Some(2), Some(3)) { (one, two, three) ->
   one + two + three
 }
 ```

--- a/arrow-docs/docs/patterns/monadcomprehensions/README.md
+++ b/arrow-docs/docs/patterns/monadcomprehensions/README.md
@@ -49,7 +49,7 @@ With knowledge of `flatMap`, we can write sequential expressions that are run as
 The [typeclass]({{ '/typeclasses/intro' | relative_url }}) interface that abstracts sequenced execution of code via `flatMap` is called a [`Monad`]({{ '/arrow/typeclasses/monad' | relative_url }}),
 for which we also have a [tutorial]({{ '/patterns/monads' | relative_url }}).
 
-Implementations of [`Monad`]({{ '/arrow/typeclasses/monad' | relative_url }}) are available for internal types like `Try` and also integrations like [RxJava 2]({{ '/integrations/rx2' | relative_url }}) and [kotlinx.coroutines]({{ '/integrations/kotlinxcoroutines' | relative_url }}).
+Implementations of [`Monad`]({{ '/docs/arrow/typeclasses/monad' | relative_url }}) are available for internal types like `IO` and also integrations like [RxJava 2]({{ '/docs/integrations/rx2' | relative_url }}) and [kotlinx.coroutines]({{ '/docs/integrations/kotlinxcoroutines' | relative_url }}).
 Let's see one example using a [`Monad`]({{ '/arrow/typeclasses/monad' | relative_url }}) called [`IO`]({{ '/effects/io' | relative_url }}), where we fetch from a database the information about the dean of a university some student attend:
 
 ```kotlin

--- a/arrow-docs/docs/quickstart/README.md
+++ b/arrow-docs/docs/quickstart/README.md
@@ -16,7 +16,7 @@ permalink: /core/
 Λrrow is a library for Typed Functional Programming in Kotlin.
 
 Arrow aims to provide a [*lingua franca*](https://en.wikipedia.org/wiki/Lingua_franca) of interfaces and abstractions across Kotlin libraries.
-For this, it includes the most popular data types, type classes and abstractions such as `Option`, `Try`, `Either`, `IO`, `Functor`, `Applicative`, `Monad` to empower users to write pure FP apps and libraries built atop higher order abstractions.
+For this, it includes the most popular data types, type classes and abstractions such as `Option`, `Either`, `IO`, `Functor`, `Applicative`, `Monad` to empower users to write pure FP apps and libraries built atop higher order abstractions.
 
 Use the list below to learn more about Λrrow's main features.
 

--- a/arrow-docs/docs/typeclasses/applicativeerror/README.md
+++ b/arrow-docs/docs/typeclasses/applicativeerror/README.md
@@ -15,9 +15,7 @@ It is parametrized to an error type `E`, which means the datatype has at least a
 These errors can come in the form of `Throwable`, `Exception`, or any other type that is more relevant to the domain;
 a sealed class UserNotFoundReason that contains three inheritors, for example.
 
-Some of the datatypes Λrrow provides can have these error types already fixed.
-That's the case with [`Try<A>`]({{ '/apidocs/arrow-core-data/arrow.core/-try/' | relative_url }}), which has its error type fixed to `Throwable`.
-Other datatypes like [`Either<E, A>`]({{ '/apidocs/arrow-core-data/arrow.core/-either/' | relative_url }}) allow for the user to apply their error type of choice.
+A datatype like [`Either<E, A>`]({{ '/docs/apidocs/arrow-core-data/arrow.core/-either/' | relative_url }}) allows for the user to apply their error type of choice.
 
 ### Main Combinators
 
@@ -33,13 +31,6 @@ import arrow.core.*
 import arrow.core.extensions.either.applicativeError.*
 
 Either.applicativeError<Throwable>().raiseError<Int>(RuntimeException("Paco"))
-```
-
-```kotlin:ank
-import arrow.core.*
-import arrow.core.extensions.`try`.applicativeError.*
-
-Try.applicativeError().raiseError<Int>(RuntimeException("Paco"))
 ```
 
 ```kotlin:ank
@@ -86,27 +77,21 @@ failure.handleError { t -> 0 }
 Maps the current content of the datatype to an [`Either<E, A>`]({{ '/apidocs/arrow-core-data/arrow.core/-either/' | relative_url }}), recovering from any previous error state.
 
 ```kotlin:ank
-Try { "3".toInt() }.attempt()
+IO { "3".toInt() }.attempt()
 ```
 
 ```kotlin:ank
-Try { "nope".toInt() }.attempt()
+IO { "nope".toInt() }.attempt()
 ```
 
-#### fromEither/fromTry/fromOption
+#### fromEither/fromOption
 
-Constructor function from an [`Either<E, A>`]({{ '/apidocs/arrow-core-data/arrow.core/-either/' | relative_url }}), [`Option<A>`]({{ '/apidocs/arrow-core-data/arrow.core/-option/' | relative_url }}), or [`Try<A>`]({{ '/apidocs/arrow-core-data/arrow.core/-try/' | relative_url }}) to the current datatype.
+Constructor function from an [`Either<E, A>`]({{ '/docs/apidocs/arrow-core-data/arrow.core/-either/' | relative_url }}) or [`Option<A>`]({{ '/docs/apidocs/arrow-core-data/arrow.core/-option/' | relative_url }}) to the current datatype.
 
 While `fromOption()` requires creating a new error value.
 
 ```kotlin:ank
 Either.applicativeError<Throwable>().run { Some(1).fromOption { RuntimeException("Boom") } }
-```
-
-In the case of `fromTry()`, converting from `Throwable` to the type of the error is required.
-
-```kotlin:ank
-Either.applicativeError<String>().run { Try { RuntimeException("Boom") }.fromTry { it.message!! } }
 ```
 
 In the case of `fromEither()`, converting from the error type of the `Either<EE, A>` to the type of the ApplicativeError<F, E> is required.

--- a/arrow-docs/docs/typeclasses/applicativeerror/README.md
+++ b/arrow-docs/docs/typeclasses/applicativeerror/README.md
@@ -86,7 +86,7 @@ IO { "nope".toInt() }.attempt()
 
 #### fromEither/fromOption
 
-Constructor function from an [`Either<E, A>`]({{ '/docs/apidocs/arrow-core-data/arrow.core/-either/' | relative_url }}) or [`Option<A>`]({{ '/docs/apidocs/arrow-core-data/arrow.core/-option/' | relative_url }}) to the current datatype.
+Constructor function from an [`Either<E, A>`]({{ '/apidocs/arrow-core-data/arrow.core/-either/' | relative_url }}) or [`Option<A>`]({{ '/apidocs/arrow-core-data/arrow.core/-option/' | relative_url }}) to the current datatype.
 
 While `fromOption()` requires creating a new error value.
 

--- a/arrow-docs/docs/typeclasses/functor/README.md
+++ b/arrow-docs/docs/typeclasses/functor/README.md
@@ -20,23 +20,25 @@ refers to `Option`, `List`, or any other type constructor whose contents can be 
 Oftentimes we find ourselves in situations where we need to transform the contents of some datatype. `Functor#map` allows
 us to safely compute over values under the assumption that they'll be there returning the transformation encapsulated in the same context.
 
-Consider both `Option` and `Try`:
+Consider both `Option` and `Either`:
 
 `Option<A>` allows us to model absence and has two possible states: `Some(a: A)` if the value is not absent, and `None` to represent an empty case.
 
-In a similar fashion, `Try<A>` may have two possible cases: `Success(a: A)` for computations that succeed, and `Failure(e: Throwable)` if they fail with an exception.
+In a similar fashion, `Either<A, B>` may have two possible cases: `Left(a: A)` for computations that succeed, and `Right(b: B)`.
 
-Both `Try` and `Option` are example datatypes that can be computed over transforming their inner results.
+By convention, the `Left` case is used to model the exceptional case.
+
+`Either` is an example datatype that can be computed over transforming its inner results.
 
 ```kotlin:ank
 import arrow.*
 import arrow.core.*
 
-Try { "1".toInt() }.map { it * 2 }
+Either.right(1).map { it * 2 }
 Option(1).map { it * 2 }
 ```
 
-Both `Try` and `Option` include ready-to-use `Functor` instances:
+Both `Either` and `Option` include ready-to-use `Functor` instances:
 
 ```kotlin:ank
 import arrow.core.extensions.option.functor.*
@@ -45,17 +47,17 @@ val optionFunctor = Option.functor()
 ```
 
 ```kotlin:ank
-import arrow.core.extensions.`try`.functor.*
+import arrow.core.extensions.either.functor.*
 
-val tryFunctor = Try.functor()
+val eitherFunctor = Either.functor<Int>()
 ```
 
-Mapping over the empty/failed cases is always safe since the `map` operation in both Try and Option operate under the bias of those containing success values.
+Mapping over the empty/failed cases is always safe since the `map` operation in both Either and Option operate under the bias of those containing success values.
 
 ```kotlin:ank
 
-Try { "x".toInt() }.map { it * 2 }
-none<Int>().map { it * 2 }
+(None as Option<Int>).map { it * 2 }
+(Either.left(IllegalArgumentException("")) as Either<Throwable, Int>).map { it * 2 }
 ```
 
 ### Main Combinators

--- a/arrow-docs/docs/typeclasses/functor/README.md
+++ b/arrow-docs/docs/typeclasses/functor/README.md
@@ -24,11 +24,9 @@ Consider both `Option` and `Either`:
 
 `Option<A>` allows us to model absence and has two possible states: `Some(a: A)` if the value is not absent, and `None` to represent an empty case.
 
-In a similar fashion, `Either<A, B>` may have two possible cases: `Left(a: A)` for computations that succeed, and `Right(b: B)`.
+In a similar fashion, `Either<A, B>` may have two possible cases: `Right(b: B)` for computations that succeed, and `Left(a: A)` for exceptional cases.
 
-By convention, the `Left` case is used to model the exceptional case.
-
-`Either` is an example datatype that can be computed over transforming its inner results.
+Both `Either` and `Option` are example datatypes that can be computed over transforming their inner results.
 
 ```kotlin:ank
 import arrow.*

--- a/arrow-docs/docs/typeclasses/monaderror/README.md
+++ b/arrow-docs/docs/typeclasses/monaderror/README.md
@@ -36,16 +36,6 @@ eitherResult
 ```
 
 ```kotlin:ank
-import arrow.core.*
-import arrow.core.extensions.`try`.applicativeError.*
-
-val tryResult: Try<Int> =
-  RuntimeException("BOOM!").raiseError()
-
-tryResult
-```
-
-```kotlin:ank
 import arrow.fx.*
 import arrow.fx.extensions.io.applicativeError.*
 


### PR DESCRIPTION
Original PR can be seen [here](https://github.com/arrow-kt/arrow-core/issues/26).

What version are you currently using? 0.10

What would you like to see?
The documentation includes Try examples. Since Try is deprecated, these examples should be removed (or transitioned to Either examples) to prevent confusion.