### PR TITLE
Suspend Either.fx implementation

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/SuspendingMonadContinuation.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/SuspendingMonadContinuation.kt
@@ -54,7 +54,7 @@ abstract class SuspendMonadContinuation<F, A>(private val parent: Continuation<K
             else -> Unit // loop again
           }
         }
-        else -> { // If not `UNDECIDED` then wwe need to pass result to `parent`
+        else -> { // If not `UNDECIDED` then we need to pass result to `parent`
           val res: Result<Kind<F, A>> = result.fold({ Result.success(it) }, { t ->
             if (t is ShortCircuit) Result.success(t.recover())
             else Result.failure(t)

--- a/arrow-core-data/src/main/kotlin/arrow/core/SuspendingMonadContinuation.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/SuspendingMonadContinuation.kt
@@ -1,0 +1,81 @@
+package arrow.core
+
+import arrow.Kind
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.loop
+import java.lang.RuntimeException
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.resumeWithException
+
+internal const val UNDECIDED = 0
+internal const val SUSPENDED = 1
+
+@Suppress("UNCHECKED_CAST")
+abstract class SuspendMonadContinuation<F, A>(private val parent: Continuation<Kind<F, A>>) : Continuation<Kind<F, A>> {
+
+  class ShortCircuit(val e: Any?) : Throwable(message = null, cause = null) {
+    override fun fillInStackTrace(): Throwable = this
+  }
+
+  abstract operator fun <A> Kind<F, A>.not(): A
+
+  abstract fun ShortCircuit.recover(): Kind<F, A>
+
+  /**
+   * State is either
+   *  0 - UNDECIDED
+   *  1 - SUSPENDED
+   *  Any? (3) `resumeWith` always stores it upon UNDECIDED, and `getResult` can atomically get it.
+   */
+  private val _decision = atomic<Any>(UNDECIDED)
+
+  override val context: CoroutineContext = EmptyCoroutineContext
+
+  override fun resumeWith(result: Result<Kind<F, A>>) {
+    _decision.loop { decision ->
+      when (decision) {
+        UNDECIDED -> {
+          val r: Kind<F, A>? = when {
+            result.isFailure -> {
+              val e = result.exceptionOrNull()
+              if (e is ShortCircuit) e.recover() else null
+            }
+            result.isSuccess -> result.getOrNull()
+            else -> throw RuntimeException("IMPOSSIBLE")
+          }
+
+          println("r: $r, exception: ${result.exceptionOrNull()}")
+
+          when {
+            r == null -> {
+              parent.resumeWithException(result.exceptionOrNull()!!)
+              return
+            }
+            _decision.compareAndSet(UNDECIDED, r) -> return
+            else -> Unit // loop again
+          }
+        }
+        else -> { // If not `UNDECIDED` then wwe need to pass result to `parent`
+          val res: Result<Kind<F, A>> = result.fold({ Result.success(it) }, { t ->
+            if (t is ShortCircuit) Result.success(t.recover())
+            else Result.failure(t)
+          })
+          parent.resumeWith(res)
+          return
+        }
+      }
+    }
+  }
+
+  @PublishedApi // return the result
+  internal fun getResult(): Any? =
+    _decision.loop { decision ->
+      when (decision) {
+        UNDECIDED -> if (this._decision.compareAndSet(UNDECIDED, SUSPENDED)) return COROUTINE_SUSPENDED
+        else -> return decision
+      }
+    }
+}

--- a/arrow-core-data/src/main/kotlin/arrow/core/predef.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/predef.kt
@@ -7,3 +7,10 @@ fun <A, B, Z> ((A, B) -> Z).curry(): (A) -> (B) -> Z = { p1: A -> { p2: B -> thi
 infix fun <A, B, C> ((B) -> C).compose(f: (A) -> B): (A) -> C = { a: A -> this(f(a)) }
 
 infix fun <A, B, C> ((A) -> B).andThen(g: (B) -> C): (A) -> C = { a: A -> g(this(a)) }
+
+internal object ArrowCoreInternalException : RuntimeException(
+  "Arrow-Core internal error. Please let us know and create a ticket at https://github.com/arrow-kt/arrow-core/issues/new/choose",
+  null
+) {
+  override fun fillInStackTrace(): Throwable = this
+}

--- a/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
@@ -227,11 +227,11 @@ class EitherTest : UnitSpec() {
     "suspended Either.fx can bind suspended values" {
       Gen.either(Gen.string(), Gen.int())
         .random()
-        .take(1001)
+        .take(10)
         .forEach { either ->
           Either.fx<String, Int> {
             val res = !(suspend {
-              sleep(1)
+              sleep(100)
               either
             }).invoke()
 
@@ -259,12 +259,12 @@ class EitherTest : UnitSpec() {
     "suspended Either.fx can bind suspended exceptions" {
       Gen.bind(Gen.int(), Gen.throwable(), ::Pair)
         .random()
-        .take(1001)
+        .take(10)
         .forEach { (i, exception) ->
           shouldThrow<Throwable> {
             Either.fx<String, Int> {
               val res = !Either.Right(i)
-              sleep(1)
+              sleep(100)
               throw exception
               res
             }

--- a/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
@@ -41,6 +41,7 @@ import arrow.core.test.laws.SemigroupKLaws
 import arrow.core.test.laws.ShowLaws
 import arrow.core.test.laws.TraverseLaws
 import arrow.typeclasses.Eq
+import io.kotlintest.fail
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
 import io.kotlintest.shouldBe
@@ -249,7 +250,8 @@ class EitherTest : UnitSpec() {
               val res = !Either.Right(i)
               throw exception
               res
-            } shouldBe Either.Right(i)
+            }
+            fail("It should never reach here. Either.fx should've thrown $exception")
           } shouldBe exception
         }
     }
@@ -265,7 +267,8 @@ class EitherTest : UnitSpec() {
               sleep(1)
               throw exception
               res
-            } shouldBe Either.Right(i)
+            }
+            fail("It should never reach here. Either.fx should've thrown $exception")
           } shouldBe exception
         }
     }


### PR DESCRIPTION
One of the biggest issue we currently have in Arrow Core is when you try to use the data-types and APIs in combination with `suspend fun`.

The current `fx` implementation doesn't allow calling foreign `suspend` functions inside an `fx` block. This implementation solves that problem by introducing a state machine that keeps track of the `suspension` state.

This implementation can be copied to all other data types, and can thus offer an alternative to our currently non-suspending `fx` implementation.

With the `suspend` implementation it'll be possible to do the following.

```kotlin
import arrow.core.Either
import arrow.core.extensions.fx

data class User(val name: String)
object DomainError

suspend fun fetchDataFromNetwork(id: Int): Either<DomainError, User> = TODO()

suspend fun getUser(id: Int) : Either<DomainError, User> =
  Either.fx<DomainError, User> {
    // Restricted suspending functions can only invoke member or extension suspending functions on their restricted coroutine scope
    !fetchDataFromNetwork(id) 
  }
```