### PR TITLE
Adds Validated.catch

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -682,6 +682,20 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
      */
     fun <E, A> fromNullable(value: A?, ifNull: () -> E): Validated<E, A> =
       value?.let(::Valid) ?: Invalid(ifNull())
+
+    suspend fun <A> catch(f: suspend () -> A): Validated<Throwable, A> =
+      try {
+        f().valid()
+      } catch (e: Throwable) {
+        e.nonFatalOrThrow().invalid()
+      }
+
+    suspend fun <A> catchNel(f: suspend () -> A): ValidatedNel<Throwable, A> =
+      try {
+        f().validNel()
+      } catch (e: Throwable) {
+        e.nonFatalOrThrow().invalidNel()
+      }
   }
 
   fun show(SE: Show<E>, SA: Show<A>): String = fold({

--- a/arrow-core-data/src/test/kotlin/arrow/core/ValidatedTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/ValidatedTest.kt
@@ -33,6 +33,7 @@ import io.kotlintest.fail
 import io.kotlintest.properties.Gen
 import io.kotlintest.shouldBe
 
+@Suppress("RedundantSuspendModifier")
 class ValidatedTest : UnitSpec() {
 
   init {
@@ -206,6 +207,32 @@ class ValidatedTest : UnitSpec() {
     "withEither should return Invalid(result) if f return Left" {
       Valid(10).withEither { Left(5) } shouldBe Invalid(5)
       Invalid(10).withEither(::identity) shouldBe Invalid(10)
+    }
+
+    "catch should return Valid(result) when f does not throw" {
+      suspend fun loadFromNetwork(): Int = 1
+      val validated = Validated.catch { loadFromNetwork() }
+      validated shouldBe Valid(1)
+    }
+
+    "catch should return Invalid(result) when f throws" {
+      val exception = MyException("Boom!")
+      suspend fun loadFromNetwork(): Int = throw exception
+      val validated = Validated.catch { loadFromNetwork() }
+      validated shouldBe Invalid(exception)
+    }
+
+    "catchNel should return Valid(result) when f does not throw" {
+      suspend fun loadFromNetwork(): Int = 1
+      val validated = Validated.catchNel { loadFromNetwork() }
+      validated shouldBe Valid(1)
+    }
+
+    "catchNel should return Invalid(Nel(result)) when f throws" {
+      val exception = MyException("Boom!")
+      suspend fun loadFromNetwork(): Int = throw exception
+      val validated = Validated.catchNel { loadFromNetwork() }
+      validated shouldBe Invalid(NonEmptyList(exception))
     }
 
     with(VAL_AP) {


### PR DESCRIPTION
This mimics `Either.catch` constructor for `suspend` ops but for `Validated` and `ValidatedNel`. I wrote one of these manually [in this Ank PR](https://github.com/arrow-kt/arrow-ank/pull/43), so decided to add it to `arrow-core`.