### PR TITLE
Promote Arrow Fx Coroutines in library page

### DIFF
--- a/arrow-docs/docs/quickstart/libraries/README.md
+++ b/arrow-docs/docs/quickstart/libraries/README.md
@@ -18,7 +18,7 @@ In this doc, we'll describe all the modules that form the core, alongside a list
 * [arrow-core]({{ '/quickstart/libraries/#arrow-core' | relative_url }})
 * [arrow-core-data]({{ '/quickstart/libraries/#arrow-core-data' | relative_url }})
 * [arrow-optics]({{ '/quickstart/libraries/#arrow-optics' | relative_url }})
-* [arrow-fx]({{ '/quickstart/libraries/#arrow-fx' | relative_url }})
+* [arrow-fx-coroutines]({{ '/quickstart/libraries/#arrow-fx-coroutines' | relative_url }})
 * [arrow-syntax]({{ '/quickstart/libraries/#arrow-syntax' | relative_url }})
 * [arrow-fx-rx2 & arrow-fx-reactor]({{ '/quickstart/libraries/#arrow-fx-rx2&arrow-fx-reactor' | relative_url }})
 * [arrow-mtl]({{ '/quickstart/libraries/#arrow-mtl' | relative_url }})
@@ -72,15 +72,16 @@ For all the new typeclasses, it also includes the extensions available for basic
 
 Dependency: `arrow-core`
 
-### arrow-fx
+### arrow-fx-coroutines
 
 ```groovy
 dependencies {
-    implementation "io.arrow-kt:arrow-fx:$arrow_version"
+    implementation "io.arrow-kt:arrow-fx-coroutines:$arrow_version"
 }
 ```
 
-The [fx library]({{ '/fx/' | relative_url }}) offers a powerful concurrency DSL with an emphasis on easy concurrency and parallelism with guarantees about concurrent and parallel resource safety. It can be used with Arrow Fx's IO or a set of typeclasses to abstract over concurrency frameworks like `RxJava`, `Reactor`, `Arrow's IO`, etc.
+The [fx library]({{ '/fx/' | relative_url }}) is a Kotlin idiomatic functional effects stytem that offers a powerful set concurrency combinators and primitives with an emphasis on easy concurrency and parallelism with guarantees about concurrent and parallel resource safety and composition.
+If offers a set of integrations for `KotlinX Coroutines`, `RxJava`, `Reactor`, etc. Check the [Arrow Fx documentation](({{ '/fx/' | relative_url }})) for more details.
 
 Dependency: `arrow-core`
 


### PR DESCRIPTION
Updates the library section to promote Arrow Fx Coroutines according to https://github.com/arrow-kt/arrow-fx/pull/257, and reference the docs to check for its integrations.

I think the size of Arrow Fx warrants it has it's own "libraries" section, that might also be in line with issue https://github.com/arrow-kt/arrow/issues/2207? 