### PR TITLE
Updating `MapK` to have `Option` alternatives

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/MapK.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/MapK.kt
@@ -97,7 +97,6 @@ fun <K, A> Pair<K, A>?.asIterable(): Iterable<Pair<K, A>> =
     else -> listOf(this)
   }
 
-
 fun <K, A, B> Map<K, A>.foldRight(b: Map<K, B>, f: (Map.Entry<K, A>, Map<K, B>) -> Map<K, B>): Map<K, B> =
   this.entries.reversed().k().foldLeft(b) { x, y: Map.Entry<K, A> -> f(y, x) }
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/MapK.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/MapK.kt
@@ -65,15 +65,12 @@ data class MapK<K, out A>(private val map: Map<K, A>) : MapKOf<K, A>, Map<K, A> 
 
 fun <K, A> Map<K, A>.k(): MapK<K, A> = MapK(this)
 
-@Deprecated("Deprecated, use nullable instead", ReplaceWith("Tuple2<k, A>?.k()"))
+@Deprecated("Deprecated, use nullable instead", ReplaceWith("Tuple2<K, A>>?.let { ... }"))
 fun <K, A> Option<Tuple2<K, A>>.k(): MapK<K, A> =
   when (this) {
     is Some -> mapOf(this.t).k()
     is None -> emptyMap<K, A>().k()
   }
-
-fun <K, A> Tuple2<K, A>?.k(): MapK<K, A> =
-  this?.let { mapOf(this).k() } ?: emptyMap<K, A>().k()
 
 fun <K, V, G> MapKOf<K, Kind<G, V>>.sequence(GA: Applicative<G>): Kind<G, MapK<K, V>> =
   fix().traverse(GA, ::identity)
@@ -91,7 +88,7 @@ fun <K, A, B> Map<K, A>.foldLeft(b: Map<K, B>, f: (Map<K, B>, Map.Entry<K, A>) -
   return result
 }
 
-fun <K, A> Pair<K, A>?.asIterable(): Iterable<Pair<K, A>> =
+internal fun <K, A> Pair<K, A>?.asIterable(): Iterable<Pair<K, A>> =
   when (this) {
     null -> emptyList()
     else -> listOf(this)

--- a/arrow-core-data/src/main/kotlin/arrow/core/MapK.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/MapK.kt
@@ -65,6 +65,7 @@ data class MapK<K, out A>(private val map: Map<K, A>) : MapKOf<K, A>, Map<K, A> 
 
 fun <K, A> Map<K, A>.k(): MapK<K, A> = MapK(this)
 
+@Deprecated("Deprecated, use nullable instead", ReplaceWith("Tuple2<k, A>?.k()"))
 fun <K, A> Option<Tuple2<K, A>>.k(): MapK<K, A> =
   when (this) {
     is Some -> mapOf(this.t).k()
@@ -79,6 +80,7 @@ fun <K, V, G> MapKOf<K, Kind<G, V>>.sequence(GA: Applicative<G>): Kind<G, MapK<K
 
 fun <K, A> List<Map.Entry<K, A>>.k(): MapK<K, A> = this.map { it.key to it.value }.toMap().k()
 
+@Deprecated("Deprecated, use nullable instead", ReplaceWith("map[k]?.let { ... }"))
 fun <K, A> Map<K, A>.getOption(k: K): Option<A> = Option.fromNullable(this[k])
 
 fun <K, A> MapK<K, A>.updated(k: K, value: A): MapK<K, A> = (this + (k to value)).k()

--- a/arrow-core-data/src/test/kotlin/arrow/core/MapKTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/MapKTest.kt
@@ -7,7 +7,6 @@ import arrow.core.extensions.mapk.align.align
 import arrow.core.extensions.mapk.eq.eq
 import arrow.core.extensions.mapk.eqK.eqK
 import arrow.core.extensions.mapk.foldable.foldable
-import arrow.core.extensions.mapk.functorFilter.filterMap
 import arrow.core.extensions.mapk.functorFilter.functorFilter
 import arrow.core.extensions.mapk.hash.hash
 import arrow.core.extensions.mapk.monoid.monoid
@@ -23,6 +22,8 @@ import arrow.core.test.generators.genK
 import arrow.core.test.generators.intSmall
 import arrow.core.test.generators.longSmall
 import arrow.core.test.generators.mapK
+import arrow.core.test.generators.option
+import arrow.core.test.generators.tuple2
 import arrow.core.test.laws.AlignLaws
 import arrow.core.test.laws.EqLaws
 import arrow.core.test.laws.FoldableLaws
@@ -152,10 +153,6 @@ class MapKTest : UnitSpec() {
           .let { mapOf(*it.toTypedArray()) }
         result == expected
       }
-    }
-
-    "traverse" {
-
     }
   }
 }

--- a/arrow-core-data/src/test/kotlin/arrow/core/MapKTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/MapKTest.kt
@@ -110,5 +110,25 @@ class MapKTest : UnitSpec() {
         }
       }
     }
+
+    "map2" {
+
+    }
+
+    "map2Eval" {
+
+    }
+
+    "ap2" {
+
+    }
+
+    "flatMap" {
+
+    }
+
+    "traverse" {
+
+    }
   }
 }

--- a/arrow-core-data/src/test/kotlin/arrow/core/MapKTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/MapKTest.kt
@@ -22,8 +22,6 @@ import arrow.core.test.generators.genK
 import arrow.core.test.generators.intSmall
 import arrow.core.test.generators.longSmall
 import arrow.core.test.generators.mapK
-import arrow.core.test.generators.option
-import arrow.core.test.generators.tuple2
 import arrow.core.test.laws.AlignLaws
 import arrow.core.test.laws.EqLaws
 import arrow.core.test.laws.FoldableLaws

--- a/arrow-core-data/src/test/kotlin/arrow/core/MapKTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/MapKTest.kt
@@ -142,7 +142,16 @@ class MapKTest : UnitSpec() {
     }
 
     "flatMap" {
-
+      forAll(
+        Gen.mapK(Gen.string(), Gen.intSmall()),
+        Gen.mapK(Gen.string(), Gen.string())
+      ) { a, b ->
+        val result: MapK<String, String> = a.flatMap { b }
+        val expected: MapK<String, String> = a.filter { (k, _) -> b.containsKey(k) }
+          .map { (k, v) -> Tuple2(k, b[k]!!) }
+          .let { mapOf(*it.toTypedArray()) }
+        result == expected
+      }
     }
 
     "traverse" {

--- a/arrow-core-data/src/test/kotlin/arrow/core/MapKTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/MapKTest.kt
@@ -125,12 +125,20 @@ class MapKTest : UnitSpec() {
       }
     }
 
-    "map2Eval" {
-
-    }
-
     "ap2" {
-
+      forAll(
+        Gen.mapK(Gen.intSmall(), Gen.intSmall()),
+        Gen.mapK(Gen.intSmall(), Gen.intSmall())
+      ) { a, b ->
+        val result = a.ap2(
+          a.map { {x: Int, y: Int -> x + y } },
+          b
+        )
+        val expected: MapK<Int, Int> = a.filter { (k, v) -> b.containsKey(k) }
+          .map { (k, v) -> Tuple2(k, v + b[k]!!) }
+          .let { mapOf(*it.toTypedArray()) }
+        result == expected
+      }
     }
 
     "flatMap" {

--- a/arrow-core-data/src/test/kotlin/arrow/core/MapKTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/MapKTest.kt
@@ -7,6 +7,7 @@ import arrow.core.extensions.mapk.align.align
 import arrow.core.extensions.mapk.eq.eq
 import arrow.core.extensions.mapk.eqK.eqK
 import arrow.core.extensions.mapk.foldable.foldable
+import arrow.core.extensions.mapk.functorFilter.filterMap
 import arrow.core.extensions.mapk.functorFilter.functorFilter
 import arrow.core.extensions.mapk.hash.hash
 import arrow.core.extensions.mapk.monoid.monoid
@@ -112,7 +113,16 @@ class MapKTest : UnitSpec() {
     }
 
     "map2" {
-
+      forAll(
+        Gen.mapK(Gen.intSmall(), Gen.intSmall()),
+        Gen.mapK(Gen.intSmall(), Gen.intSmall())
+      ) { a, b ->
+        val result = a.map2(b) { left, right -> left + right }
+        val expected: MapK<Int, Int> = a.filter { (k, v) -> b.containsKey(k) }
+          .map { (k, v) -> Tuple2(k, v + b[k]!!) }
+          .let { mapOf(*it.toTypedArray()) }
+        result == expected
+      }
     }
 
     "map2Eval" {

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/mapk.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/mapk.kt
@@ -42,7 +42,6 @@ import arrow.typeclasses.Traverse
 import arrow.typeclasses.Zip
 import arrow.typeclasses.Unalign
 import arrow.typeclasses.Unzip
-import arrow.typeclasses.hashWithSalt
 import arrow.undocumented
 
 @extension


### PR DESCRIPTION
Update a few functions that use Option to use nullables instead.
Deprecate two functions and provide alternatives.