### PR TITLE
Bump versions of KOTLIN_VERSION and KOTLIN_TEST_VERSION locally for core

### DIFF
--- a/arrow-core-data/build.gradle
+++ b/arrow-core-data/build.gradle
@@ -14,7 +14,7 @@ apply from: "$DOC_CONF"
 apply from: "$PUBLISH_CONF"
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$KOTLIN_VERSION"
     compile project(":arrow-annotations")
     kapt project(":arrow-meta")
     kaptTest project(":arrow-meta")

--- a/arrow-core-test/build.gradle
+++ b/arrow-core-test/build.gradle
@@ -14,8 +14,7 @@ apply from: "$PUBLISH_CONF"
 dependencies {
     compile project(":arrow-core")
     compile project(":arrow-core-data")
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
-    compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:$KOTLINX_COROUTINES_VERSION"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$KOTLIN_VERSION"
     testRuntime "org.junit.vintage:junit-vintage-engine:$JUNIT_VINTAGE_VERSION"
     compile "io.kotlintest:kotlintest-runner-junit5:$KOTLIN_TEST_VERSION", excludeArrow
     kapt project(":arrow-meta")

--- a/arrow-core/build.gradle
+++ b/arrow-core/build.gradle
@@ -14,7 +14,7 @@ apply from: "$DOC_CONF"
 apply from: "$PUBLISH_CONF"
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$KOTLIN_VERSION"
     compile project(":arrow-annotations")
     compile project(":arrow-core-data")
     kapt project(":arrow-meta")

--- a/arrow-syntax/build.gradle
+++ b/arrow-syntax/build.gradle
@@ -14,7 +14,7 @@ apply from: "$DOC_CONF"
 apply from: "$PUBLISH_CONF"
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$KOTLIN_VERSION"
     compile project(":arrow-annotations")
     compile project(":arrow-core")
     testRuntime "org.junit.vintage:junit-vintage-engine:$JUNIT_VINTAGE_VERSION"

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,5 @@ kotlin.incremental=true
 # Kotlin Test configuration
 #Parallelism needs to be set to 1 since the concurrent tests in arrow-effects become flaky otherwise
 kotlintest.parallelism=1
+KOTLIN_VERSION=1.3.70
+KOTLIN_TEST_VERSION=3.4.2


### PR DESCRIPTION
Bump versions of KOTLIN_VERSION=1.3.70 and KOTLIN_TEST_VERSION=3.4.2. All test passed 
[core-dependencies.txt](https://github.com/arrow-kt/arrow-core/files/4338038/core-dependencies.txt)
