### PR TITLE
Properly support suspend with inline

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
@@ -15,10 +15,12 @@ data class Const<A, out T>(private val value: A) : ConstOf<A, T> {
   fun <U> retag(): Const<A, U> =
     this as Const<A, U>
 
-  fun <G, U> traverse(GA: Applicative<G>): Kind<G, Const<A, U>> =
+  @Suppress("UNUSED_PARAMETER")
+  fun <G, U> traverse(GA: Applicative<G>, f: (T) -> Kind<G, U>): Kind<G, Const<A, U>> =
     GA.just(retag())
 
-  fun <G, U> traverseFilter(GA: Applicative<G>): Kind<G, Const<A, U>> =
+  @Suppress("UNUSED_PARAMETER")
+  fun <G, U> traverseFilter(GA: Applicative<G>, f: (T) -> Kind<G, Option<U>>): Kind<G, Const<A, U>> =
     GA.just(retag())
 
   companion object {
@@ -43,7 +45,7 @@ fun <A, T, U> ConstOf<A, T>.ap(SG: Semigroup<A>, ff: ConstOf<A, (T) -> U>): Cons
   fix().retag<U>().combine(SG, ff.fix().retag())
 
 fun <T, A, G> ConstOf<A, Kind<G, T>>.sequence(GA: Applicative<G>): Kind<G, Const<A, T>> =
-  fix().traverse(GA)
+  fix().traverse(GA, ::identity)
 
 inline fun <A> A.const(): Const<A, Nothing> =
   Const(this)

--- a/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
@@ -15,12 +15,10 @@ data class Const<A, out T>(private val value: A) : ConstOf<A, T> {
   fun <U> retag(): Const<A, U> =
     this as Const<A, U>
 
-  @Suppress("UNUSED_PARAMETER")
-  fun <G, U> traverse(GA: Applicative<G>, f: (T) -> Kind<G, U>): Kind<G, Const<A, U>> =
+  fun <G, U> traverse(GA: Applicative<G>): Kind<G, Const<A, U>> =
     GA.just(retag())
 
-  @Suppress("UNUSED_PARAMETER")
-  fun <G, U> traverseFilter(GA: Applicative<G>, f: (T) -> Kind<G, Option<U>>): Kind<G, Const<A, U>> =
+  fun <G, U> traverseFilter(GA: Applicative<G>): Kind<G, Const<A, U>> =
     GA.just(retag())
 
   companion object {
@@ -45,7 +43,7 @@ fun <A, T, U> ConstOf<A, T>.ap(SG: Semigroup<A>, ff: ConstOf<A, (T) -> U>): Cons
   fix().retag<U>().combine(SG, ff.fix().retag())
 
 fun <T, A, G> ConstOf<A, Kind<G, T>>.sequence(GA: Applicative<G>): Kind<G, Const<A, T>> =
-  fix().traverse(GA, ::identity)
+  fix().traverse(GA)
 
 inline fun <A> A.const(): Const<A, Nothing> =
   Const(this)

--- a/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
@@ -41,7 +41,7 @@ data class Const<A, out T>(private val value: A) : ConstOf<A, T> {
 fun <A, T> ConstOf<A, T>.combine(SG: Semigroup<A>, that: ConstOf<A, T>): Const<A, T> =
   Const(SG.run { value().combine(that.value()) })
 
-inline fun <A, T, U> ConstOf<A, T>.ap(SG: Semigroup<A>, ff: ConstOf<A, (T) -> U>): Const<A, U> =
+fun <A, T, U> ConstOf<A, T>.ap(SG: Semigroup<A>, ff: ConstOf<A, (T) -> U>): Const<A, U> =
   fix().retag<U>().combine(SG, ff.fix().retag())
 
 fun <T, A, G> ConstOf<A, Kind<G, T>>.sequence(GA: Applicative<G>): Kind<G, Const<A, T>> =

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -726,7 +726,8 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
       }
     }
 
-  inline fun <C> bifoldLeft(c: C, f: (C, A) -> C, g: (C, B) -> C): C = fold({ f(c, it) }, { g(c, it) })
+  inline fun <C> bifoldLeft(c: C, f: (C, A) -> C, g: (C, B) -> C): C =
+    fold({ f(c, it) }, { g(c, it) })
 
   inline fun <C> bifoldRight(c: Eval<C>, f: (A, Eval<C>) -> Eval<C>, g: (B, Eval<C>) -> Eval<C>): Eval<C> =
     fold({ f(it, c) }, { g(it, c) })
@@ -740,7 +741,8 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
    * Right("right").swap() // Result: Left("right")
    * ```
    */
-  fun swap(): Either<B, A> = fold({ Right(it) }, { Left(it) })
+  fun swap(): Either<B, A> =
+    fold({ Right(it) }, { Left(it) })
 
   /**
    * The given function is applied if this is a `Right`.
@@ -865,13 +867,14 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
     }
 
     @Deprecated(
-      message = "use conditionally as parameter order is consistent with Either class",
+      message = "Use conditionally since the parameter order is consistent with Either class",
       replaceWith = ReplaceWith(
         "Either.conditionally(test, ifFalse, ifTrue)",
         "arrow.core.Either.conditionally"
       )
     )
-    fun <L, R> cond(test: Boolean, ifTrue: () -> R, ifFalse: () -> L): Either<L, R> = conditionally(test, ifFalse, ifTrue)
+    fun <L, R> cond(test: Boolean, ifTrue: () -> R, ifFalse: () -> L): Either<L, R> =
+      conditionally(test, ifFalse, ifTrue)
 
     /**
      * Will create an [Either] from the result of evaluating the first parameter using the functions
@@ -885,7 +888,8 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
      *
      * @return [Either.Right] if evaluation succeed, [Either.Left] otherwise
      */
-    inline fun <L, R> conditionally(test: Boolean, ifFalse: () -> L, ifTrue: () -> R): Either<L, R> = if (test) right(ifTrue()) else left(ifFalse())
+    inline fun <L, R> conditionally(test: Boolean, ifFalse: () -> L, ifTrue: () -> R): Either<L, R> =
+      if (test) right(ifTrue()) else left(ifFalse())
 
     suspend fun <R> catch(f: suspend () -> R): Either<Throwable, R> =
       try {
@@ -904,9 +908,9 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
   }
 }
 
-fun <L> Left(left: L): Either<L, Nothing> = Either.left(left)
+fun <L> Left(left: L): Either<L, Nothing> = Left(left)
 
-fun <R> Right(right: R): Either<Nothing, R> = Either.right(right)
+fun <R> Right(right: R): Either<Nothing, R> = Right(right)
 
 /**
  * Binds the given function across [Either.Right].
@@ -1011,8 +1015,8 @@ inline fun <A, B> EitherOf<A, B>.filterOrElse(predicate: (B) -> Boolean, default
  */
 inline fun <A, B> EitherOf<A, B>.filterOrOther(predicate: (B) -> Boolean, default: (B) -> A): Either<A, B> =
   flatMap {
-    if (predicate(it)) arrow.core.Either.Right(it)
-    else arrow.core.Either.Left(default(it))
+    if (predicate(it)) Right(it)
+    else Left(default(it))
   }
 
 /**
@@ -1084,8 +1088,8 @@ inline fun <A, B> B?.rightIfNotNull(default: () -> A): Either<A, B> = when (this
  * [Either.Left].
  */
 inline fun <A> Any?.rightIfNull(default: () -> A): Either<A, Nothing?> = when (this) {
-  null -> Either.right(null)
-  else -> Either.left(default())
+  null -> Right(null)
+  else -> Left(default())
 }
 
 /**

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -718,7 +718,7 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
       }
     }
 
-  fun <C> foldRight(initial: Eval<C>, rightOperation: (B, Eval<C>) -> Eval<C>): Eval<C> =
+  inline fun <C> foldRight(initial: Eval<C>, crossinline rightOperation: (B, Eval<C>) -> Eval<C>): Eval<C> =
     fix().let { either ->
       when (either) {
         is Right -> Eval.defer { rightOperation(either.b, initial) }
@@ -1026,7 +1026,7 @@ inline fun <A, B> EitherOf<A, B>.filterOrOther(predicate: (B) -> Boolean, defaul
  * Left(12).leftIfNull({ -1 })    // Result: Left(12)
  * ```
  */
-fun <A, B> EitherOf<A, B?>.leftIfNull(default: () -> A): Either<A, B> =
+inline fun <A, B> EitherOf<A, B?>.leftIfNull(default: () -> A): Either<A, B> =
   fix().flatMap { it.rightIfNotNull { default() } }
 
 /**

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -888,8 +888,13 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
     inline fun <L, R> conditionally(test: Boolean, ifFalse: () -> L, ifTrue: () -> R): Either<L, R> = if (test) right(ifTrue()) else left(ifFalse())
 
     suspend fun <R> catch(f: suspend () -> R): Either<Throwable, R> =
-      catch(::identity, f)
+      try {
+        f().right()
+      } catch (t: Throwable) {
+        t.nonFatalOrThrow().left()
+      }
 
+    @Deprecated("Use catch with mapLeft instead", ReplaceWith("catch(f).mapLeft(fe)"))
     suspend fun <L, R> catch(fe: (Throwable) -> L, f: suspend () -> R): Either<L, R> =
       try {
         f().right()

--- a/arrow-core-data/src/main/kotlin/arrow/core/Eval.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Eval.kt
@@ -1,6 +1,7 @@
 package arrow.core
 
 import arrow.higherkind
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 
 fun <A> EvalOf<A>.value(): A = this.fix().value()
 
@@ -253,6 +254,7 @@ sealed class Eval<out A> : EvalOf<A> {
     when (this) {
       is FlatMap<A> -> object : FlatMap<B>() {
         override fun <S> start(): Eval<S> = (this@Eval).start()
+        @IgnoreJRERequirement
         override fun <S> run(s: S): Eval<B> =
           object : FlatMap<B>() {
             override fun <S1> start(): Eval<S1> = (this@Eval).run(s) as Eval<S1>

--- a/arrow-core-data/src/main/kotlin/arrow/core/Eval.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Eval.kt
@@ -111,8 +111,8 @@ sealed class Eval<out A> : EvalOf<A> {
      *
      * "expensive computation" is only computed once since the results are memoized and multiple calls to `value()` will just return the cached value.
      */
-    fun <A> later(f: () -> A): Later<A> =
-      Later(f)
+    inline fun <A> later(crossinline f: () -> A): Later<A> =
+      Later { f() }
 
     /**
      * Creates an Eval instance from a function deferring it's evaluation until `.value()` is invoked recomputing each time `.value()` is invoked.
@@ -132,11 +132,11 @@ sealed class Eval<out A> : EvalOf<A> {
      *
      * "expensive computation" is computed every time `value()` is invoked.
      */
-    fun <A> always(f: () -> A) =
-      Always(f)
+    inline fun <A> always(crossinline f: () -> A) =
+      Always { f() }
 
-    fun <A> defer(f: () -> Eval<A>): Eval<A> =
-      Defer(f)
+    inline fun <A> defer(crossinline f: () -> Eval<A>): Eval<A> =
+      Defer { f() }
 
     fun raise(t: Throwable): Eval<Nothing> =
       defer { throw t }
@@ -244,12 +244,14 @@ sealed class Eval<out A> : EvalOf<A> {
 
   abstract fun memoize(): Eval<A>
 
-  fun <B> map(f: (A) -> B): Eval<B> = flatMap { a -> Now(f(a)) }
+  inline fun <B> map(crossinline f: (A) -> B): Eval<B> =
+    flatMap { a -> Now(f(a)) }
 
-  fun <B> ap(ff: EvalOf<(A) -> B>): Eval<B> = ff.fix().flatMap { f -> map(f) }.fix()
+  fun <B> ap(ff: EvalOf<(A) -> B>): Eval<B> =
+    ff.fix().flatMap { f -> map(f) }.fix()
 
   @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE", "UNCHECKED_CAST")
-  fun <B> flatMap(f: (A) -> EvalOf<B>): Eval<B> =
+  inline fun <B> flatMap(crossinline f: (A) -> EvalOf<B>): Eval<B> =
     when (this) {
       is FlatMap<A> -> object : FlatMap<B>() {
         override fun <S> start(): Eval<S> = (this@Eval).start()
@@ -269,7 +271,8 @@ sealed class Eval<out A> : EvalOf<A> {
       }
     }
 
-  fun <B> coflatMap(f: (EvalOf<A>) -> B): Eval<B> = Later { f(this) }
+  inline fun <B> coflatMap(crossinline f: (EvalOf<A>) -> B): Eval<B> =
+    Later { f(this) }
 
   fun extract(): A = value()
 
@@ -335,7 +338,7 @@ sealed class Eval<out A> : EvalOf<A> {
    * Unlike a traditional trampoline, the internal workings of the trampoline are not exposed. This allows a slightly
    * more efficient implementation of the .value method.
    */
-  internal abstract class FlatMap<out A> : Eval<A>() {
+  abstract class FlatMap<out A> : Eval<A>() {
     abstract fun <S> start(): Eval<S>
     abstract fun <S> run(s: S): Eval<A>
     override fun memoize(): Eval<A> = Memoize(this)

--- a/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
@@ -385,9 +385,8 @@ sealed class Option<out A> : OptionOf<A> {
      */
     fun <A> just(a: A): Option<A> = Some(a)
 
-    tailrec fun <A, B> tailRecM(a: A, f: (A) -> OptionOf<Either<A, B>>): Option<B> {
-      val option = f(a).fix()
-      return when (option) {
+    tailrec fun <A, B> tailRecM(a: A, f: (A) -> OptionOf<Either<A, B>>): Option<B> =
+      when (val option = f(a).fix()) {
         is Some -> {
           when (option.t) {
             is Either.Left -> tailRecM(option.t.a, f)
@@ -396,7 +395,6 @@ sealed class Option<out A> : OptionOf<A> {
         }
         is None -> None
       }
-    }
 
     fun <A> fromNullable(a: A?): Option<A> = if (a != null) Some(a) else None
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -667,7 +667,7 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
      * Converts an `Option<A>` to a `Validated<E, A>`, where the provided `ifNone` output value is returned as [Invalid]
      * when the specified `Option` is `None`.
      */
-    fun <E, A> fromOption(o: Option<A>, ifNone: () -> E): Validated<E, A> =
+    inline fun <E, A> fromOption(o: Option<A>, ifNone: () -> E): Validated<E, A> =
       o.fold(
         { Invalid(ifNone()) },
         { Valid(it) }
@@ -677,7 +677,7 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
      * Converts a nullable `A?` to a `Validated<E, A>`, where the provided `ifNull` output value is returned as [Invalid]
      * when the specified value is null.
      */
-    fun <E, A> fromNullable(value: A?, ifNull: () -> E): Validated<E, A> =
+    inline fun <E, A> fromNullable(value: A?, ifNull: () -> E): Validated<E, A> =
       value?.let(::Valid) ?: Invalid(ifNull())
 
     suspend fun <A> catch(f: suspend () -> A): Validated<Throwable, A> =

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -770,11 +770,15 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
   inline fun <B> map(f: (A) -> B): Validated<E, B> =
     bimap(::identity, f)
 
+  @Deprecated("Use mapLeft for consistency", ReplaceWith("mapLeft(f)"))
+  inline fun <EE> leftMap(f: (E) -> EE): Validated<EE, A> =
+    mapLeft(f)
+
   /**
    * Apply a function to an Invalid value, returning a new Invalid value.
    * Or, if the original valid was Valid, return it.
    */
-  inline fun <EE> leftMap(f: (E) -> EE): Validated<EE, A> =
+  inline fun <EE> mapLeft(f: (E) -> EE): Validated<EE, A> =
     bimap(f, ::identity)
 
   /**

--- a/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
@@ -216,5 +216,16 @@ class EitherTest : UnitSpec() {
           Right(a).handleErrorWith { Right(b) } == Right(a)
       }
     }
+
+    "catch should return Valid(result) when f does not throw" {
+      suspend fun loadFromNetwork(): Int = 1
+      Either.catch { loadFromNetwork() } shouldBe Right(1)
+    }
+
+    "catch should return Invalid(result) when f throws" {
+      val exception = Exception("Boom!")
+      suspend fun loadFromNetwork(): Int = throw exception
+      Either.catch { loadFromNetwork() } shouldBe Left(exception)
+    }
   }
 }

--- a/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
@@ -217,12 +217,12 @@ class EitherTest : UnitSpec() {
       }
     }
 
-    "catch should return Valid(result) when f does not throw" {
+    "catch should return Right(result) when f does not throw" {
       suspend fun loadFromNetwork(): Int = 1
       Either.catch { loadFromNetwork() } shouldBe Right(1)
     }
 
-    "catch should return Invalid(result) when f throws" {
+    "catch should return Left(result) when f throws" {
       val exception = Exception("Boom!")
       suspend fun loadFromNetwork(): Int = throw exception
       Either.catch { loadFromNetwork() } shouldBe Left(exception)

--- a/arrow-core-data/src/test/kotlin/arrow/core/ValidatedTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/ValidatedTest.kt
@@ -83,8 +83,8 @@ class ValidatedTest : UnitSpec() {
     }
 
     "leftMap should modify error" {
-      Valid(10).leftMap { fail("None should not be called") } shouldBe Valid(10)
-      Invalid(13).leftMap { i -> i.toString() + " is Coming soon!" } shouldBe Invalid("13 is Coming soon!")
+      Valid(10).mapLeft { fail("None should not be called") } shouldBe Valid(10)
+      Invalid(13).mapLeft { i -> "$i is Coming soon!" } shouldBe Invalid("13 is Coming soon!")
     }
 
     "exist should return false if is Invalid" {

--- a/arrow-core-data/src/test/kotlin/arrow/core/ValidatedTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/ValidatedTest.kt
@@ -212,28 +212,24 @@ class ValidatedTest : UnitSpec() {
 
     "catch should return Valid(result) when f does not throw" {
       suspend fun loadFromNetwork(): Int = 1
-      val validated = Validated.catch { loadFromNetwork() }
-      validated shouldBe Valid(1)
+      Validated.catch { loadFromNetwork() } shouldBe Valid(1)
     }
 
     "catch should return Invalid(result) when f throws" {
       val exception = MyException("Boom!")
       suspend fun loadFromNetwork(): Int = throw exception
-      val validated = Validated.catch { loadFromNetwork() }
-      validated shouldBe Invalid(exception)
+      Validated.catch { loadFromNetwork() } shouldBe Invalid(exception)
     }
 
     "catchNel should return Valid(result) when f does not throw" {
       suspend fun loadFromNetwork(): Int = 1
-      val validated = Validated.catchNel { loadFromNetwork() }
-      validated shouldBe Valid(1)
+      Validated.catchNel { loadFromNetwork() } shouldBe Valid(1)
     }
 
     "catchNel should return Invalid(Nel(result)) when f throws" {
       val exception = MyException("Boom!")
       suspend fun loadFromNetwork(): Int = throw exception
-      val validated = Validated.catchNel { loadFromNetwork() }
-      validated shouldBe Invalid(NonEmptyList(exception))
+      Validated.catchNel { loadFromNetwork() } shouldBe Invalid(NonEmptyList(exception))
     }
 
     with(VAL_AP) {

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const.kt
@@ -107,7 +107,7 @@ interface ConstTraverse<X> : Traverse<ConstPartialOf<X>>, ConstFoldable<X> {
   override fun <T, U> ConstOf<X, T>.map(f: (T) -> U): Const<X, U> = fix().retag()
 
   override fun <G, A, B> ConstOf<X, A>.traverse(AP: Applicative<G>, f: (A) -> Kind<G, B>): Kind<G, ConstOf<X, B>> =
-    fix().traverse(AP, f)
+    fix().traverse(AP)
 }
 
 @extension
@@ -116,7 +116,7 @@ interface ConstTraverseFilter<X> : TraverseFilter<ConstPartialOf<X>>, ConstTrave
   override fun <T, U> Kind<ConstPartialOf<X>, T>.map(f: (T) -> U): Const<X, U> = fix().retag()
 
   override fun <G, A, B> Kind<ConstPartialOf<X>, A>.traverseFilter(AP: Applicative<G>, f: (A) -> Kind<G, Option<B>>): Kind<G, ConstOf<X, B>> =
-    fix().traverseFilter(AP, f)
+    fix().traverseFilter(AP)
 }
 
 @extension

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const.kt
@@ -107,7 +107,7 @@ interface ConstTraverse<X> : Traverse<ConstPartialOf<X>>, ConstFoldable<X> {
   override fun <T, U> ConstOf<X, T>.map(f: (T) -> U): Const<X, U> = fix().retag()
 
   override fun <G, A, B> ConstOf<X, A>.traverse(AP: Applicative<G>, f: (A) -> Kind<G, B>): Kind<G, ConstOf<X, B>> =
-    fix().traverse(AP)
+    fix().traverse(AP, f)
 }
 
 @extension
@@ -116,7 +116,7 @@ interface ConstTraverseFilter<X> : TraverseFilter<ConstPartialOf<X>>, ConstTrave
   override fun <T, U> Kind<ConstPartialOf<X>, T>.map(f: (T) -> U): Const<X, U> = fix().retag()
 
   override fun <G, A, B> Kind<ConstPartialOf<X>, A>.traverseFilter(AP: Applicative<G>, f: (A) -> Kind<G, Option<B>>): Kind<G, ConstOf<X, B>> =
-    fix().traverseFilter(AP)
+    fix().traverseFilter(AP, f)
 }
 
 @extension

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ configure(subprojects - project("arrow-meta")) {
     apply plugin: 'ru.vyarus.animalsniffer'
     apply plugin: 'java'
     dependencies {
+        implementation "org.codehaus.mojo:animal-sniffer-annotations:1.19"
         signature 'net.sf.androidscents.signature:android-api-level-21:5.0.1_r2@signature'
     }
 }


### PR DESCRIPTION
* Make the remaining functions inline with crossinline lambdas

Also:
* 👀 Remove unused lambda in Const's traverse and traverseFilter
* 🔧 Deprecate Validated.leftMap in favour of mapLeft
* 🔧 Deprecate Either.catch(fe, f) in favour catch(f).mapLeft(fe)
* ✅ Add missing tests to Either.catch

Fixes #115