### PR TITLE
Fix asKotlin extension function to just working with fqName

### DIFF
--- a/arrow-meta/src/main/java/arrow/meta/encoder/jvm/JvmMetaApi.kt
+++ b/arrow-meta/src/main/java/arrow/meta/encoder/jvm/JvmMetaApi.kt
@@ -1,14 +1,8 @@
 package arrow.meta.encoder.jvm
 
 import arrow.common.utils.ProcessorUtils
+import arrow.meta.ast.*
 import arrow.meta.ast.Annotation
-import arrow.meta.ast.Code
-import arrow.meta.ast.Func
-import arrow.meta.ast.Modifier
-import arrow.meta.ast.PackageName
-import arrow.meta.ast.Parameter
-import arrow.meta.ast.Type
-import arrow.meta.ast.TypeName
 import arrow.meta.decoder.TypeDecoder
 import arrow.meta.encoder.MetaApi
 import arrow.meta.encoder.TypeClassInstance
@@ -473,9 +467,15 @@ interface JvmMetaApi : MetaApi, TypeElementEncoder, ProcessorUtils, TypeDecoder 
   /**
    * @see [MetaApi.asKotlin]
    */
-  override fun TypeName.Classy.asKotlin(): TypeName.Classy =
-    if (simpleName == "Iterable") copy(simpleName = simpleName.asKotlin(), fqName = fqName.asKotlin(), pckg = PackageName("kotlin.collections"))
-    else copy(simpleName = simpleName.asKotlin(), fqName = fqName.asKotlin(), pckg = PackageName(pckg.value.asKotlin()))
+  override fun TypeName.Classy.asKotlin(): TypeName.Classy {
+    val fqNameAsKotlin = fqName.asKotlin()
+    return copy(
+      fqName = fqNameAsKotlin,
+      simpleName = fqNameAsKotlin.substringAfterLast("."),
+      pckg = PackageName(fqNameAsKotlin.substringBeforeLast("."))
+    )
+  }
+
 
   /**
    * @see [MetaApi.asPlatform]

--- a/arrow-meta/src/main/java/arrow/meta/encoder/jvm/JvmMetaApi.kt
+++ b/arrow-meta/src/main/java/arrow/meta/encoder/jvm/JvmMetaApi.kt
@@ -1,8 +1,14 @@
 package arrow.meta.encoder.jvm
 
 import arrow.common.utils.ProcessorUtils
-import arrow.meta.ast.*
 import arrow.meta.ast.Annotation
+import arrow.meta.ast.Code
+import arrow.meta.ast.Func
+import arrow.meta.ast.Modifier
+import arrow.meta.ast.PackageName
+import arrow.meta.ast.Parameter
+import arrow.meta.ast.Type
+import arrow.meta.ast.TypeName
 import arrow.meta.decoder.TypeDecoder
 import arrow.meta.encoder.MetaApi
 import arrow.meta.encoder.TypeClassInstance
@@ -475,7 +481,6 @@ interface JvmMetaApi : MetaApi, TypeElementEncoder, ProcessorUtils, TypeDecoder 
       pckg = PackageName(fqNameAsKotlin.substringBeforeLast("."))
     )
   }
-
 
   /**
    * @see [MetaApi.asPlatform]

--- a/arrow-meta/src/main/java/arrow/meta/encoder/jvm/KotlinPoetEncoder.kt
+++ b/arrow-meta/src/main/java/arrow/meta/encoder/jvm/KotlinPoetEncoder.kt
@@ -1,10 +1,20 @@
 package arrow.meta.encoder.jvm
 
-import arrow.meta.ast.*
 import arrow.meta.ast.Annotation
+import arrow.meta.ast.Code
+import arrow.meta.ast.Func
+import arrow.meta.ast.Modifier
+import arrow.meta.ast.PackageName
+import arrow.meta.ast.Parameter
 import arrow.meta.ast.TypeName
+import arrow.meta.ast.UseSiteTarget
 import arrow.meta.encoder.MetaApi
-import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterizedTypeName
+import com.squareup.kotlinpoet.TypeVariableName
+import com.squareup.kotlinpoet.WildcardTypeName
 import me.eugeniomarletti.kotlin.metadata.KotlinMetadataUtils
 import javax.lang.model.element.ExecutableElement
 

--- a/arrow-meta/src/main/java/arrow/meta/encoder/jvm/KotlinPoetEncoder.kt
+++ b/arrow-meta/src/main/java/arrow/meta/encoder/jvm/KotlinPoetEncoder.kt
@@ -1,20 +1,10 @@
 package arrow.meta.encoder.jvm
 
+import arrow.meta.ast.*
 import arrow.meta.ast.Annotation
-import arrow.meta.ast.Code
-import arrow.meta.ast.Func
-import arrow.meta.ast.Modifier
-import arrow.meta.ast.PackageName
-import arrow.meta.ast.Parameter
 import arrow.meta.ast.TypeName
-import arrow.meta.ast.UseSiteTarget
 import arrow.meta.encoder.MetaApi
-import com.squareup.kotlinpoet.AnnotationSpec
-import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.KModifier
-import com.squareup.kotlinpoet.ParameterizedTypeName
-import com.squareup.kotlinpoet.TypeVariableName
-import com.squareup.kotlinpoet.WildcardTypeName
+import com.squareup.kotlinpoet.*
 import me.eugeniomarletti.kotlin.metadata.KotlinMetadataUtils
 import javax.lang.model.element.ExecutableElement
 
@@ -75,14 +65,16 @@ interface KotlinPoetEncoder {
       annotations = annotations.map { it.toMeta() }
     )
 
-  private fun com.squareup.kotlinpoet.ClassName.toMeta(): TypeName.Classy =
-    TypeName.Classy(
-      simpleName = simpleName.asKotlin(),
-      fqName = canonicalName.asKotlin(),
+  private fun com.squareup.kotlinpoet.ClassName.toMeta(): TypeName.Classy {
+    val fqNameAsKotlin = canonicalName.asKotlin()
+    return TypeName.Classy(
+      fqName = fqNameAsKotlin,
+      simpleName = fqNameAsKotlin.substringAfterLast("."),
+      pckg = PackageName(fqNameAsKotlin.substringBeforeLast(".")),
       annotations = annotations.map { it.toMeta() },
-      nullable = isNullable,
-      pckg = PackageName(packageName.asKotlin())
+      nullable = isNullable
     )
+  }
 
   private fun com.squareup.kotlinpoet.ParameterizedTypeName.toMeta(): TypeName =
     TypeName.ParameterizedType(

--- a/arrow-meta/src/main/java/arrow/meta/encoder/jvm/StringTypeExtensions.kt
+++ b/arrow-meta/src/main/java/arrow/meta/encoder/jvm/StringTypeExtensions.kt
@@ -28,13 +28,10 @@ fun String.asKotlin(): String =
     .replace("java.util.SortedMap", "kotlin.collections.SortedMap")
     .replace("java.util.Collection", "kotlin.collections.Collection")
     .replace("java.lang.Number", "kotlin.Number")
-    .replace("java.lang.Throwable", "kotlin.Throwable").let {
-      if (it == "java.lang") it.replace("java.lang", "kotlin")
-      else it
-    }.let {
-      if (it == "java.util") it.replace("java.util", "kotlin.collections")
-      else it
-    }
+    .replace("java.lang.Comparable", "kotlin.Comparable")
+    .replace("java.lang.Boolean", "kotlin.Boolean")
+    .replace("java.lang.Long", "kotlin.Long")
+    .replace("java.lang.Throwable", "kotlin.Throwable")
     .replace("kotlin.Integer", "kotlin.Int")
     .replace("Integer", "Int")
     .replace("java.lang.String", "kotlin.String")

--- a/arrow-meta/src/main/java/arrow/meta/encoder/jvm/StringTypeExtensions.kt
+++ b/arrow-meta/src/main/java/arrow/meta/encoder/jvm/StringTypeExtensions.kt
@@ -33,7 +33,7 @@ fun String.asKotlin(): String =
     .replace("java.lang.Long", "kotlin.Long")
     .replace("java.lang.Throwable", "kotlin.Throwable")
     .replace("kotlin.Integer", "kotlin.Int")
-    .replace("Integer", "Int")
+    .replace("java.lang.Integer", "kotlin.Int")
     .replace("java.lang.String", "kotlin.String")
 
 internal fun String.asClassy(): TypeName.Classy {


### PR DESCRIPTION
In https://github.com/arrow-kt/arrow-core/pull/129 PR there is a problem that `arrow-meta` converts `java.lang.Class` to `kotlin.Class`, which does not exist. This is happening because the `asKotlin` extension function tries to convert the packageName alone. In this PR both packageName and simpleName are depending to fqName and `asKotlin` just converts fqName without generally guessing the corresponding kotlin dual of classes.
This solution can have more impact if I would removed all the packageName.asKotlin() and simpleName.asKotlin() in the code, but I would do that if this approach be acceptable one by reviewers.