### PR TITLE
Rework Order to use Ordering and test instance laws

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/Ordering.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Ordering.kt
@@ -1,0 +1,36 @@
+package arrow.core
+
+sealed class Ordering {
+  override fun equals(other: Any?): Boolean = this === other // ref equality is fine because objects should be singletons
+
+  override fun toString(): String = when (this) {
+    LT -> "LT"
+    GT -> "GT"
+    EQ -> "EQ"
+  }
+
+  override fun hashCode(): Int = toInt()
+
+  fun toInt(): Int = when (this) {
+    LT -> -1
+    GT -> 1
+    EQ -> 0
+  }
+
+  operator fun plus(b: Ordering): Ordering = when (this) {
+    LT -> LT
+    EQ -> b
+    GT -> GT
+  }
+
+  companion object {
+    fun fromInt(i: Int): Ordering = when (i) {
+      0 -> EQ
+      else -> if (i < 0) LT else GT
+    }
+  }
+}
+
+object LT : Ordering()
+object GT : Ordering()
+object EQ : Ordering()

--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Order.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Order.kt
@@ -36,9 +36,9 @@ sealed class Ordering {
     }
   }
 }
-object LT: Ordering()
-object GT: Ordering()
-object EQ: Ordering()
+object LT : Ordering()
+object GT : Ordering()
+object EQ : Ordering()
 
 /**
  * ank_macro_hierarchy(arrow.typeclasses.Order)

--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Order.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Order.kt
@@ -1,44 +1,10 @@
 package arrow.typeclasses
 
+import arrow.core.EQ
+import arrow.core.GT
+import arrow.core.LT
+import arrow.core.Ordering
 import arrow.core.Tuple2
-
-sealed class Ordering {
-  override fun equals(other: Any?): Boolean = this === other // ref equality is fine because objects should be singletons
-
-  override fun toString(): String = when (this) {
-    LT -> "LT"
-    GT -> "GT"
-    EQ -> "EQ"
-  }
-
-  override fun hashCode(): Int = when (this) {
-    LT -> 0
-    GT -> 1
-    EQ -> 2
-  }
-
-  fun toInt(): Int = when (this) {
-    LT -> -1
-    GT -> 1
-    EQ -> 0
-  }
-
-  operator fun plus(b: Ordering): Ordering = when (this) {
-    LT -> LT
-    EQ -> b
-    GT -> GT
-  }
-
-  companion object {
-    fun fromInt(i: Int): Ordering = when (i) {
-      0 -> EQ
-      else -> if (i < 0) LT else GT
-    }
-  }
-}
-object LT : Ordering()
-object GT : Ordering()
-object EQ : Ordering()
 
 /**
  * ank_macro_hierarchy(arrow.typeclasses.Order)

--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Order.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Order.kt
@@ -2,12 +2,50 @@ package arrow.typeclasses
 
 import arrow.core.Tuple2
 
+sealed class Ordering {
+  override fun equals(other: Any?): Boolean = this === other // ref equality is fine because objects should be singletons
+
+  override fun toString(): String = when (this) {
+    LT -> "LT"
+    GT -> "GT"
+    EQ -> "EQ"
+  }
+
+  override fun hashCode(): Int = when (this) {
+    LT -> 0
+    GT -> 1
+    EQ -> 2
+  }
+
+  fun toInt(): Int = when (this) {
+    LT -> -1
+    GT -> 1
+    EQ -> 0
+  }
+
+  operator fun plus(b: Ordering): Ordering = when (this) {
+    LT -> LT
+    EQ -> b
+    GT -> GT
+  }
+
+  companion object {
+    fun fromInt(i: Int): Ordering = when (i) {
+      0 -> EQ
+      else -> if (i < 0) LT else GT
+    }
+  }
+}
+object LT: Ordering()
+object GT: Ordering()
+object EQ: Ordering()
+
 /**
  * ank_macro_hierarchy(arrow.typeclasses.Order)
  *
  * The [Order] type class is used to define a total ordering on some type [F] and is defined by being able to fully determine order between two instances.
  *
- * [Order] is a subtype of [Eq] and defines [eqv] in terms of [compare].
+ * [Order] is a subtype of [Eq] and defines [eqv] in terms of [compare]
  *
  * @see [Eq]
  * @see <a href="http://arrow-kt.io/docs/arrow/typeclasses/order/">Order documentation</a>
@@ -15,22 +53,19 @@ import arrow.core.Tuple2
 interface Order<F> : Eq<F> {
 
   /**
-   * Compare [this@compare] with [b]. Returns an Int whose sign is:
-   * - negative if `x < y`
-   * - zero     if `x = y`
-   * - positive if `x > y`
+   * Compare [this@compare] with [b].
    *
    * @receiver object to compare with [b]
    * @param b object to compare with [this@compare]
-   * @returns zero objects are equal, a negative number if [this@compare] is less than [b], or a positive number if [this@compare] greater than [b].
+   * @returns [Ordering] sum type which defines the ordering
    */
-  fun F.compare(b: F): Int
+  fun F.compare(b: F): Ordering
 
   /** Kotlin operator overload */
-  operator fun F.compareTo(b: F): Int = compare(b)
+  operator fun F.compareTo(b: F): Int = compare(b).toInt()
 
   /** @see [Eq.eqv] */
-  override fun F.eqv(b: F): Boolean = this.compare(b) == 0
+  override fun F.eqv(b: F): Boolean = this.compare(b) == EQ
 
   /**
    * Check if [this@lt] is `lower than` [b]
@@ -39,7 +74,7 @@ interface Order<F> : Eq<F> {
    * @param b object to compare with [this@lt]
    * @returns true if [this@lt] is `lower than` [b] and false otherwise
    */
-  fun F.lt(b: F): Boolean = compare(b) < 0
+  fun F.lt(b: F): Boolean = compare(b) == LT
 
   /**
    * Check if [this@lte] is `lower than or equal to` [b]
@@ -48,7 +83,7 @@ interface Order<F> : Eq<F> {
    * @param b object to compare with [this@lte]
    * @returns true if [this@lte] is `lower than or equal to` [b] and false otherwise
    */
-  fun F.lte(b: F): Boolean = compare(b) <= 0
+  fun F.lte(b: F): Boolean = compare(b) != GT
 
   /**
    * Check if [this@gt] is `greater than` [b]
@@ -57,7 +92,7 @@ interface Order<F> : Eq<F> {
    * @param b object to compare with [this@gt]
    * @returns true if [this@gt] is `greater than` [b] and false otherwise
    */
-  fun F.gt(b: F): Boolean = compare(b) > 0
+  fun F.gt(b: F): Boolean = compare(b) == GT
 
   /**
    * Check if [this@gte] is `greater than or equal to` [b]
@@ -66,7 +101,7 @@ interface Order<F> : Eq<F> {
    * @param b object to compare with [this@gte]
    * @returns true if [this@gte] is `greater than or equal to` [b] and false otherwise
    */
-  fun F.gte(b: F): Boolean = compare(b) >= 0
+  fun F.gte(b: F): Boolean = compare(b) != LT
 
   /**
    * Determines the maximum of [this@max] and [b] in terms of order.
@@ -98,13 +133,13 @@ interface Order<F> : Eq<F> {
   companion object {
 
     /**
-     * Construct an [Order] from a function `(F, F) -> Int`.
+     * Construct an [Order] from a function `(F, F) -> Ordering`.
      *
      * @param compare a function that defines the order for 2 objects of type [F].
      * @returns an [Order] instance that is defined by the [compare] function.
      */
-    inline operator fun <F> invoke(crossinline compare: (F, F) -> Int): Order<F> = object : Order<F> {
-      override fun F.compare(b: F): Int = compare(this, b)
+    inline operator fun <F> invoke(crossinline compare: (F, F) -> Ordering): Order<F> = object : Order<F> {
+      override fun F.compare(b: F): Ordering = compare(this, b)
     }
 
     /**
@@ -113,7 +148,7 @@ interface Order<F> : Eq<F> {
      * @returns an [Order] instance wherefore all instances of type [F] are equal.
      */
     fun <F> allEqual(): Order<F> = object : Order<F> {
-      override fun F.compare(b: F): Int = 0
+      override fun F.compare(b: F): Ordering = EQ
     }
   }
 }

--- a/arrow-core-data/src/test/kotlin/arrow/core/BooleanTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/BooleanTest.kt
@@ -2,14 +2,25 @@ package arrow.core
 
 import arrow.core.extensions.AndMonoid
 import arrow.core.extensions.eq
+import arrow.core.extensions.hash
+import arrow.core.extensions.order
+import arrow.core.extensions.show
 import arrow.core.test.UnitSpec
+import arrow.core.test.laws.EqLaws
+import arrow.core.test.laws.HashLaws
 import arrow.core.test.laws.MonoidLaws
+import arrow.core.test.laws.OrderLaws
+import arrow.core.test.laws.ShowLaws
 import io.kotlintest.properties.Gen
 
 class BooleanTest : UnitSpec() {
   init {
     testLaws(
-      MonoidLaws.laws(AndMonoid, Gen.bool(), Boolean.eq())
+      MonoidLaws.laws(AndMonoid, Gen.bool(), Boolean.eq()),
+      EqLaws.laws(Boolean.eq(), Gen.bool()),
+      ShowLaws.laws(Boolean.show(), Boolean.eq(), Gen.bool()),
+      HashLaws.laws(Boolean.hash(), Gen.bool(), Boolean.eq()),
+      OrderLaws.laws(Boolean.order(), Gen.bool())
     )
   }
 }

--- a/arrow-core-data/src/test/kotlin/arrow/core/ConstTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/ConstTest.kt
@@ -5,10 +5,14 @@ import arrow.core.computations.const
 import arrow.core.extensions.const.applicative.applicative
 import arrow.core.extensions.const.eq.eq
 import arrow.core.extensions.const.functor.functor
+import arrow.core.extensions.const.hash.hash
+import arrow.core.extensions.const.order.order
 import arrow.core.extensions.const.show.show
 import arrow.core.extensions.const.traverseFilter.traverseFilter
 import arrow.core.extensions.eq
+import arrow.core.extensions.hash
 import arrow.core.extensions.monoid
+import arrow.core.extensions.order
 import arrow.core.extensions.show
 import arrow.core.test.UnitSpec
 import arrow.core.test.generators.genConst
@@ -16,6 +20,8 @@ import arrow.core.test.generators.genK
 import arrow.core.test.laws.ApplicativeLaws
 import arrow.core.test.laws.EqLaws
 import arrow.core.test.laws.FxLaws
+import arrow.core.test.laws.HashLaws
+import arrow.core.test.laws.OrderLaws
 import arrow.core.test.laws.ShowLaws
 import arrow.core.test.laws.TraverseFilterLaws
 import arrow.typeclasses.Eq
@@ -38,11 +44,13 @@ class ConstTest : UnitSpec() {
     val GEN = Gen.genConst<Int, Int>(Gen.int())
 
     testLaws(
-        TraverseFilterLaws.laws(Const.traverseFilter(), Const.applicative(M), GENK, EQK),
-        ApplicativeLaws.laws(Const.applicative(M), Const.functor(), GENK, EQK),
-        EqLaws.laws(Const.eq<Int, Int>(Eq.any()), GEN),
-        ShowLaws.laws(Const.show(Int.show()), Const.eq<Int, Int>(Eq.any()), GEN),
-        FxLaws.laws<ConstPartialOf<Int>, Int>(GENK.genK(Gen.int()), GENK.genK(Gen.int()), EQK.liftEq(Int.eq()), const::eager, const::invoke)
-      )
+      TraverseFilterLaws.laws(Const.traverseFilter(), Const.applicative(M), GENK, EQK),
+      ApplicativeLaws.laws(Const.applicative(M), Const.functor(), GENK, EQK),
+      EqLaws.laws(Const.eq<Int, Int>(Eq.any()), GEN),
+      ShowLaws.laws(Const.show(Int.show()), Const.eq<Int, Int>(Eq.any()), GEN),
+      FxLaws.laws<ConstPartialOf<Int>, Int>(GENK.genK(Gen.int()), GENK.genK(Gen.int()), EQK.liftEq(Int.eq()), const::eager, const::invoke),
+      HashLaws.laws(Const.hash(Int.hash()), GEN, Const.eq(Int.eq())),
+      OrderLaws.laws(Const.order<Int, Int>(Int.order()), GEN)
+    )
   }
 }

--- a/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
@@ -15,6 +15,7 @@ import arrow.core.extensions.either.hash.hash
 import arrow.core.extensions.either.monad.monad
 import arrow.core.extensions.either.monadError.monadError
 import arrow.core.extensions.either.monoid.monoid
+import arrow.core.extensions.either.order.order
 import arrow.core.extensions.either.semigroupK.semigroupK
 import arrow.core.extensions.either.show.show
 import arrow.core.extensions.either.traverse.traverse
@@ -22,6 +23,7 @@ import arrow.core.extensions.eq
 import arrow.core.extensions.hash
 import arrow.core.extensions.id.eq.eq
 import arrow.core.extensions.monoid
+import arrow.core.extensions.order
 import arrow.core.extensions.show
 import arrow.core.test.UnitSpec
 import arrow.core.test.generators.either
@@ -38,6 +40,7 @@ import arrow.core.test.laws.FxLaws
 import arrow.core.test.laws.HashLaws
 import arrow.core.test.laws.MonadErrorLaws
 import arrow.core.test.laws.MonoidLaws
+import arrow.core.test.laws.OrderLaws
 import arrow.core.test.laws.SemigroupKLaws
 import arrow.core.test.laws.ShowLaws
 import arrow.core.test.laws.TraverseLaws
@@ -70,6 +73,7 @@ class EitherTest : UnitSpec() {
       BitraverseLaws.laws(Either.bitraverse(), Either.genK2(), Either.eqK2()),
       SemigroupKLaws.laws(Either.semigroupK(), Either.genK(Gen.id(Gen.int())), Either.eqK(Id.eq(Int.eq()))),
       HashLaws.laws(Either.hash(String.hash(), Int.hash()), GEN, Either.eq(String.eq(), Int.eq())),
+      OrderLaws.laws(Either.order(String.order(), Int.order()), GEN),
       BicrosswalkLaws.laws(Either.bicrosswalk(), Either.genK2(), Either.eqK2()),
       FxLaws.laws<EitherPartialOf<String>, Int>(Gen.int().map(::Right), GEN.map { it }, Either.eqK(String.eq()).liftEq(Int.eq()), either::eager, either::invoke)
     )

--- a/arrow-core-data/src/test/kotlin/arrow/core/IdTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/IdTest.kt
@@ -13,6 +13,7 @@ import arrow.core.extensions.id.functor.functor
 import arrow.core.extensions.id.hash.hash
 import arrow.core.extensions.id.monad.monad
 import arrow.core.extensions.id.monoid.monoid
+import arrow.core.extensions.id.order.order
 import arrow.core.extensions.id.repeat.repeat
 import arrow.core.extensions.id.selective.selective
 import arrow.core.extensions.id.semialign.semialign
@@ -21,6 +22,7 @@ import arrow.core.extensions.id.show.show
 import arrow.core.extensions.id.traverse.traverse
 import arrow.core.extensions.id.unzip.unzip
 import arrow.core.extensions.monoid
+import arrow.core.extensions.order
 import arrow.core.extensions.semigroup
 import arrow.core.extensions.show
 import arrow.core.test.UnitSpec
@@ -31,6 +33,7 @@ import arrow.core.test.laws.CrosswalkLaws
 import arrow.core.test.laws.EqKLaws
 import arrow.core.test.laws.HashLaws
 import arrow.core.test.laws.MonoidLaws
+import arrow.core.test.laws.OrderLaws
 import arrow.core.test.laws.RepeatLaws
 import arrow.core.test.laws.SemialignLaws
 import arrow.core.test.laws.ShowLaws
@@ -58,6 +61,7 @@ class IdTest : UnitSpec() {
         Id.eqK()
       ),
       HashLaws.laws(Id.hash(Int.hash()), Gen.id(Gen.int()), Id.eq(Int.eq())),
+      OrderLaws.laws(Id.order(Int.order()), Gen.id(Gen.int())),
       EqKLaws.laws(
         Id.eqK(),
         Id.genK()

--- a/arrow-core-data/src/test/kotlin/arrow/core/IorTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/IorTest.kt
@@ -13,8 +13,10 @@ import arrow.core.extensions.ior.eqK2.eqK2
 import arrow.core.extensions.ior.functor.functor
 import arrow.core.extensions.ior.hash.hash
 import arrow.core.extensions.ior.monad.monad
+import arrow.core.extensions.ior.order.order
 import arrow.core.extensions.ior.show.show
 import arrow.core.extensions.ior.traverse.traverse
+import arrow.core.extensions.order
 import arrow.core.extensions.semigroup
 import arrow.core.extensions.show
 import arrow.core.test.UnitSpec
@@ -28,6 +30,7 @@ import arrow.core.test.laws.CrosswalkLaws
 import arrow.core.test.laws.EqK2Laws
 import arrow.core.test.laws.HashLaws
 import arrow.core.test.laws.MonadLaws
+import arrow.core.test.laws.OrderLaws
 import arrow.core.test.laws.ShowLaws
 import arrow.core.test.laws.TraverseLaws
 import arrow.typeclasses.Eq
@@ -62,6 +65,7 @@ class IorTest : UnitSpec() {
         Ior.eqK(Int.eq())
       ),
       HashLaws.laws(Ior.hash(String.hash(), Int.hash()), Gen.ior(Gen.string(), Gen.int()), Ior.eq(String.eq(), Int.eq())),
+      OrderLaws.laws(Ior.order(String.order(), Int.order()), Gen.ior(Gen.string(), Gen.int())),
       BitraverseLaws.laws(Ior.bitraverse(), Ior.genK2(), Ior.eqK2()),
       CrosswalkLaws.laws(Ior.crosswalk(), Ior.genK(Gen.int()), Ior.eqK(Int.eq())),
       BicrosswalkLaws.laws(Ior.bicrosswalk(), Ior.genK2(), Ior.eqK2())

--- a/arrow-core-data/src/test/kotlin/arrow/core/ListKTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/ListKTest.kt
@@ -46,7 +46,6 @@ import arrow.core.test.laws.UnalignLaws
 import arrow.core.test.laws.UnzipLaws
 import arrow.core.test.laws.equalUnderTheLaw
 import arrow.typeclasses.Eq
-import arrow.typeclasses.Order
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
 import io.kotlintest.shouldBe

--- a/arrow-core-data/src/test/kotlin/arrow/core/ListKTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/ListKTest.kt
@@ -17,12 +17,14 @@ import arrow.core.extensions.listk.monadLogic.monadLogic
 import arrow.core.extensions.listk.monoid.monoid
 import arrow.core.extensions.listk.monoidK.monoidK
 import arrow.core.extensions.listk.monoidal.monoidal
+import arrow.core.extensions.listk.order.order
 import arrow.core.extensions.listk.semialign.semialign
 import arrow.core.extensions.listk.semigroupK.semigroupK
 import arrow.core.extensions.listk.show.show
 import arrow.core.extensions.listk.traverse.traverse
 import arrow.core.extensions.listk.unalign.unalign
 import arrow.core.extensions.listk.unzip.unzip
+import arrow.core.extensions.order
 import arrow.core.extensions.show
 import arrow.core.test.UnitSpec
 import arrow.core.test.generators.genK
@@ -36,6 +38,7 @@ import arrow.core.test.laws.MonadLogicLaws
 import arrow.core.test.laws.MonoidKLaws
 import arrow.core.test.laws.MonoidLaws
 import arrow.core.test.laws.MonoidalLaws
+import arrow.core.test.laws.OrderLaws
 import arrow.core.test.laws.SemigroupKLaws
 import arrow.core.test.laws.ShowLaws
 import arrow.core.test.laws.TraverseLaws
@@ -43,6 +46,7 @@ import arrow.core.test.laws.UnalignLaws
 import arrow.core.test.laws.UnzipLaws
 import arrow.core.test.laws.equalUnderTheLaw
 import arrow.typeclasses.Eq
+import arrow.typeclasses.Order
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
 import io.kotlintest.shouldBe
@@ -77,6 +81,7 @@ class ListKTest : UnitSpec() {
       TraverseLaws.laws(ListK.traverse(), ListK.applicative(), ListK.genK(), ListK.eqK()),
 
       HashLaws.laws(ListK.hash(Int.hash()), Gen.listK(Gen.int()), ListK.eq(Int.eq())),
+      OrderLaws.laws(ListK.order(Int.order()), Gen.listK(Gen.int()).map { it as ListKOf<Int> }),
       EqKLaws.laws(
         ListK.eqK(),
         ListK.genK()

--- a/arrow-core-data/src/test/kotlin/arrow/core/NonEmptyListTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/NonEmptyListTest.kt
@@ -11,12 +11,14 @@ import arrow.core.extensions.nonemptylist.foldable.foldable
 import arrow.core.extensions.nonemptylist.functor.functor
 import arrow.core.extensions.nonemptylist.hash.hash
 import arrow.core.extensions.nonemptylist.monad.monad
+import arrow.core.extensions.nonemptylist.order.order
 import arrow.core.extensions.nonemptylist.semialign.semialign
 import arrow.core.extensions.nonemptylist.semigroup.semigroup
 import arrow.core.extensions.nonemptylist.semigroupK.semigroupK
 import arrow.core.extensions.nonemptylist.show.show
 import arrow.core.extensions.nonemptylist.traverse.traverse
 import arrow.core.extensions.nonemptylist.unzip.unzip
+import arrow.core.extensions.order
 import arrow.core.extensions.show
 import arrow.core.test.UnitSpec
 import arrow.core.test.generators.genK
@@ -24,6 +26,7 @@ import arrow.core.test.generators.nonEmptyList
 import arrow.core.test.laws.BimonadLaws
 import arrow.core.test.laws.EqKLaws
 import arrow.core.test.laws.HashLaws
+import arrow.core.test.laws.OrderLaws
 import arrow.core.test.laws.SemigroupKLaws
 import arrow.core.test.laws.SemigroupLaws
 import arrow.core.test.laws.ShowLaws
@@ -58,6 +61,7 @@ class NonEmptyListTest : UnitSpec() {
       TraverseLaws.laws(NonEmptyList.traverse(), NonEmptyList.applicative(), NonEmptyList.genK(), NonEmptyList.eqK()),
       SemigroupLaws.laws(NonEmptyList.semigroup(), Gen.nonEmptyList(Gen.int()), EQ1),
       HashLaws.laws(NonEmptyList.hash(Int.hash()), Gen.nonEmptyList(Gen.int()), EQ1),
+      OrderLaws.laws(NonEmptyList.order(Int.order()), Gen.nonEmptyList(Gen.int())),
       EqKLaws.laws(
         NonEmptyList.eqK(),
         NonEmptyList.genK()

--- a/arrow-core-data/src/test/kotlin/arrow/core/OptionTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/OptionTest.kt
@@ -17,12 +17,14 @@ import arrow.core.extensions.option.monadCombine.monadCombine
 import arrow.core.extensions.option.monadPlus.monadPlus
 import arrow.core.extensions.option.monoid.monoid
 import arrow.core.extensions.option.monoidal.monoidal
+import arrow.core.extensions.option.order.order
 import arrow.core.extensions.option.repeat.repeat
 import arrow.core.extensions.option.selective.selective
 import arrow.core.extensions.option.show.show
 import arrow.core.extensions.option.traverseFilter.traverseFilter
 import arrow.core.extensions.option.unalign.unalign
 import arrow.core.extensions.option.unzip.unzip
+import arrow.core.extensions.order
 import arrow.core.extensions.show
 import arrow.core.extensions.tuple2.eq.eq
 import arrow.core.test.UnitSpec
@@ -37,6 +39,7 @@ import arrow.core.test.laws.MonadCombineLaws
 import arrow.core.test.laws.MonadPlusLaws
 import arrow.core.test.laws.MonoidLaws
 import arrow.core.test.laws.MonoidalLaws
+import arrow.core.test.laws.OrderLaws
 import arrow.core.test.laws.RepeatLaws
 import arrow.core.test.laws.ShowLaws
 import arrow.core.test.laws.TraverseFilterLaws
@@ -78,6 +81,7 @@ class OptionTest : UnitSpec() {
       FunctorFilterLaws.laws(Option.traverseFilter(), Option.genK(), Option.eqK()),
       TraverseFilterLaws.laws(Option.traverseFilter(), Option.applicative(), Option.genK(), Option.eqK()),
       HashLaws.laws(Option.hash(Int.hash()), Gen.option(Gen.int()), Option.eq(Int.eq())),
+      OrderLaws.laws(Option.order(Int.order()), Gen.option(Gen.int())),
       MonoidalLaws.laws(Option.monoidal(), Option.genK(), Option.eqK(), ::bijection),
       EqKLaws.laws(
         Option.eqK(),

--- a/arrow-core-data/src/test/kotlin/arrow/core/SequenceKTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/SequenceKTest.kt
@@ -3,6 +3,7 @@ package arrow.core
 import arrow.Kind
 import arrow.core.extensions.eq
 import arrow.core.extensions.hash
+import arrow.core.extensions.order
 import arrow.core.extensions.sequencek.align.align
 import arrow.core.extensions.sequencek.applicative.applicative
 import arrow.core.extensions.sequencek.crosswalk.crosswalk
@@ -18,6 +19,7 @@ import arrow.core.extensions.sequencek.monadLogic.monadLogic
 import arrow.core.extensions.sequencek.monoid.monoid
 import arrow.core.extensions.sequencek.monoidK.monoidK
 import arrow.core.extensions.sequencek.monoidal.monoidal
+import arrow.core.extensions.sequencek.order.order
 import arrow.core.extensions.sequencek.repeat.repeat
 import arrow.core.extensions.sequencek.semialign.semialign
 import arrow.core.extensions.sequencek.show.show
@@ -37,6 +39,7 @@ import arrow.core.test.laws.MonadLogicLaws
 import arrow.core.test.laws.MonoidKLaws
 import arrow.core.test.laws.MonoidLaws
 import arrow.core.test.laws.MonoidalLaws
+import arrow.core.test.laws.OrderLaws
 import arrow.core.test.laws.RepeatLaws
 import arrow.core.test.laws.ShowLaws
 import arrow.core.test.laws.TraverseLaws
@@ -71,6 +74,7 @@ class SequenceKTest : UnitSpec() {
       TraverseLaws.laws(SequenceK.traverse(), SequenceK.genK(), SequenceK.eqK()),
       FunctorFilterLaws.laws(SequenceK.functorFilter(), SequenceK.genK(), SequenceK.eqK()),
       HashLaws.laws(SequenceK.hash(Int.hash()), Gen.sequenceK(Gen.int()), SequenceK.eq(Int.eq())),
+      OrderLaws.laws(SequenceK.order(Int.order()), Gen.sequenceK(Gen.int())),
       AlignLaws.laws(SequenceK.align(),
         SequenceK.genK(),
         SequenceK.eqK(),

--- a/arrow-core-data/src/test/kotlin/arrow/core/ValidatedTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/ValidatedTest.kt
@@ -2,7 +2,9 @@ package arrow.core
 
 import arrow.core.computations.validated
 import arrow.core.extensions.eq
+import arrow.core.extensions.hash
 import arrow.core.extensions.monoid
+import arrow.core.extensions.order
 import arrow.core.extensions.semigroup
 import arrow.core.extensions.show
 import arrow.core.extensions.validated.applicative.applicative
@@ -12,6 +14,8 @@ import arrow.core.extensions.validated.eq.eq
 import arrow.core.extensions.validated.eqK.eqK
 import arrow.core.extensions.validated.eqK2.eqK2
 import arrow.core.extensions.validated.functor.functor
+import arrow.core.extensions.validated.hash.hash
+import arrow.core.extensions.validated.order.order
 import arrow.core.extensions.validated.selective.selective
 import arrow.core.extensions.validated.semigroupK.semigroupK
 import arrow.core.extensions.validated.show.show
@@ -25,6 +29,8 @@ import arrow.core.test.laws.BitraverseLaws
 import arrow.core.test.laws.EqK2Laws
 import arrow.core.test.laws.EqLaws
 import arrow.core.test.laws.FxLaws
+import arrow.core.test.laws.HashLaws
+import arrow.core.test.laws.OrderLaws
 import arrow.core.test.laws.SelectiveLaws
 import arrow.core.test.laws.SemigroupKLaws
 import arrow.core.test.laws.ShowLaws
@@ -50,6 +56,8 @@ class ValidatedTest : UnitSpec() {
       BifunctorLaws.laws(Validated.bifunctor(), Validated.genK2(), Validated.eqK2()),
       EqLaws.laws(EQ, Gen.validated(Gen.string(), Gen.int())),
       ShowLaws.laws(Validated.show(String.show(), Int.show()), EQ, Gen.validated(Gen.string(), Gen.int())),
+      HashLaws.laws(Validated.hash(String.hash(), Int.hash()), Gen.validated(Gen.string(), Gen.int()), EQ),
+      OrderLaws.laws(Validated.order(String.order(), Int.order()), Gen.validated(Gen.string(), Gen.int())),
       SelectiveLaws.laws(Validated.selective(String.semigroup()), Validated.functor(), Validated.genK(Gen.string()), Validated.eqK(String.eq())),
       TraverseLaws.laws(Validated.traverse(), Validated.applicative(String.semigroup()), Validated.genK(Gen.string()), Validated.eqK(String.eq())),
       SemigroupKLaws.laws(

--- a/arrow-core-data/src/test/kotlin/arrow/core/extensions/NumberInstancesTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/extensions/NumberInstancesTest.kt
@@ -11,29 +11,32 @@ import arrow.core.test.generators.short
 import arrow.core.test.generators.shortSmall
 import arrow.core.test.laws.HashLaws
 import arrow.core.test.laws.MonoidLaws
+import arrow.core.test.laws.OrderLaws
 import arrow.core.test.laws.SemiringLaws
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
+import arrow.typeclasses.Order
 import arrow.typeclasses.Semiring
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
 
 class NumberInstancesTest : UnitSpec() {
 
-  fun <F> testAllLaws(SG: Semiring<F>, M: Monoid<F>, HF: Hash<F>, GEN: Gen<F>, EQ: Eq<F>) {
+  fun <F> testAllLaws(SG: Semiring<F>, M: Monoid<F>, HF: Hash<F>, GEN: Gen<F>, EQ: Eq<F>, OF: Order<F>) {
     testLaws(SemiringLaws.laws(SG, GEN, EQ))
     testLaws(MonoidLaws.laws(M, GEN, EQ))
     testLaws(HashLaws.laws(HF, GEN, EQ))
+    testLaws(OrderLaws.laws(OF, GEN))
   }
 
   init {
-    testAllLaws(Byte.semiring(), Byte.monoid(), Byte.hash(), Gen.byteSmall(), Byte.eq())
-    testAllLaws(Double.semiring(), Double.monoid(), Double.hash(), Gen.doubleSmall(), Double.eq())
-    testAllLaws(Int.semiring(), Int.monoid(), Int.hash(), Gen.intSmall(), Int.eq())
-    testAllLaws(Short.semiring(), Short.monoid(), Short.hash(), Gen.shortSmall(), Short.eq())
-    testAllLaws(Float.semiring(), Float.monoid(), Float.hash(), Gen.floatSmall(), Float.eq())
-    testAllLaws(Long.semiring(), Long.monoid(), Long.hash(), Gen.longSmall(), Long.eq())
+    testAllLaws(Byte.semiring(), Byte.monoid(), Byte.hash(), Gen.byteSmall(), Byte.eq(), Byte.order())
+    testAllLaws(Double.semiring(), Double.monoid(), Double.hash(), Gen.doubleSmall(), Double.eq(), Double.order())
+    testAllLaws(Int.semiring(), Int.monoid(), Int.hash(), Gen.intSmall(), Int.eq(), Int.order())
+    testAllLaws(Short.semiring(), Short.monoid(), Short.hash(), Gen.shortSmall(), Short.eq(), Short.order())
+    testAllLaws(Float.semiring(), Float.monoid(), Float.hash(), Gen.floatSmall(), Float.eq(), Float.order())
+    testAllLaws(Long.semiring(), Long.monoid(), Long.hash(), Gen.longSmall(), Long.eq(), Long.order())
 
     /** Semigroup specific instance check */
 

--- a/arrow-core-data/src/test/kotlin/arrow/core/extensions/StringInstancesTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/extensions/StringInstancesTest.kt
@@ -1,7 +1,9 @@
 package arrow.core.extensions
 
 import arrow.core.test.UnitSpec
+import arrow.core.test.laws.EqLaws
 import arrow.core.test.laws.HashLaws
+import arrow.core.test.laws.OrderLaws
 import arrow.core.test.laws.ShowLaws
 import io.kotlintest.properties.Gen
 
@@ -9,7 +11,9 @@ class StringInstancesTest : UnitSpec() {
   init {
     testLaws(
       ShowLaws.laws(String.show(), String.eq(), Gen.string()),
-      HashLaws.laws(String.hash(), Gen.string(), String.eq())
+      HashLaws.laws(String.hash(), Gen.string(), String.eq()),
+      OrderLaws.laws(String.order(), Gen.string()),
+      EqLaws.laws(String.eq(), Gen.string())
     )
   }
 }

--- a/arrow-core-test/src/main/kotlin/arrow/core/test/laws/OrderLaws.kt
+++ b/arrow-core-test/src/main/kotlin/arrow/core/test/laws/OrderLaws.kt
@@ -1,0 +1,71 @@
+package arrow.core.test.laws
+
+import arrow.typeclasses.EQ
+import arrow.typeclasses.GT
+import arrow.typeclasses.LT
+import arrow.typeclasses.Order
+import arrow.typeclasses.Ordering
+import io.kotlintest.properties.Gen
+import io.kotlintest.properties.forAll
+
+object OrderLaws {
+  fun <A> laws(OA: Order<A>, gen: Gen<A>): List<Law> =
+    EqLaws.laws(OA, gen) + listOf(
+      Law("OrderLaws: x.gte(y) = y.lte(x)") { OA.gteEqualsLteReversed(gen) },
+      Law("OrderLaws: x.lt(y) = x.lte(y) && x != y") { OA.ltEqualsLteAndIneq(gen) },
+      Law("OrderLaws: x.gt(y) = y.lt(x)") { OA.gtEqualsLtReversed(gen) },
+      Law("OrderLaws: x.lt(y) = x.compare(y) == LT") { OA.ltEqualsCompareLT(gen) },
+      Law("OrderLaws: x.gt(y) = x.compare(y) == GT") { OA.gtEqualsCompareGT(gen) },
+      Law("OrderLaws: x == y = x.compare(y) == EQ") { OA.eqvEqualsCompareEQ(gen) },
+      Law("OrderLaws: x.min(y) = if (x.lte(y)) x else y") { OA.minConsistent(gen) },
+      Law("OrderLaws: x.max(y) = if (x.gte(y)) x else y") { OA.maxConsistent(gen) },
+      Law("OrderLaws: Ordering.fromInt(x.compareTo(y)) = x.compare(y)") { OA.compareToConsistent(gen) }
+    )
+}
+
+private fun <F> Order<F>.compareToConsistent(gen: Gen<F>) =
+  forAll(gen, gen) { x, y ->
+    Ordering.fromInt(x.compareTo(y)) === x.compare(y)
+  }
+
+private fun <F> Order<F>.maxConsistent(gen: Gen<F>) =
+  forAll(gen, gen) { x, y ->
+    x.max(y) == (if (x.gt(y)) x else y)
+  }
+
+private fun <F> Order<F>.minConsistent(gen: Gen<F>) =
+  forAll(gen, gen) { x, y ->
+    x.min(y) == (if (x.lt(y)) x else y)
+  }
+
+private fun <F> Order<F>.eqvEqualsCompareEQ(gen: Gen<F>) =
+  forAll(gen, gen) { x, y ->
+    x.eqv(y) == (x.compare(y) == EQ)
+  }
+
+private fun <F> Order<F>.gtEqualsCompareGT(gen: Gen<F>) =
+  forAll(gen, gen) { x, y ->
+    x.gt(y) == (x.compare(y) == GT)
+  }
+
+private fun <F> Order<F>.ltEqualsCompareLT(gen: Gen<F>) =
+  forAll(gen, gen) { x, y ->
+    x.lt(y) == (x.compare(y) == LT)
+  }
+
+private fun <F> Order<F>.gtEqualsLtReversed(gen: Gen<F>) =
+  forAll(gen, gen) { x, y ->
+    x.gt(y) == y.lt(x)
+  }
+
+private fun <F> Order<F>.ltEqualsLteAndIneq(gen: Gen<F>) =
+  forAll(gen, gen) { x, y ->
+    x.lt(y) == (x.lte(y) && x.neqv(y))
+  }
+
+private fun <F> Order<F>.gteEqualsLteReversed(gen: Gen<F>) =
+  forAll(gen, gen) { x, y ->
+    x.gte(y) == y.lte(x)
+  }
+
+

--- a/arrow-core-test/src/main/kotlin/arrow/core/test/laws/OrderLaws.kt
+++ b/arrow-core-test/src/main/kotlin/arrow/core/test/laws/OrderLaws.kt
@@ -67,5 +67,3 @@ private fun <F> Order<F>.gteEqualsLteReversed(gen: Gen<F>) =
   forAll(gen, gen) { x, y ->
     x.gte(y) == y.lte(x)
   }
-
-

--- a/arrow-core-test/src/main/kotlin/arrow/core/test/laws/OrderLaws.kt
+++ b/arrow-core-test/src/main/kotlin/arrow/core/test/laws/OrderLaws.kt
@@ -1,10 +1,10 @@
 package arrow.core.test.laws
 
-import arrow.typeclasses.EQ
-import arrow.typeclasses.GT
-import arrow.typeclasses.LT
+import arrow.core.EQ
+import arrow.core.GT
+import arrow.core.LT
+import arrow.core.Ordering
 import arrow.typeclasses.Order
-import arrow.typeclasses.Ordering
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
 

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/boolean.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/boolean.kt
@@ -3,6 +3,8 @@ package arrow.core.extensions
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
+import arrow.typeclasses.Order
+import arrow.typeclasses.Ordering
 import arrow.typeclasses.Show
 
 interface BooleanShow : Show<Boolean> {
@@ -14,6 +16,11 @@ interface BooleanEq : Eq<Boolean> {
   override fun Boolean.eqv(b: Boolean): Boolean = this == b
 }
 
+interface BooleanOrder : Order<Boolean> {
+  override fun Boolean.compare(b: Boolean): Ordering = Ordering.fromInt(this.compareTo(b))
+  override fun Boolean.compareTo(b: Boolean): Int = this.compareTo(b)
+}
+
 interface BooleanHash : Hash<Boolean>, BooleanEq {
   override fun Boolean.hash(): Int = this.hashCode()
 }
@@ -23,6 +30,9 @@ fun Boolean.Companion.show(): Show<Boolean> =
 
 fun Boolean.Companion.eq(): Eq<Boolean> =
   object : BooleanEq {}
+
+fun Boolean.Companion.order(): Order<Boolean> =
+  object : BooleanOrder {}
 
 fun Boolean.Companion.hash(): Hash<Boolean> =
   object : BooleanHash {}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/boolean.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/boolean.kt
@@ -1,10 +1,10 @@
 package arrow.core.extensions
 
+import arrow.core.Ordering
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
-import arrow.typeclasses.Ordering
 import arrow.typeclasses.Show
 
 interface BooleanShow : Show<Boolean> {

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/char.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/char.kt
@@ -1,10 +1,7 @@
 package arrow.core.extensions
 
-import arrow.typeclasses.EQ
 import arrow.typeclasses.Eq
-import arrow.typeclasses.GT
 import arrow.typeclasses.Hash
-import arrow.typeclasses.LT
 import arrow.typeclasses.Order
 import arrow.typeclasses.Ordering
 import arrow.typeclasses.Show
@@ -19,20 +16,11 @@ interface CharEq : Eq<Char> {
 }
 
 interface CharOrder : Order<Char> {
-  override fun Char.eqv(b: Char): Boolean = this == b
-
   override fun Char.compare(b: Char): Ordering =
-    if (this < b) LT else if (this > b) GT else EQ
+    Ordering.fromInt(this.compareTo(b))
 
-  override fun Char.lt(b: Char): Boolean = this < b
-
-  override fun Char.lte(b: Char): Boolean = this <= b
-
-  override fun Char.gt(b: Char): Boolean = this > b
-
-  override fun Char.gte(b: Char): Boolean = this >= b
-
-  override fun Char.neqv(b: Char): Boolean = this != b
+  override fun Char.compareTo(b: Char): Int =
+    this.compareTo(b)
 }
 
 interface CharHash : Hash<Char>, CharEq {

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/char.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/char.kt
@@ -1,8 +1,12 @@
 package arrow.core.extensions
 
+import arrow.typeclasses.EQ
 import arrow.typeclasses.Eq
+import arrow.typeclasses.GT
 import arrow.typeclasses.Hash
+import arrow.typeclasses.LT
 import arrow.typeclasses.Order
+import arrow.typeclasses.Ordering
 import arrow.typeclasses.Show
 
 interface CharShow : Show<Char> {
@@ -17,8 +21,8 @@ interface CharEq : Eq<Char> {
 interface CharOrder : Order<Char> {
   override fun Char.eqv(b: Char): Boolean = this == b
 
-  override fun Char.compare(b: Char): Int =
-    if (this < b) -1 else if (this > b) 1 else 0
+  override fun Char.compare(b: Char): Ordering =
+    if (this < b) LT else if (this > b) GT else EQ
 
   override fun Char.lt(b: Char): Boolean = this < b
 

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/char.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/char.kt
@@ -1,9 +1,9 @@
 package arrow.core.extensions
 
+import arrow.core.Ordering
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Order
-import arrow.typeclasses.Ordering
 import arrow.typeclasses.Show
 
 interface CharShow : Show<Char> {

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const.kt
@@ -6,6 +6,7 @@ import arrow.core.ConstOf
 import arrow.core.ConstPartialOf
 import arrow.core.Eval
 import arrow.core.Option
+import arrow.core.Ordering
 import arrow.core.Tuple2
 import arrow.core.extensions.const.eq.eq
 import arrow.core.fix
@@ -24,7 +25,6 @@ import arrow.typeclasses.Hash
 import arrow.typeclasses.Invariant
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
-import arrow.typeclasses.Ordering
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
 import arrow.typeclasses.Traverse

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const.kt
@@ -23,6 +23,8 @@ import arrow.typeclasses.Functor
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Invariant
 import arrow.typeclasses.Monoid
+import arrow.typeclasses.Order
+import arrow.typeclasses.Ordering
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
 import arrow.typeclasses.Traverse
@@ -145,6 +147,13 @@ interface ConstEq<A, T> : Eq<Const<A, T>> {
 
   override fun Const<A, T>.eqv(b: Const<A, T>): Boolean =
     EQ().run { value().eqv(b.value()) }
+}
+
+@extension
+interface ConstOrder<A, T> : Order<Const<A, T>> {
+  fun ORD(): Order<A>
+  override fun Const<A, T>.compare(b: Const<A, T>): Ordering =
+    ORD().run { value().compare(b.value()) }
 }
 
 @extension

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either.kt
@@ -264,7 +264,7 @@ interface EitherOrder<L, R> : Order<Either<L, R>> {
   override fun Either<L, R>.compare(b: Either<L, R>): Ordering = fold({ l1 ->
     b.fold({ l2 -> OL().run { l1.compare(l2) } }, { LT })
   }, { r1 ->
-    b.fold({ GT }, { r2 -> OR().run { r1.compare(r2) }  })
+    b.fold({ GT }, { r2 -> OR().run { r1.compare(r2) } })
   })
 }
 

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either.kt
@@ -9,7 +9,10 @@ import arrow.core.EitherOf
 import arrow.core.EitherPartialOf
 import arrow.core.Eval
 import arrow.core.ForEither
+import arrow.core.GT
+import arrow.core.LT
 import arrow.core.Left
+import arrow.core.Ordering
 import arrow.core.Right
 import arrow.core.extensions.either.eq.eq
 import arrow.core.extensions.either.monad.monad
@@ -30,16 +33,13 @@ import arrow.typeclasses.EqK
 import arrow.typeclasses.EqK2
 import arrow.typeclasses.Foldable
 import arrow.typeclasses.Functor
-import arrow.typeclasses.GT
 import arrow.typeclasses.Hash
-import arrow.typeclasses.LT
 import arrow.typeclasses.Monad
 import arrow.typeclasses.MonadError
 import arrow.typeclasses.MonadFx
 import arrow.typeclasses.MonadSyntax
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
-import arrow.typeclasses.Ordering
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.SemigroupK
 import arrow.typeclasses.Show

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either.kt
@@ -30,12 +30,16 @@ import arrow.typeclasses.EqK
 import arrow.typeclasses.EqK2
 import arrow.typeclasses.Foldable
 import arrow.typeclasses.Functor
+import arrow.typeclasses.GT
 import arrow.typeclasses.Hash
+import arrow.typeclasses.LT
 import arrow.typeclasses.Monad
 import arrow.typeclasses.MonadError
 import arrow.typeclasses.MonadFx
 import arrow.typeclasses.MonadSyntax
 import arrow.typeclasses.Monoid
+import arrow.typeclasses.Order
+import arrow.typeclasses.Ordering
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.SemigroupK
 import arrow.typeclasses.Show
@@ -250,6 +254,17 @@ interface EitherHash<L, R> : Hash<Either<L, R>>, EitherEq<L, R> {
     HL().run { it.hash() }
   }, {
     HR().run { it.hash() }
+  })
+}
+
+@extension
+interface EitherOrder<L, R> : Order<Either<L, R>> {
+  fun OL(): Order<L>
+  fun OR(): Order<R>
+  override fun Either<L, R>.compare(b: Either<L, R>): Ordering = fold({ l1 ->
+    b.fold({ l2 -> OL().run { l1.compare(l2) } }, { LT })
+  }, { r1 ->
+    b.fold({ GT }, { r2 -> OR().run { r1.compare(r2) }  })
   })
 }
 

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/id.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/id.kt
@@ -31,6 +31,8 @@ import arrow.typeclasses.Monad
 import arrow.typeclasses.MonadFx
 import arrow.typeclasses.MonadSyntax
 import arrow.typeclasses.Monoid
+import arrow.typeclasses.Order
+import arrow.typeclasses.Ordering
 import arrow.typeclasses.Repeat
 import arrow.typeclasses.Selective
 import arrow.typeclasses.Semialign
@@ -210,6 +212,12 @@ interface IdHash<A> : Hash<Id<A>>, IdEq<A> {
   override fun EQ(): Eq<A> = HA()
 
   override fun Id<A>.hash(): Int = HA().run { value().hash() }
+}
+
+@extension
+interface IdOrder<A> : Order<Id<A>> {
+  fun OA(): Order<A>
+  override fun Id<A>.compare(b: Id<A>): Ordering = OA().run { value().compare(b.value()) }
 }
 
 fun <A> Id.Companion.fx(c: suspend MonadSyntax<ForId>.() -> A): Id<A> =

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/id.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/id.kt
@@ -9,6 +9,7 @@ import arrow.core.ForId
 import arrow.core.Id
 import arrow.core.IdOf
 import arrow.core.Ior
+import arrow.core.Ordering
 import arrow.core.Tuple2
 import arrow.core.extensions.id.monad.monad
 import arrow.core.fix
@@ -32,7 +33,6 @@ import arrow.typeclasses.MonadFx
 import arrow.typeclasses.MonadSyntax
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
-import arrow.typeclasses.Ordering
 import arrow.typeclasses.Repeat
 import arrow.typeclasses.Selective
 import arrow.typeclasses.Semialign

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior.kt
@@ -5,9 +5,12 @@ import arrow.Kind2
 import arrow.core.Either
 import arrow.core.Eval
 import arrow.core.ForIor
+import arrow.core.GT
 import arrow.core.Ior
 import arrow.core.IorOf
 import arrow.core.IorPartialOf
+import arrow.core.LT
+import arrow.core.Ordering
 import arrow.core.ap
 import arrow.core.extensions.ior.eq.eq
 import arrow.core.extensions.ior.monad.monad
@@ -29,13 +32,10 @@ import arrow.typeclasses.EqK
 import arrow.typeclasses.EqK2
 import arrow.typeclasses.Foldable
 import arrow.typeclasses.Functor
-import arrow.typeclasses.GT
 import arrow.typeclasses.Hash
-import arrow.typeclasses.LT
 import arrow.typeclasses.Monad
 import arrow.typeclasses.MonadSyntax
 import arrow.typeclasses.Order
-import arrow.typeclasses.Ordering
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
 import arrow.typeclasses.Traverse

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/listk.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/listk.kt
@@ -4,13 +4,15 @@ import arrow.Kind
 import arrow.core.Either
 import arrow.core.Eval
 import arrow.core.ForListK
+import arrow.core.GT
 import arrow.core.Ior
+import arrow.core.LT
 import arrow.core.ListK
 import arrow.core.ListKOf
 import arrow.core.Option
+import arrow.core.Ordering
 import arrow.core.Tuple2
 import arrow.core.extensions.list.foldable.fold
-import arrow.core.extensions.list.monad.flatten
 import arrow.core.extensions.listk.eq.eq
 import arrow.core.extensions.listk.monad.monad
 import arrow.core.extensions.listk.semigroup.plus
@@ -30,9 +32,7 @@ import arrow.typeclasses.EqK
 import arrow.typeclasses.Foldable
 import arrow.typeclasses.Functor
 import arrow.typeclasses.FunctorFilter
-import arrow.typeclasses.GT
 import arrow.typeclasses.Hash
-import arrow.typeclasses.LT
 import arrow.typeclasses.Monad
 import arrow.typeclasses.MonadCombine
 import arrow.typeclasses.MonadFilter
@@ -43,7 +43,6 @@ import arrow.typeclasses.Monoid
 import arrow.typeclasses.MonoidK
 import arrow.typeclasses.Monoidal
 import arrow.typeclasses.Order
-import arrow.typeclasses.Ordering
 import arrow.typeclasses.Semialign
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.SemigroupK

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/listk.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/listk.kt
@@ -9,10 +9,12 @@ import arrow.core.ListK
 import arrow.core.ListKOf
 import arrow.core.Option
 import arrow.core.Tuple2
+import arrow.core.extensions.list.foldable.fold
 import arrow.core.extensions.list.monad.flatten
 import arrow.core.extensions.listk.eq.eq
 import arrow.core.extensions.listk.monad.monad
 import arrow.core.extensions.listk.semigroup.plus
+import arrow.core.extensions.ordering.monoid.monoid
 import arrow.core.fix
 import arrow.core.identity
 import arrow.core.k
@@ -28,7 +30,9 @@ import arrow.typeclasses.EqK
 import arrow.typeclasses.Foldable
 import arrow.typeclasses.Functor
 import arrow.typeclasses.FunctorFilter
+import arrow.typeclasses.GT
 import arrow.typeclasses.Hash
+import arrow.typeclasses.LT
 import arrow.typeclasses.Monad
 import arrow.typeclasses.MonadCombine
 import arrow.typeclasses.MonadFilter
@@ -38,6 +42,8 @@ import arrow.typeclasses.MonadSyntax
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.MonoidK
 import arrow.typeclasses.Monoidal
+import arrow.typeclasses.Order
+import arrow.typeclasses.Ordering
 import arrow.typeclasses.Semialign
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.SemigroupK
@@ -209,6 +215,14 @@ interface ListKHash<A> : Hash<ListKOf<A>>, ListKEq<A> {
   override fun ListKOf<A>.hash(): Int = fix().foldLeft(1) { hash, a ->
     31 * hash + HA().run { a.hash() }
   }
+}
+
+@extension
+interface ListKOrder<A> : Order<ListKOf<A>> {
+  fun OA(): Order<A>
+  override fun ListKOf<A>.compare(b: ListKOf<A>): Ordering =
+    ListK.alignWith(fix(), b.fix()) { ior -> ior.fold({ GT }, { LT }, { a1, a2 -> OA().run { a1.compare(a2) } }) }
+      .fold(Ordering.monoid())
 }
 
 @extension

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist.kt
@@ -11,6 +11,7 @@ import arrow.core.NonEmptyList
 import arrow.core.NonEmptyListOf
 import arrow.core.Tuple2
 import arrow.core.extensions.listk.eq.eq
+import arrow.core.extensions.listk.order.order
 import arrow.core.extensions.nonemptylist.monad.monad
 import arrow.core.fix
 import arrow.core.k
@@ -29,6 +30,8 @@ import arrow.typeclasses.Functor
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monad
 import arrow.typeclasses.MonadSyntax
+import arrow.typeclasses.Order
+import arrow.typeclasses.Ordering
 import arrow.typeclasses.Reducible
 import arrow.typeclasses.Semialign
 import arrow.typeclasses.Semigroup
@@ -187,6 +190,13 @@ interface NonEmptyListHash<A> : Hash<NonEmptyList<A>>, NonEmptyListEq<A> {
   override fun NonEmptyList<A>.hash(): Int = foldLeft(1) { hash, a ->
     31 * hash + HA().run { a.hash() }
   }
+}
+
+@extension
+interface NonEmptyListOrder<A> : Order<NonEmptyList<A>> {
+  fun OA(): Order<A>
+  override fun NonEmptyList<A>.compare(b: NonEmptyList<A>): Ordering =
+    ListK.order(OA()).run { all.k().compare(b.all.k()) }
 }
 
 fun <F, A> Reducible<F>.toNonEmptyList(fa: Kind<F, A>): NonEmptyList<A> =

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist.kt
@@ -9,6 +9,7 @@ import arrow.core.ListK
 import arrow.core.Nel
 import arrow.core.NonEmptyList
 import arrow.core.NonEmptyListOf
+import arrow.core.Ordering
 import arrow.core.Tuple2
 import arrow.core.extensions.listk.eq.eq
 import arrow.core.extensions.listk.order.order
@@ -31,7 +32,6 @@ import arrow.typeclasses.Hash
 import arrow.typeclasses.Monad
 import arrow.typeclasses.MonadSyntax
 import arrow.typeclasses.Order
-import arrow.typeclasses.Ordering
 import arrow.typeclasses.Reducible
 import arrow.typeclasses.Semialign
 import arrow.typeclasses.Semigroup

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/number.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/number.kt
@@ -1,10 +1,10 @@
 package arrow.core.extensions
 
+import arrow.core.Ordering
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
-import arrow.typeclasses.Ordering
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Semiring
 import arrow.typeclasses.Show

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/number.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/number.kt
@@ -4,6 +4,7 @@ import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
+import arrow.typeclasses.Ordering
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Semiring
 import arrow.typeclasses.Show
@@ -28,7 +29,8 @@ interface ByteSemiring : Semiring<Byte> {
 }
 
 interface ByteOrder : Order<Byte> {
-  override fun Byte.compare(b: Byte): Int = compareTo(b)
+  override fun Byte.compare(b: Byte): Ordering = Ordering.fromInt(this.compareTo(b))
+  override fun Byte.compareTo(b: Byte): Int = this.compareTo(b)
 }
 
 interface ByteEq : Eq<Byte> {
@@ -85,7 +87,8 @@ interface DoubleSemiring : Semiring<Double> {
 }
 
 interface DoubleOrder : Order<Double> {
-  override fun Double.compare(b: Double): Int = compareTo(b)
+  override fun Double.compare(b: Double): Ordering = Ordering.fromInt(this.compareTo(b))
+  override fun Double.compareTo(b: Double): Int = this.compareTo(b)
 }
 
 interface DoubleEq : Eq<Double> {
@@ -149,7 +152,8 @@ interface IntShow : Show<Int> {
 }
 
 interface IntOrder : Order<Int> {
-  override fun Int.compare(b: Int): Int = compareTo(b)
+  override fun Int.compare(b: Int): Ordering = Ordering.fromInt(this.compareTo(b))
+  override fun Int.compareTo(b: Int): Int = this.compareTo(b)
 }
 
 interface IntHash : Hash<Int>, IntEq {
@@ -198,7 +202,8 @@ interface LongSemiring : Semiring<Long> {
 }
 
 interface LongOrder : Order<Long> {
-  override fun Long.compare(b: Long): Int = compareTo(b)
+  override fun Long.compare(b: Long): Ordering = Ordering.fromInt(this.compareTo(b))
+  override fun Long.compareTo(b: Long): Int = this.compareTo(b)
 }
 
 interface LongEq : Eq<Long> {
@@ -255,7 +260,8 @@ interface ShortSemiring : Semiring<Short> {
 }
 
 interface ShortOrder : Order<Short> {
-  override fun Short.compare(b: Short): Int = compareTo(b)
+  override fun Short.compare(b: Short): Ordering = Ordering.fromInt(this.compareTo(b))
+  override fun Short.compareTo(b: Short): Int = this.compareTo(b)
 }
 
 interface ShortEq : Eq<Short> {
@@ -312,7 +318,8 @@ interface FloatSemiring : Semiring<Float> {
 }
 
 interface FloatOrder : Order<Float> {
-  override fun Float.compare(b: Float): Int = compareTo(b)
+  override fun Float.compare(b: Float): Ordering = Ordering.fromInt(this.compareTo(b))
+  override fun Float.compareTo(b: Float): Int = this.compareTo(b)
 }
 
 interface FloatEq : Eq<Float> {

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/option.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/option.kt
@@ -29,12 +29,15 @@ import arrow.typeclasses.Applicative
 import arrow.typeclasses.ApplicativeError
 import arrow.typeclasses.Apply
 import arrow.typeclasses.Crosswalk
+import arrow.typeclasses.EQ
 import arrow.typeclasses.Eq
 import arrow.typeclasses.EqK
 import arrow.typeclasses.Foldable
 import arrow.typeclasses.Functor
 import arrow.typeclasses.FunctorFilter
+import arrow.typeclasses.GT
 import arrow.typeclasses.Hash
+import arrow.typeclasses.LT
 import arrow.typeclasses.Monad
 import arrow.typeclasses.MonadCombine
 import arrow.typeclasses.MonadError
@@ -45,6 +48,8 @@ import arrow.typeclasses.MonadSyntax
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.MonoidK
 import arrow.typeclasses.Monoidal
+import arrow.typeclasses.Order
+import arrow.typeclasses.Ordering
 import arrow.typeclasses.Repeat
 import arrow.typeclasses.Selective
 import arrow.typeclasses.Semialign
@@ -285,6 +290,16 @@ interface OptionHash<A> : Hash<Option<A>>, OptionEq<A> {
     None.hashCode()
   }, {
     HA().run { it.hash() }
+  })
+}
+
+@extension
+interface OptionOrder<A> : Order<Option<A>> {
+  fun OA(): Order<A>
+  override fun Option<A>.compare(b: Option<A>): Ordering = fold({
+    b.fold({ EQ }, { LT })
+  }, { a1 ->
+    b.fold({ GT }, { a2 -> OA().run { a1.compare(a2) } })
   })
 }
 

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/option.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/option.kt
@@ -3,13 +3,17 @@
 package arrow.core.extensions
 
 import arrow.Kind
+import arrow.core.EQ
 import arrow.core.Either
 import arrow.core.Eval
 import arrow.core.ForOption
+import arrow.core.GT
 import arrow.core.Ior
+import arrow.core.LT
 import arrow.core.None
 import arrow.core.Option
 import arrow.core.OptionOf
+import arrow.core.Ordering
 import arrow.core.SequenceK
 import arrow.core.Some
 import arrow.core.Tuple2
@@ -29,15 +33,12 @@ import arrow.typeclasses.Applicative
 import arrow.typeclasses.ApplicativeError
 import arrow.typeclasses.Apply
 import arrow.typeclasses.Crosswalk
-import arrow.typeclasses.EQ
 import arrow.typeclasses.Eq
 import arrow.typeclasses.EqK
 import arrow.typeclasses.Foldable
 import arrow.typeclasses.Functor
 import arrow.typeclasses.FunctorFilter
-import arrow.typeclasses.GT
 import arrow.typeclasses.Hash
-import arrow.typeclasses.LT
 import arrow.typeclasses.Monad
 import arrow.typeclasses.MonadCombine
 import arrow.typeclasses.MonadError
@@ -49,7 +50,6 @@ import arrow.typeclasses.Monoid
 import arrow.typeclasses.MonoidK
 import arrow.typeclasses.Monoidal
 import arrow.typeclasses.Order
-import arrow.typeclasses.Ordering
 import arrow.typeclasses.Repeat
 import arrow.typeclasses.Selective
 import arrow.typeclasses.Semialign

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ordering.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ordering.kt
@@ -1,12 +1,12 @@
 package arrow.core.extensions
 
+import arrow.core.EQ
+import arrow.core.Ordering
 import arrow.extension
-import arrow.typeclasses.EQ
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
-import arrow.typeclasses.Ordering
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
 

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ordering.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ordering.kt
@@ -3,9 +3,7 @@ package arrow.core.extensions
 import arrow.extension
 import arrow.typeclasses.EQ
 import arrow.typeclasses.Eq
-import arrow.typeclasses.GT
 import arrow.typeclasses.Hash
-import arrow.typeclasses.LT
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
 import arrow.typeclasses.Ordering

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ordering.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ordering.kt
@@ -1,0 +1,43 @@
+package arrow.core.extensions
+
+import arrow.extension
+import arrow.typeclasses.EQ
+import arrow.typeclasses.Eq
+import arrow.typeclasses.GT
+import arrow.typeclasses.Hash
+import arrow.typeclasses.LT
+import arrow.typeclasses.Monoid
+import arrow.typeclasses.Order
+import arrow.typeclasses.Ordering
+import arrow.typeclasses.Semigroup
+import arrow.typeclasses.Show
+
+@extension
+interface OrderingEq : Eq<Ordering> {
+  override fun Ordering.eqv(b: Ordering): Boolean = this === b
+}
+
+@extension
+interface OrderingShow : Show<Ordering> {
+  override fun Ordering.show(): String = toString()
+}
+
+@extension
+interface OrderingHash : Hash<Ordering>, OrderingEq {
+  override fun Ordering.hash(): Int = hashCode()
+}
+
+@extension
+interface OrderingOrder : Order<Ordering> {
+  override fun Ordering.compare(b: Ordering): Ordering = Ordering.fromInt(toInt().compareTo(b.toInt()))
+}
+
+@extension
+interface OrderingSemigroup : Semigroup<Ordering> {
+  override fun Ordering.combine(b: Ordering): Ordering = this + b
+}
+
+@extension
+interface OrderingMonoid : Monoid<Ordering>, OrderingSemigroup {
+  override fun empty(): Ordering = EQ
+}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequenceK.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequenceK.kt
@@ -1,13 +1,17 @@
 package arrow.core.extensions
 
 import arrow.Kind
+import arrow.core.EQ
 import arrow.core.Either
 import arrow.core.Eval
 import arrow.core.ForSequenceK
+import arrow.core.GT
 import arrow.core.Ior
+import arrow.core.LT
 import arrow.core.ListK
 import arrow.core.None
 import arrow.core.Option
+import arrow.core.Ordering
 import arrow.core.SequenceK
 import arrow.core.SequenceKOf
 import arrow.core.Tuple2
@@ -33,15 +37,12 @@ import arrow.typeclasses.Alternative
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Apply
 import arrow.typeclasses.Crosswalk
-import arrow.typeclasses.EQ
 import arrow.typeclasses.Eq
 import arrow.typeclasses.EqK
 import arrow.typeclasses.Foldable
 import arrow.typeclasses.Functor
 import arrow.typeclasses.FunctorFilter
-import arrow.typeclasses.GT
 import arrow.typeclasses.Hash
-import arrow.typeclasses.LT
 import arrow.typeclasses.Monad
 import arrow.typeclasses.MonadCombine
 import arrow.typeclasses.MonadFilter
@@ -52,7 +53,6 @@ import arrow.typeclasses.Monoid
 import arrow.typeclasses.MonoidK
 import arrow.typeclasses.Monoidal
 import arrow.typeclasses.Order
-import arrow.typeclasses.Ordering
 import arrow.typeclasses.Repeat
 import arrow.typeclasses.Semialign
 import arrow.typeclasses.Semigroup

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/string.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/string.kt
@@ -4,6 +4,7 @@ import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
+import arrow.typeclasses.Ordering
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
 
@@ -41,7 +42,8 @@ fun String.Companion.show(): Show<String> =
   object : StringShow {}
 
 interface StringOrder : Order<String> {
-  override fun String.compare(b: String): Int = this.compareTo(b)
+  override fun String.compare(b: String): Ordering = Ordering.fromInt(this.compareTo(b))
+  override fun String.compareTo(b: String): Int = this.compareTo(b)
 }
 
 fun String.Companion.order(): Order<String> =

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/string.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/string.kt
@@ -1,10 +1,10 @@
 package arrow.core.extensions
 
+import arrow.core.Ordering
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
-import arrow.typeclasses.Ordering
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
 
@@ -42,7 +42,9 @@ fun String.Companion.show(): Show<String> =
   object : StringShow {}
 
 interface StringOrder : Order<String> {
-  override fun String.compare(b: String): Ordering = Ordering.fromInt(this.compareTo(b))
+  override fun String.compare(b: String): Ordering =
+    Ordering.fromInt(this.compareTo(b))
+
   override fun String.compareTo(b: String): Int = this.compareTo(b)
 }
 

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/tuple.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/tuple.kt
@@ -19,6 +19,8 @@ import arrow.core.Tuple6
 import arrow.core.Tuple7
 import arrow.core.Tuple8
 import arrow.core.Tuple9
+import arrow.core.extensions.list.foldable.fold
+import arrow.core.extensions.ordering.monoid.monoid
 import arrow.core.fix
 import arrow.core.identity
 import arrow.core.toT
@@ -35,6 +37,8 @@ import arrow.typeclasses.Functor
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monad
 import arrow.typeclasses.Monoid
+import arrow.typeclasses.Order
+import arrow.typeclasses.Ordering
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
 import arrow.typeclasses.Traverse
@@ -214,6 +218,17 @@ interface Tuple2Hash<A, B> : Hash<Tuple2<A, B>>, Tuple2Eq<A, B> {
 }
 
 @extension
+interface Tuple2Order<A, B> : Order<Tuple2<A, B>> {
+  fun OA(): Order<A>
+  fun OB(): Order<B>
+
+  override fun Tuple2<A, B>.compare(other: Tuple2<A, B>): Ordering = listOf(
+    OA().run { a.compare(other.a) },
+    OB().run { b.compare(other.b) }
+  ).fold(Ordering.monoid())
+}
+
+@extension
 interface Tuple3Eq<A, B, C> : Eq<Tuple3<A, B, C>> {
 
   fun EQA(): Eq<A>
@@ -255,6 +270,19 @@ interface Tuple3Hash<A, B, C> : Hash<Tuple3<A, B, C>>, Tuple3Eq<A, B, C> {
 }
 
 @extension
+interface Tuple3Order<A, B, C> : Order<Tuple3<A, B, C>> {
+  fun OA(): Order<A>
+  fun OB(): Order<B>
+  fun OC(): Order<C>
+
+  override fun Tuple3<A, B, C>.compare(other: Tuple3<A, B, C>): Ordering = listOf(
+    OA().run { a.compare(other.a) },
+    OB().run { b.compare(other.b) },
+    OC().run { c.compare(other.c) }
+  ).fold(Ordering.monoid())
+}
+
+@extension
 interface Tuple4Eq<A, B, C, D> : Eq<Tuple4<A, B, C, D>> {
 
   fun EQA(): Eq<A>
@@ -290,6 +318,21 @@ interface Tuple4Hash<A, B, C, D> : Hash<Tuple4<A, B, C, D>>, Tuple4Eq<A, B, C, D
     HC().run { c.hash() },
     HD().run { d.hash() }
   ).fold(1) { hash, v -> 31 * hash + v }
+}
+
+@extension
+interface Tuple4Order<A, B, C, D> : Order<Tuple4<A, B, C, D>> {
+  fun OA(): Order<A>
+  fun OB(): Order<B>
+  fun OC(): Order<C>
+  fun OD(): Order<D>
+
+  override fun Tuple4<A, B, C, D>.compare(other: Tuple4<A, B, C, D>): Ordering = listOf(
+    OA().run { a.compare(other.a) },
+    OB().run { b.compare(other.b) },
+    OC().run { c.compare(other.c) },
+    OD().run { d.compare(other.d) }
+  ).fold(Ordering.monoid())
 }
 
 @extension
@@ -344,6 +387,23 @@ interface Tuple5Hash<A, B, C, D, E> : Hash<Tuple5<A, B, C, D, E>>, Tuple5Eq<A, B
     HD().run { d.hash() },
     HE().run { e.hash() }
   ).fold(1) { hash, v -> 31 * hash + v }
+}
+
+@extension
+interface Tuple5Order<A, B, C, D, E> : Order<Tuple5<A, B, C, D, E>> {
+  fun OA(): Order<A>
+  fun OB(): Order<B>
+  fun OC(): Order<C>
+  fun OD(): Order<D>
+  fun OE(): Order<E>
+
+  override fun Tuple5<A, B, C, D, E>.compare(other: Tuple5<A, B, C, D, E>): Ordering = listOf(
+    OA().run { a.compare(other.a) },
+    OB().run { b.compare(other.b) },
+    OC().run { c.compare(other.c) },
+    OD().run { d.compare(other.d) },
+    OE().run { e.compare(other.e) }
+  ).fold(Ordering.monoid())
 }
 
 @extension
@@ -405,6 +465,25 @@ interface Tuple6Hash<A, B, C, D, E, F> : Hash<Tuple6<A, B, C, D, E, F>>, Tuple6E
     HE().run { e.hash() },
     HF().run { f.hash() }
   ).fold(1) { hash, v -> 31 * hash + v }
+}
+
+@extension
+interface Tuple6Order<A, B, C, D, E, F> : Order<Tuple6<A, B, C, D, E, F>> {
+  fun OA(): Order<A>
+  fun OB(): Order<B>
+  fun OC(): Order<C>
+  fun OD(): Order<D>
+  fun OE(): Order<E>
+  fun OF(): Order<F>
+
+  override fun Tuple6<A, B, C, D, E, F>.compare(other: Tuple6<A, B, C, D, E, F>): Ordering = listOf(
+    OA().run { a.compare(other.a) },
+    OB().run { b.compare(other.b) },
+    OC().run { c.compare(other.c) },
+    OD().run { d.compare(other.d) },
+    OE().run { e.compare(other.e) },
+    OF().run { f.compare(other.f) }
+  ).fold(Ordering.monoid())
 }
 
 @extension
@@ -473,6 +552,27 @@ interface Tuple7Hash<A, B, C, D, E, F, G> : Hash<Tuple7<A, B, C, D, E, F, G>>, T
     HF().run { f.hash() },
     HG().run { g.hash() }
   ).fold(1) { hash, v -> 31 * hash + v }
+}
+
+@extension
+interface Tuple7Order<A, B, C, D, E, F, G> : Order<Tuple7<A, B, C, D, E, F, G>> {
+  fun OA(): Order<A>
+  fun OB(): Order<B>
+  fun OC(): Order<C>
+  fun OD(): Order<D>
+  fun OE(): Order<E>
+  fun OF(): Order<F>
+  fun OG(): Order<G>
+
+  override fun Tuple7<A, B, C, D, E, F, G>.compare(other: Tuple7<A, B, C, D, E, F, G>): Ordering = listOf(
+    OA().run { a.compare(other.a) },
+    OB().run { b.compare(other.b) },
+    OC().run { c.compare(other.c) },
+    OD().run { d.compare(other.d) },
+    OE().run { e.compare(other.e) },
+    OF().run { f.compare(other.f) },
+    OG().run { g.compare(other.g) }
+  ).fold(Ordering.monoid())
 }
 
 @extension
@@ -548,6 +648,29 @@ interface Tuple8Hash<A, B, C, D, E, F, G, H> : Hash<Tuple8<A, B, C, D, E, F, G, 
     HG().run { g.hash() },
     HH().run { h.hash() }
   ).fold(1) { hash, v -> 31 * hash + v }
+}
+
+@extension
+interface Tuple8Order<A, B, C, D, E, F, G, H> : Order<Tuple8<A, B, C, D, E, F, G, H>> {
+  fun OA(): Order<A>
+  fun OB(): Order<B>
+  fun OC(): Order<C>
+  fun OD(): Order<D>
+  fun OE(): Order<E>
+  fun OF(): Order<F>
+  fun OG(): Order<G>
+  fun OH(): Order<H>
+
+  override fun Tuple8<A, B, C, D, E, F, G, H>.compare(other: Tuple8<A, B, C, D, E, F, G, H>): Ordering = listOf(
+    OA().run { a.compare(other.a) },
+    OB().run { b.compare(other.b) },
+    OC().run { c.compare(other.c) },
+    OD().run { d.compare(other.d) },
+    OE().run { e.compare(other.e) },
+    OF().run { f.compare(other.f) },
+    OG().run { g.compare(other.g) },
+    OH().run { h.compare(other.h) }
+  ).fold(Ordering.monoid())
 }
 
 @extension
@@ -630,6 +753,31 @@ interface Tuple9Hash<A, B, C, D, E, F, G, H, I> : Hash<Tuple9<A, B, C, D, E, F, 
     HH().run { h.hash() },
     HI().run { i.hash() }
   ).fold(1) { hash, v -> 31 * hash + v }
+}
+
+@extension
+interface Tuple9Order<A, B, C, D, E, F, G, H, I> : Order<Tuple9<A, B, C, D, E, F, G, H, I>> {
+  fun OA(): Order<A>
+  fun OB(): Order<B>
+  fun OC(): Order<C>
+  fun OD(): Order<D>
+  fun OE(): Order<E>
+  fun OF(): Order<F>
+  fun OG(): Order<G>
+  fun OH(): Order<H>
+  fun OI(): Order<I>
+
+  override fun Tuple9<A, B, C, D, E, F, G, H, I>.compare(other: Tuple9<A, B, C, D, E, F, G, H, I>): Ordering = listOf(
+    OA().run { a.compare(other.a) },
+    OB().run { b.compare(other.b) },
+    OC().run { c.compare(other.c) },
+    OD().run { d.compare(other.d) },
+    OE().run { e.compare(other.e) },
+    OF().run { f.compare(other.f) },
+    OG().run { g.compare(other.g) },
+    OH().run { h.compare(other.h) },
+    OI().run { i.compare(other.i) }
+  ).fold(Ordering.monoid())
 }
 
 @extension
@@ -719,6 +867,33 @@ interface Tuple10Hash<A, B, C, D, E, F, G, H, I, J> : Hash<Tuple10<A, B, C, D, E
     HI().run { i.hash() },
     HJ().run { j.hash() }
   ).fold(1) { hash, v -> 31 * hash + v }
+}
+
+@extension
+interface Tuple10Order<A, B, C, D, E, F, G, H, I, J> : Order<Tuple10<A, B, C, D, E, F, G, H, I, J>> {
+  fun OA(): Order<A>
+  fun OB(): Order<B>
+  fun OC(): Order<C>
+  fun OD(): Order<D>
+  fun OE(): Order<E>
+  fun OF(): Order<F>
+  fun OG(): Order<G>
+  fun OH(): Order<H>
+  fun OI(): Order<I>
+  fun OJ(): Order<J>
+
+  override fun Tuple10<A, B, C, D, E, F, G, H, I, J>.compare(other: Tuple10<A, B, C, D, E, F, G, H, I, J>): Ordering = listOf(
+    OA().run { a.compare(other.a) },
+    OB().run { b.compare(other.b) },
+    OC().run { c.compare(other.c) },
+    OD().run { d.compare(other.d) },
+    OE().run { e.compare(other.e) },
+    OF().run { f.compare(other.f) },
+    OG().run { g.compare(other.g) },
+    OH().run { h.compare(other.h) },
+    OI().run { i.compare(other.i) },
+    OJ().run { j.compare(other.j) }
+  ).fold(Ordering.monoid())
 }
 
 @extension

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/tuple.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/tuple.kt
@@ -8,6 +8,7 @@ import arrow.core.Either.Left
 import arrow.core.Either.Right
 import arrow.core.Eval
 import arrow.core.ForTuple2
+import arrow.core.Ordering
 import arrow.core.Tuple10
 import arrow.core.Tuple2
 import arrow.core.Tuple2Of
@@ -38,7 +39,6 @@ import arrow.typeclasses.Hash
 import arrow.typeclasses.Monad
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
-import arrow.typeclasses.Ordering
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
 import arrow.typeclasses.Traverse

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated.kt
@@ -28,7 +28,11 @@ import arrow.typeclasses.EqK
 import arrow.typeclasses.EqK2
 import arrow.typeclasses.Foldable
 import arrow.typeclasses.Functor
+import arrow.typeclasses.GT
 import arrow.typeclasses.Hash
+import arrow.typeclasses.LT
+import arrow.typeclasses.Order
+import arrow.typeclasses.Ordering
 import arrow.typeclasses.Selective
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.SemigroupK
@@ -186,6 +190,17 @@ interface ValidatedHash<L, R> : Hash<Validated<L, R>>, ValidatedEq<L, R> {
     HL().run { it.hash() }
   }, {
     HR().run { it.hash() }
+  })
+}
+
+@extension
+interface ValidatedOrder<L, R> : Order<Validated<L, R>> {
+  fun OL(): Order<L>
+  fun OR(): Order<R>
+  override fun Validated<L, R>.compare(b: Validated<L, R>): Ordering = fold({ l1 ->
+    b.fold({ l2 -> OL().run { l1.compare(l2) } }, { LT })
+  }, { r1 ->
+    b.fold({ GT }, { r2 -> OR().run { r1.compare(r2) } })
   })
 }
 

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated.kt
@@ -5,8 +5,11 @@ import arrow.Kind2
 import arrow.core.Either
 import arrow.core.Eval
 import arrow.core.ForValidated
+import arrow.core.GT
 import arrow.core.Invalid
+import arrow.core.LT
 import arrow.core.NonEmptyList
+import arrow.core.Ordering
 import arrow.core.Valid
 import arrow.core.Validated
 import arrow.core.ValidatedOf
@@ -28,11 +31,8 @@ import arrow.typeclasses.EqK
 import arrow.typeclasses.EqK2
 import arrow.typeclasses.Foldable
 import arrow.typeclasses.Functor
-import arrow.typeclasses.GT
 import arrow.typeclasses.Hash
-import arrow.typeclasses.LT
 import arrow.typeclasses.Order
-import arrow.typeclasses.Ordering
 import arrow.typeclasses.Selective
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.SemigroupK

--- a/arrow-docs/docs/arrow/typeclasses/order/README.md
+++ b/arrow-docs/docs/arrow/typeclasses/order/README.md
@@ -6,9 +6,6 @@ permalink: /arrow/typeclasses/order/
 
 ## Order
 
-
-
-
 The `Order` typeclass abstracts the ability to compare two instances of any object and determine their total order.
 Depending on your needs, this comparison can be structural (the content of the object), referential (the memory address of the object), based on an identity (like an Id field), or any combination of these.
 
@@ -18,12 +15,7 @@ It can be considered the typeclass equivalent of Java's `Comparable`.
 
 #### F#compare
 
-`fun F.compare(b: F): Int`
-
-Compare [a] with [b]. Returns an Int whose sign is:
-  * negative if `x < y`
-  * zero     if `x = y`
-  * positive if `x > y`
+`fun F.compare(b: F): Ordering`
 
 ```kotlin:ank
 import arrow.*
@@ -93,11 +85,11 @@ Arrow provides `OrderLaws` in the form of test cases for internal verification o
 
 #### Creating your own `Order` instances
 
-Order has a constructor to create an `Order` instance from a compare function `(F, F) -> Int`.
+Order has a constructor to create an `Order` instance from a compare function `(F, F) -> Ordering`.
 
 ```kotlin:ank
 
-Order { a: Int, b: Int -> b - a }.run {
+Order { a: Int, b: Int -> Ordering.fromInt(b - a) }.run {
   1.lt(2)
 }
 ```

--- a/arrow-docs/docs/arrow/typeclasses/order/README.md
+++ b/arrow-docs/docs/arrow/typeclasses/order/README.md
@@ -88,7 +88,7 @@ Arrow provides `OrderLaws` in the form of test cases for internal verification o
 Order has a constructor to create an `Order` instance from a compare function `(F, F) -> Ordering`.
 
 ```kotlin:ank
-
+import arrow.core.Ordering
 Order { a: Int, b: Int -> Ordering.fromInt(b - a) }.run {
   1.lt(2)
 }


### PR DESCRIPTION
Two changes worth noting:
- Orders main combinator now returns `Ordering`. This has a few advantages: It is much easier to reason about than integers and second it offers a monoid instance so we can combine the result of `compare` to obtain a new `Ordering`. This allows nice and easy definitions for types with multiple values.
- Added laws and tests for the `Order` typeclass. It was previously lawless.