### PR TITLE
Fix Mapk extensions

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/ListK.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/ListK.kt
@@ -281,3 +281,7 @@ fun <A> ListKOf<A>.combineK(y: ListKOf<A>): ListK<A> =
   (fix() + y.fix()).k()
 
 fun <A> List<A>.k(): ListK<A> = ListK(this)
+
+fun <A> listKOf(vararg elements: A): ListK<A> =
+  listOf(*elements).k()
+

--- a/arrow-core-data/src/main/kotlin/arrow/core/ListK.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/ListK.kt
@@ -284,4 +284,3 @@ fun <A> List<A>.k(): ListK<A> = ListK(this)
 
 fun <A> listKOf(vararg elements: A): ListK<A> =
   listOf(*elements).k()
-

--- a/arrow-meta/src/main/java/arrow/meta/encoder/jvm/JvmMetaApi.kt
+++ b/arrow-meta/src/main/java/arrow/meta/encoder/jvm/JvmMetaApi.kt
@@ -600,7 +600,7 @@ interface JvmMetaApi : MetaApi, TypeElementEncoder, ProcessorUtils, TypeDecoder 
    * ex: SetK<A> to Set<A>
    */
   val Type.kindWrapper: Pair<TypeName, TypeName.ParameterizedType>?
-    get() = if (primaryConstructor?.parameters?.size == 1 && typeVariables.size == 1) {
+    get() = if (primaryConstructor?.parameters?.size == 1) {
       val wrappedType = primaryConstructor.parameters[0].type.asKotlin()
       when (wrappedType) {
         is TypeName.ParameterizedType -> {


### PR DESCRIPTION
* Added `listKOf` for ListK as equivalent to List's `listOf`
  -> With this, there's no need to create normal Lists and Maps to then convert them to the wrapped version via `.k()`, but instead just create the wrapped versions directly as follows:

```
val m = mapOf("a" toT  listKOf(1, 2), "b" toT listKOf(3)) // Note that the `toT` will use an Arrow's Tuple to create a MapK
val n = mapOf("a" toT listKOf(4), "c" toT listKOf(5, 6))
val p = m.plus(ListK.semigroup(), n)
```

* Fix MapK extensions projected over stdlib Map
  -> So now there's no need to convert all maps to MapK because we can use the Map extensions as follows (note that we cannot still use `List.semigroup` tho):

```
val m = mapOf("a" to 1, "b" to 3)
val n = mapOf("a" to 5, "c" to 5)
val p = m.plus(Int.semigroup(), n)
```

Fixes #140 