### PR TITLE
Fix a few broken links in the docs

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -11,8 +11,6 @@ import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 
 /**
  *
- * ank_macro_hierarchy(arrow.core.Either)
- *
  *
  * In day-to-day programming, it is fairly common to find ourselves writing functions that can fail.
  * For instance, querying a service may result in a connection issue, or some unexpected JSON response.
@@ -608,7 +606,7 @@ import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
  * Arrow contains `Either` instances for many useful typeclasses that allows you to use and transform right values.
  * Option does not require a type parameter with the following functions, but it is specifically used for Either.Left
  *
- * [Functor]({{'/docs/arrow/typeclasses/functor/' | relative_url }})
+ * [`Functor`](../../../../arrow/typeclasses/functor/)
  *
  * Transforming the inner contents
  *
@@ -624,7 +622,7 @@ import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
  * }
  * ```
  *
- * [Applicative]({{'/arrow/typeclasses/applicative/' | relative_url }})
+ * [`Applicative`](../../../../arrow/typeclasses/applicative/)
  *
  * Computing over independent values
  *
@@ -641,7 +639,7 @@ import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
  * }
  * ```
  *
- * [Monad]({{'/arrow/typeclasses/monad/' | relative_url }})
+ * [`Monad`](../../../../arrow/typeclasses/monad/)
  *
  * Computing over dependent values ignoring absence
  *

--- a/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
@@ -6,8 +6,6 @@ import arrow.typeclasses.Show
 
 /**
  *
- * ank_macro_hierarchy(arrow.core.Option)
- *
  *
  * If you have worked with Java at all in the past, it is very likely that you have come across a `NullPointerException` at some time (other languages will throw similarly named errors in such a case). Usually this happens because some method returns `null` when you weren't expecting it and, thus, isn't dealing with that possibility in your client code. A value of `null` is often abused to represent an absent optional value.
  * Kotlin tries to solve the problem by getting rid of `null` values altogether, and providing its own special syntax [Null-safety machinery based on `?`](https://kotlinlang.org/docs/reference/null-safety.html).
@@ -272,7 +270,7 @@ import arrow.typeclasses.Show
  *
  * Arrow contains `Option` instances for many useful typeclasses that allow you to use and transform optional values
  *
- * [Functor]({{'/arrow/typeclasses/functor/' | relative_url }})
+ * [`Functor`](../../../../arrow/typeclasses/functor/)
  *
  * Transforming the inner contents
  *
@@ -288,7 +286,7 @@ import arrow.typeclasses.Show
  * }
  * ```
  *
- * [Applicative]({{'/arrow/typeclasses/applicative/' | relative_url }})
+ * [`Applicative`](../../../../arrow/typeclasses/applicative/)
  *
  * Computing over independent values
  *
@@ -305,7 +303,7 @@ import arrow.typeclasses.Show
  * }
  * ```
  *
- * [Monad]({{'/arrow/typeclasses/monad/' | relative_url }})
+ * [`Monad`](../../../../arrow/typeclasses/monad/)
  *
  * Computing over dependent values ignoring absence
  *

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -15,8 +15,6 @@ typealias Invalid<E> = Validated.Invalid<E>
 
 /**
  *
- * ank_macro_hierarchy(arrow.core.Validated)
- *
  *
  * Imagine you are filling out a web form to sign up for an account. You input your username and
  * password, then submit. A response comes back saying your username can't have dashes in it,


### PR DESCRIPTION
I couldn't work out exactly why they were broken. Tried a few different
things but couldn't get it to generate the link correctly. Ended up
removing the curly braces and using a plain old Markdown link.

Also removed the "type class hierarchy" section from these pages. They
are not type classes, so the macro was generating an empty diagram.