### PR TITLE
Deprecate `fx` blocks from typeclasses

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Monad.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Monad.kt
@@ -31,6 +31,7 @@ interface Monad<F> : Selective<F> {
    * A coroutine is initiated and suspended inside [MonadThrowContinuation] yielding to [Monad.flatMap]. Once all the flatMap binds are completed
    * the underlying monad is returned from the act of executing the coroutine
    */
+  @Deprecated("Fx will be moved to each datatype as a DSL constructor.")
   val fx: MonadFx<F>
     get() = object : MonadFx<F> {
       override val M: Monad<F> = this@Monad

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either.kt
@@ -253,6 +253,8 @@ interface EitherHash<L, R> : Hash<Either<L, R>>, EitherEq<L, R> {
   })
 }
 
+@Deprecated("Fx blocks are now named based on each datatype, please use `either { }` instead",
+  replaceWith = ReplaceWith("either(c)"))
 fun <L, R> Either.Companion.fx(c: suspend MonadSyntax<EitherPartialOf<L>>.() -> R): Either<L, R> =
   Either.monad<L>().fx.monad(c).fix()
 

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/eval.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/eval.kt
@@ -105,3 +105,8 @@ interface EvalBimonad : Bimonad<ForEval> {
   override fun <A> EvalOf<A>.extract(): A =
     fix().extract()
 }
+
+@Deprecated("Fx blocks are now named based on each datatype, please use `eval { }` instead",
+  replaceWith = ReplaceWith("eval(c)"))
+fun <B> Eval.Companion.fx(c: suspend MonadSyntax<ForEval>.() -> B): Eval<B> =
+  defer { Eval.monad().fx.monad(c).fix() }


### PR DESCRIPTION
Deprecate Monad.fx 
Deprecates fx blocks in Either and Eval

Fixes #118