### PR TITLE
Adds Either.fromNullable

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -852,6 +852,8 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
 
     fun <R> right(right: R): Either<Nothing, R> = Right(right)
 
+    fun <A> fromNullable(a: A?): Either<Unit, A> = a?.right() ?: Unit.left()
+
     tailrec fun <L, A, B> tailRecM(a: A, f: (A) -> Kind<EitherPartialOf<L>, Either<A, B>>): Either<L, B> {
       val ev: Either<L, Either<A, B>> = f(a).fix()
       return when (ev) {

--- a/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
@@ -44,6 +44,7 @@ import arrow.core.test.laws.TraverseLaws
 import arrow.typeclasses.Eq
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
+import io.kotlintest.shouldBe
 
 class EitherTest : UnitSpec() {
 
@@ -72,6 +73,16 @@ class EitherTest : UnitSpec() {
       BicrosswalkLaws.laws(Either.bicrosswalk(), Either.genK2(), Either.eqK2()),
       FxLaws.laws<EitherPartialOf<String>, Int>(Gen.int().map(::Right), GEN.map { it }, Either.eqK(String.eq()).liftEq(Int.eq()), ::either, ::either)
     )
+
+    "fromNullable should lift value as a Right if it is not null" {
+      forAll { a: Int ->
+        Either.fromNullable(a) == Right(a)
+      }
+    }
+
+    "fromNullable should lift value as a Left(Unit) if it is null" {
+      Either.fromNullable(null) shouldBe Left(Unit)
+    }
 
     "empty should return a Right of the empty of the inner type" {
       forAll { _: String ->


### PR DESCRIPTION
Given the discussions in #114 and already ongoing `Option` deprecation to promote `?` or `Either<Unit, A>` depending on the case, I'm adding this constructor for `Either` just for syntax.