### PR TITLE
Fixes NPE in bindWithFilter

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/MonadFilterContinuation.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/MonadFilterContinuation.kt
@@ -19,8 +19,10 @@ interface MonadFilterSyntax<F> : MonadSyntax<F> {
   suspend fun <B> Kind<F, B>.bindWithFilter(f: (B) -> Boolean): B
 }
 
-open class MonadFilterContinuation<F, A>(val MF: MonadFilter<F>, override val context: CoroutineContext = EmptyCoroutineContext) :
-  MonadContinuation<F, A>(MF), MonadFilterSyntax<F> {
+open class MonadFilterContinuation<F, A>(
+  val MF: MonadFilter<F>,
+  override val context: CoroutineContext = EmptyCoroutineContext
+) : MonadContinuation<F, A>(MF), MonadFilterSyntax<F> {
 
   override fun resumeWith(result: Result<Kind<F, A>>) {
     result.fold({ super.resumeWith(result) }, {
@@ -43,8 +45,8 @@ open class MonadFilterContinuation<F, A>(val MF: MonadFilter<F>, override val co
    * Binds only if the given predicate matches the inner value otherwise binds into the Monad `empty()` value
    * on `MonadFilter` instances
    */
-  override suspend fun <B> Kind<F, B>.bindWithFilter(f: (B) -> Boolean): B {
-    val b: B = this.bind()
-    return if (f(b)) b else MF.empty<B>().bind()
-  }
+  override suspend fun <B> Kind<F, B>.bindWithFilter(f: (B) -> Boolean): B =
+    MF.run {
+      this@bindWithFilter.filter(f)
+    }.bind()
 }

--- a/arrow-core-data/src/test/kotlin/arrow/core/ListKTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/ListKTest.kt
@@ -13,6 +13,7 @@ import arrow.core.extensions.listk.functor.functor
 import arrow.core.extensions.listk.hash.hash
 import arrow.core.extensions.listk.monad.monad
 import arrow.core.extensions.listk.monadCombine.monadCombine
+import arrow.core.extensions.listk.monadFilter.monadFilter
 import arrow.core.extensions.listk.monadLogic.monadLogic
 import arrow.core.extensions.listk.monoid.monoid
 import arrow.core.extensions.listk.monoidK.monoidK
@@ -185,6 +186,14 @@ class ListKTest : UnitSpec() {
 
         result.map { it.a }.equalUnderTheLaw(a, ListK.eq(Int.eq()))
       }
+    }
+
+    "bindWithFilter bug #132" {
+      val list = listOf(1, 2, 3, 4).k()
+
+      ListK.monadFilter().fx.monadFilter {
+        list.bindWithFilter { it % 2 == 0 }
+      }.let(::println)
     }
   }
 

--- a/arrow-core-data/src/test/kotlin/arrow/core/ListKTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/ListKTest.kt
@@ -13,7 +13,6 @@ import arrow.core.extensions.listk.functor.functor
 import arrow.core.extensions.listk.hash.hash
 import arrow.core.extensions.listk.monad.monad
 import arrow.core.extensions.listk.monadCombine.monadCombine
-import arrow.core.extensions.listk.monadFilter.monadFilter
 import arrow.core.extensions.listk.monadLogic.monadLogic
 import arrow.core.extensions.listk.monoid.monoid
 import arrow.core.extensions.listk.monoidK.monoidK
@@ -186,14 +185,6 @@ class ListKTest : UnitSpec() {
 
         result.map { it.a }.equalUnderTheLaw(a, ListK.eq(Int.eq()))
       }
-    }
-
-    "bindWithFilter bug #132" {
-      val list = listOf(1, 2, 3, 4).k()
-
-      ListK.monadFilter().fx.monadFilter {
-        list.bindWithFilter { it % 2 == 0 }
-      }.let(::println)
     }
   }
 

--- a/arrow-core-test/src/main/kotlin/arrow/core/test/laws/MonadFilterLaws.kt
+++ b/arrow-core-test/src/main/kotlin/arrow/core/test/laws/MonadFilterLaws.kt
@@ -29,7 +29,7 @@ object MonadFilterLaws {
       Law("MonadFilter Laws: Right Empty") { MF.monadFilterRightEmpty(GEN, EQ) },
       Law("MonadFilter Laws: Consistency") { MF.monadFilterConsistency(GEN, EQ) },
       Law("MonadFilter Laws: Comprehension Guards") { MF.monadFilterEmptyComprehensions(EQ) },
-      Law("MonadFilter Laws: Comprehension bindWithFilter Guards") { MF.monadFilterBindWithFilterComprehensions(EQ) })
+      Law("MonadFilter Laws: Comprehension bindWithFilter Guards") { MF.monadFilterBindWithFilterComprehensions(GEN, EQ) })
   }
 
   fun <F> laws(
@@ -76,11 +76,11 @@ object MonadFilterLaws {
       }.equalUnderTheLaw(if (!guard) empty() else just(n), EQ)
     }
 
-  fun <F> MonadFilter<F>.monadFilterBindWithFilterComprehensions(EQ: Eq<Kind<F, Int>>): Unit =
-    forAll(Gen.bool(), Gen.int()) { guard: Boolean, n: Int ->
+  fun <F, A> MonadFilter<F>.monadFilterBindWithFilterComprehensions(G: Gen<Kind<F, A>>, EQ: Eq<Kind<F, A>>): Unit =
+    forAll(Gen.bool(), G) { guard: Boolean, fa: Kind<F, A> ->
       fx.monadFilter {
-        val x = just(n).bindWithFilter { _ -> guard }
+        val x = fa.bindWithFilter { guard }
         x
-      }.equalUnderTheLaw(if (!guard) empty() else just(n), EQ)
+      }.equalUnderTheLaw(if (!guard) empty() else fa, EQ)
     }
 }


### PR DESCRIPTION
Fixes #132 

* Change MonadFilterLaws to use a gen to test bindWithFilter in order to generate all possible values 
* Fix bindWithFilter by filtering first, then binding (thanks to @nomisRev)