### PR TITLE
Add foldMapA to Foldable (perhaps by adding lift to Monoid in Applicative)?

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Applicative.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Applicative.kt
@@ -26,4 +26,9 @@ interface Applicative<F> : Apply<F> {
   fun <A> Kind<F, A>.replicate(n: Int, MA: Monoid<A>): Kind<F, A> =
     if (n <= 0) just(MA.empty())
     else mapN(this@replicate, replicate(n - 1, MA)) { (a, xs) -> MA.run { a + xs } }
+
+  fun <A> Monoid<A>.lift(): Monoid<Kind<F, A>> = object : Monoid<Kind<F, A>> {
+    override fun empty(): Kind<F, A> = just(this@lift.empty())
+    override fun Kind<F, A>.combine(b: Kind<F, A>): Kind<F, A> = map2(b) { it.a.combine(it.b) }
+  }
 }

--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Applicative.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Applicative.kt
@@ -26,9 +26,9 @@ interface Applicative<F> : Apply<F> {
   fun <A> Kind<F, A>.replicate(n: Int, MA: Monoid<A>): Kind<F, A> =
     if (n <= 0) just(MA.empty())
     else mapN(this@replicate, replicate(n - 1, MA)) { (a, xs) -> MA.run { a + xs } }
+}
 
-  fun <A> Monoid<A>.lift(): Monoid<Kind<F, A>> = object : Monoid<Kind<F, A>> {
-    override fun empty(): Kind<F, A> = just(this@lift.empty())
-    override fun Kind<F, A>.combine(b: Kind<F, A>): Kind<F, A> = map2(b) { it.a.combine(it.b) }
-  }
+fun <F, A> Monoid<A>.lift(ap: Applicative<F>): Monoid<Kind<F, A>> = object : Monoid<Kind<F, A>> {
+  override fun empty(): Kind<F, A> = ap.just(this@lift.empty())
+  override fun Kind<F, A>.combine(b: Kind<F, A>): Kind<F, A> = with(ap) { map2(b) { it.a.combine(it.b) } }
 }

--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Foldable.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Foldable.kt
@@ -184,9 +184,7 @@ interface Foldable<F> {
    * Applicative folding on F by mapping A values to G<B>, combining the B values using the given Monoid<B> instance.
    */
   fun <G, A, B, AP, MO> Kind<F, A>.foldMapA(ap: AP, mo: MO, f: (A) -> Kind<G, B>): Kind<G, B>
-    where AP : Applicative<G>, MO : Monoid<B> = ap.run {
-    foldMap(mo.lift(), f)
-  }
+    where AP : Applicative<G>, MO : Monoid<B> = foldMap(mo.lift(ap), f)
 
   /**
    * Monadic folding on F by mapping A values to G<B>, combining the B values using the given Monoid<B> instance.

--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Foldable.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Foldable.kt
@@ -181,6 +181,14 @@ interface Foldable<F> {
     foldMap(MN) { 1 }
 
   /**
+   * Applicative folding on F by mapping A values to G<B>, combining the B values using the given Monoid<B> instance.
+   */
+  fun <G, A, B, AP, MO> Kind<F, A>.foldMapA(ap: AP, mo: MO, f: (A) -> Kind<G, B>): Kind<G, B>
+    where AP : Applicative<G>, MO : Monoid<B> = ap.run {
+    foldMap(mo.lift(), f)
+  }
+
+  /**
    * Monadic folding on F by mapping A values to G<B>, combining the B values using the given Monoid<B> instance.
    *
    * Similar to foldM, but using a Monoid<B>.

--- a/arrow-core-test/src/main/kotlin/arrow/core/test/laws/FoldableLaws.kt
+++ b/arrow-core-test/src/main/kotlin/arrow/core/test/laws/FoldableLaws.kt
@@ -88,7 +88,8 @@ object FoldableLaws {
       Law("Foldable Laws: isEmpty returns if there are elements or not") { FF.`isEmpty returns if there are elements or not`(GEN, EQBool) },
       Law("Foldable Laws: isNotEmpty consistent with isEmpty") { FF.`isNotEmpty consistent with isEmpty`(GEN, EQBool) },
       Law("Foldable Laws: foldMapM folds on F mapping values to G(B) using given Monoid") { FF.`foldMapM folds on F mapping values to G(B) using given Monoid`(GEN, EQForIdInt) },
-      Law("Foldable Laws: get gets the item at the given index of the Foldable") { FF.`get gets the item at the given index of the Foldable`(GEN, EQOptionInt) }
+      Law("Foldable Laws: get gets the item at the given index of the Foldable") { FF.`get gets the item at the given index of the Foldable`(GEN, EQOptionInt) },
+      Law("Foldable Laws: foldMapA folds on F mapping values to G(B) using given Monoid") { FF.`foldMapA folds on F mapping values to G(B) using given Monoid`(GEN, EQForIdInt) }
     )
   }
 
@@ -326,5 +327,15 @@ object FoldableLaws {
           }
         }.swap().toOption()
       fa.get(idx).equalUnderTheLaw(expected, EQ)
+    }
+
+  fun <F> Foldable<F>.`foldMapA folds on F mapping values to G(B) using given Monoid`(G: Gen<Kind<F, Int>>, EQ: Eq<Kind<ForId, Int>>) =
+    forAll(Gen.functionAToB<Int, Kind<ForId, Int>>(Gen.intSmall().map(::Id)), G) { f: (Int) -> Kind<ForId, Int>, fa: Kind<F, Int> ->
+      Id.monad().run {
+        with(Int.monoid()) {
+          val expected = fa.foldM(this@run, this.empty()) { b, a -> f(a).map { this.run { b.combine(it) } } }
+          fa.foldMapA(this@run, this, f).equalUnderTheLaw(expected, EQ)
+        }
+      }
     }
 }


### PR DESCRIPTION
Hi,

Would it be possible to add a `foldMapA` method to `Foldable`? I'd expect to be able to `foldMap` with a non-monadic applicative.
I've coded up a draft implementation - happy to rework or discard as appropriate (since it's a method on an existing typeclass I couldn't see how to implement it in arrow-incubator - sorry if I've misunderstood, and happy to redo it the right way).
A method for lifting a `Monoid` into an `Applicative` is something I'd also expect to see (and need to use to implement `foldMapA`) - if I've missed an existing implementation then please do point me there.

Thanks,
Mickey