### PR TITLE
Replace compile with implementation in setup guide

### DIFF
--- a/arrow-docs/docs/quickstart/setup/README.md
+++ b/arrow-docs/docs/quickstart/setup/README.md
@@ -46,8 +46,8 @@ apply plugin: 'kotlin-kapt'
 
 def arrow_version = "0.10.5"
 dependencies {
-    compile "io.arrow-kt:arrow-core:$arrow_version"
-    compile "io.arrow-kt:arrow-syntax:$arrow_version"
+    implementation "io.arrow-kt:arrow-core:$arrow_version"
+    implementation "io.arrow-kt:arrow-syntax:$arrow_version"
     kapt    "io.arrow-kt:arrow-meta:$arrow_version"
 }
 ```
@@ -59,8 +59,8 @@ apply plugin: 'kotlin-kapt'
 
 def arrow_version = "0.10.5"
 dependencies {
-    compile "io.arrow-kt:arrow-optics:$arrow_version"
-    compile "io.arrow-kt:arrow-syntax:$arrow_version"
+    implementation "io.arrow-kt:arrow-optics:$arrow_version"
+    implementation "io.arrow-kt:arrow-syntax:$arrow_version"
     kapt    "io.arrow-kt:arrow-meta:$arrow_version"
 }
 ```
@@ -72,8 +72,8 @@ apply plugin: 'kotlin-kapt'
 
 def arrow_version = "0.10.5"
 dependencies {
-    compile "io.arrow-kt:arrow-fx:$arrow_version"
-    compile "io.arrow-kt:arrow-syntax:$arrow_version"
+    implementation "io.arrow-kt:arrow-fx:$arrow_version"
+    implementation "io.arrow-kt:arrow-syntax:$arrow_version"
     kapt    "io.arrow-kt:arrow-meta:$arrow_version"
 }
 ```
@@ -85,9 +85,9 @@ apply plugin: 'kotlin-kapt'
 
 def arrow_version = "0.10.5"
 dependencies {
-    compile "io.arrow-kt:arrow-fx:$arrow_version"
-    compile "io.arrow-kt:arrow-optics:$arrow_version"
-    compile "io.arrow-kt:arrow-syntax:$arrow_version"
+    implementation "io.arrow-kt:arrow-fx:$arrow_version"
+    implementation "io.arrow-kt:arrow-optics:$arrow_version"
+    implementation "io.arrow-kt:arrow-syntax:$arrow_version"
     kapt    "io.arrow-kt:arrow-meta:$arrow_version"
 }
 ```


### PR DESCRIPTION
From the gradle docs:
The compile configuration still exists but should not be used as it will not offer the guarantees that the api and implementation configurations provide.

https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation

I was replacing `compile` with `implementation` when creating a new project, after copy-pasting from the docs, and today I decided it's the last time I do it :smile: 