### PR TITLE
Added a resolve function to Either.

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -931,55 +931,26 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
      * The resolve function can resolve any suspended function that yields an Either into one type of value.
      *
      * @param f the function that needs to be resolved.
-     * @param ifSuccess the function to apply if [f] yields a success of type [A].
-     * @param ifDomainError the function to apply if [f] yields a domain error of type [E].
-     * @param ifSystemFailure the function to apply if [f] throws a [Throwable].
-     * @param ifHandlingCaseThrows the function to apply if the [ifSuccess], [ifDomainError] or [ifSystemFailure] function throw a [Throwable].
-     * Throwing any [Throwable] in the [ifHandlingCaseThrows] function will render the [resolve] function nondeterministic.
-     * @param ifUnrecoverableState the function to apply if [resolve] is in an unrecoverable state.
+     * @param success the function to apply if [f] yields a success of type [A].
+     * @param error the function to apply if [f] yields a domain error of type [E].
+     * @param throwable the function to apply if [f] throws a [Throwable].
+     * @param handlingCaseThrows the function to apply if the [success], [error] or [throwable] function throw a [Throwable].
+     * Throwing any [Throwable] in the [handlingCaseThrows] function will render the [resolve] function nondeterministic.
+     * @param unrecoverableState the function to apply if [resolve] is in an unrecoverable state.
      * @return the result of applying the [resolve] function.
      */
     suspend fun <E, A, B> resolve(
       f: suspend () -> Either<E, A>,
-      ifSuccess: suspend (a: A) -> Either<Throwable, B>,
-      ifDomainError: suspend (e: E) -> Either<Throwable, B>,
-      ifSystemFailure: suspend (throwable: Throwable) -> Either<Throwable, B>,
-      ifHandlingCaseThrows: suspend (throwable: Throwable) -> Either<Throwable, B> = ifSystemFailure,
-      ifUnrecoverableState: suspend (throwable: Throwable) -> Either<Throwable, Unit> = { Unit.right() }
+      success: suspend (a: A) -> Either<Throwable, B>,
+      error: suspend (e: E) -> Either<Throwable, B>,
+      throwable: suspend (throwable: Throwable) -> Either<Throwable, B>,
+      handlingCaseThrows: suspend (throwable: Throwable) -> Either<Throwable, B> = throwable,
+      unrecoverableState: suspend (throwable: Throwable) -> Either<Throwable, Unit> = { Unit.right() }
     ): B =
       catch { f() }
-        .fold(
-          { throwable: Throwable ->
-            handleItSafely { ifSystemFailure(throwable) }
-          },
-          {
-            it.fold(
-              { e: E ->
-                handleItSafely { ifDomainError(e) }
-              },
-              { a: A ->
-                handleItSafely { ifSuccess(a) }
-              }
-            )
-          }
-        )
-        .fold(
-          { throwable: Throwable ->
-            ifHandlingCaseThrows(throwable)
-          },
-          { b: B ->
-            b.right()
-          }
-        )
-        .fold(
-          { throwable: Throwable ->
-            ifUnrecoverableState(throwable)
-            throw throwable
-          },
-          { b: B ->
-            b
-          }
-        )
+        .fold({ t: Throwable -> handleItSafely { throwable(t) } }, { it.fold({ e: E -> handleItSafely { error(e) } }, { a: A -> handleItSafely { success(a) } }) })
+        .fold({ t: Throwable -> handlingCaseThrows(t) }, { b: B -> b.right() })
+        .fold({ t: Throwable -> unrecoverableState(t); throw t }, { b: B -> b })
   }
 }
 
@@ -1179,13 +1150,5 @@ inline fun <A, B> EitherOf<A, B>.handleErrorWith(f: (A) -> EitherOf<A, B>): Eith
     }
   }
 
-internal suspend fun <A> handleItSafely(f: suspend () -> Either<Throwable, A>): Either<Throwable, A> =
-  Either.catch { f() }
-    .fold(
-      {
-        it.left()
-      },
-      {
-        it
-      }
-    )
+private suspend fun <A> handleItSafely(f: suspend () -> Either<Throwable, A>): Either<Throwable, A> =
+  Either.catch { f() }.fold({ it.left() }, { it })

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -338,10 +338,11 @@ import arrow.typeclasses.Show
  * }
  * ```
  *
- * ## Resolve
+ * ## Resolve Either into one type of value
  * In some cases you can not use Either as a value. For instance, when you need to respond to an HTTP request. To resolve Either into one type of value, you can use the resolve function.
- * In the case of an HTTP endpoint you most often need to return some (framework specific) response object which holds the result of the request. The result can be expected and positive, this is the happy or success flow.
- * Or the result can be expected but negative, this is the unhappy or error flow. Or the result can be unexpected and negative, in this case an unhandled exception was thrown.
+ * In the case of an HTTP endpoint you most often need to return some (framework specific) response object which holds the result of the request. The result can be expected and positive, this is the success flow.
+ * Or the result can be expected but negative, this is the error flow. Or the result can be unexpected and negative, in this case an unhandled exception was thrown.
+ * In all three cases, you want to use the same kind of response object. But probably you want to respond slightly different in each case. This can be achieved by providing specific functions for the success, error and throwable cases.
  *
  * Example:
  *
@@ -360,7 +361,7 @@ import arrow.typeclasses.Show
  *     },
  *     success = { a -> handleSuccess({ a: Any -> log(Level.INFO, "This is a: $a") }, a) },
  *     error = { e -> handleError({ e: Any -> log(Level.WARN, "This is e: $e") }, e) },
- *     throwable = { throwable -> handleSystemFailure({ throwable: Throwable -> log(Level.ERROR, "Log the throwable: $throwable.") }, throwable) }
+ *     throwable = { throwable -> handleThrowable({ throwable: Throwable -> log(Level.ERROR, "Log the throwable: $throwable.") }, throwable) }
  *   )
  * //sampleEnd
  * suspend fun main() {
@@ -380,7 +381,7 @@ import arrow.typeclasses.Show
  * suspend fun <E> handleError(log: suspend (e: E) -> Either<Throwable, Unit>, e: E): Either<Throwable, Response> =
  *   createErrorResponse(HttpStatus.NOT_FOUND, ErrorResponse("$ERROR_MESSAGE_PREFIX $e"))
  *
- * suspend fun handleSystemFailure(log: suspend (throwable: Throwable) -> Either<Throwable, Unit>, throwable: Throwable): Either<Throwable, Response> =
+ * suspend fun handleThrowable(log: suspend (throwable: Throwable) -> Either<Throwable, Unit>, throwable: Throwable): Either<Throwable, Response> =
  *   log(throwable)
  *     .flatMap { createErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, ErrorResponse("$THROWABLE_MESSAGE_PREFIX $throwable")) }
  *

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -361,7 +361,8 @@ import arrow.typeclasses.Show
  *     },
  *     success = { a -> handleSuccess({ a: Any -> log(Level.INFO, "This is a: $a") }, a) },
  *     error = { e -> handleError({ e: Any -> log(Level.WARN, "This is e: $e") }, e) },
- *     throwable = { throwable -> handleThrowable({ throwable: Throwable -> log(Level.ERROR, "Log the throwable: $throwable.") }, throwable) }
+ *     throwable = { throwable -> handleThrowable({ throwable: Throwable -> log(Level.ERROR, "Log the throwable: $throwable.") }, throwable) },
+ *     unrecoverableState = { _ -> Unit.right() }
  *   )
  * //sampleEnd
  * suspend fun main() {
@@ -1048,8 +1049,7 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
      * @param success the function to apply if [f] yields a success of type [A].
      * @param error the function to apply if [f] yields an error of type [E].
      * @param throwable the function to apply if [f] throws a [Throwable].
-     * @param handlingCaseThrows the function to apply if the [success], [error] or [throwable] function throw a [Throwable].
-     * Throwing any [Throwable] in the [handlingCaseThrows] function will render the [resolve] function nondeterministic.
+     * Throwing any [Throwable] in the [throwable] function will render the [resolve] function nondeterministic.
      * @param unrecoverableState the function to apply if [resolve] is in an unrecoverable state.
      * @return the result of applying the [resolve] function.
      */
@@ -1057,13 +1057,12 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
       f: suspend () -> Either<E, A>,
       success: suspend (a: A) -> Either<Throwable, B>,
       error: suspend (e: E) -> Either<Throwable, B>,
-      noinline throwable: suspend (throwable: Throwable) -> Either<Throwable, B>,
-      noinline handlingCaseThrows: suspend (throwable: Throwable) -> Either<Throwable, B> = throwable,
-      noinline unrecoverableState: suspend (throwable: Throwable) -> Either<Throwable, Unit> = { Unit.right() }
+      throwable: suspend (throwable: Throwable) -> Either<Throwable, B>,
+      unrecoverableState: suspend (throwable: Throwable) -> Either<Throwable, Unit>
     ): B =
       catch { f() }
-        .fold({ t: Throwable -> handleItSafely { throwable(t) } }, { it.fold({ e: E -> handleItSafely { error(e) } }, { a: A -> handleItSafely { success(a) } }) })
-        .fold({ t: Throwable -> handlingCaseThrows(t) }, { b: B -> b.right() })
+        .fold({ t: Throwable -> throwable(t) }, { it.fold({ e: E -> handleItSafely { error(e) } }, { a: A -> handleItSafely { success(a) } }) })
+        .fold({ t: Throwable -> throwable(t) }, { b: B -> b.right() })
         .fold({ t: Throwable -> unrecoverableState(t); throw t }, { b: B -> b })
   }
 }
@@ -1264,6 +1263,6 @@ inline fun <A, B> EitherOf<A, B>.handleErrorWith(f: (A) -> EitherOf<A, B>): Eith
     }
   }
 
-@PublishedApi()
+@PublishedApi
 internal suspend inline fun <A> handleItSafely(f: suspend () -> Either<Throwable, A>): Either<Throwable, A> =
   Either.catch { f() }.fold({ it.left() }, { it })

--- a/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
@@ -247,6 +247,17 @@ class EitherTest : UnitSpec() {
       Either.catch { loadFromNetwork() } shouldBe Left(exception)
     }
 
+    "catchAndFlatten should return Right(result) when f does not throw" {
+      suspend fun loadFromNetwork(): Either<Throwable, Int> = Right(1)
+      Either.catchAndFlatten { loadFromNetwork() } shouldBe Right(1)
+    }
+
+    "catchAndFlatten should return Left(result) when f throws" {
+      val exception = Exception("Boom!")
+      suspend fun loadFromNetwork(): Either<Throwable, Int> = throw exception
+      Either.catchAndFlatten { loadFromNetwork() } shouldBe Left(exception)
+    }
+
     "resolve should yield a result when deterministic functions are used as handlers" {
       forAll(
         Gen.suspendFunThatReturnsEitherAnyOrAnyOrThrows(),

--- a/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
@@ -261,7 +261,6 @@ class EitherTest : UnitSpec() {
               success = { a -> handleWithPureFunction(a, returnObject) },
               error = { e -> handleWithPureFunction(e, returnObject) },
               throwable = { t -> handleWithPureFunction(t, returnObject) },
-              handlingCaseThrows = { throwable -> handleWithPureFunction(throwable, returnObject) },
               unrecoverableState = ::handleWithPureFunction
             )
 
@@ -285,7 +284,6 @@ class EitherTest : UnitSpec() {
               success = { a -> handleWithPureFunction(a, returnObject) },
               error = { e -> handleWithPureFunction(e, returnObject) },
               throwable = { t -> handleWithPureFunction(t, returnObject) },
-              handlingCaseThrows = { t -> handleWithPureFunction(t, returnObject) },
               unrecoverableState = ::handleWithPureFunction
             )
           }
@@ -308,7 +306,6 @@ class EitherTest : UnitSpec() {
               success = ::throwException,
               error = { e -> handleWithPureFunction(e, returnObject) },
               throwable = { t -> handleWithPureFunction(t, returnObject) },
-              handlingCaseThrows = { t -> handleWithPureFunction(t, returnObject) },
               unrecoverableState = ::handleWithPureFunction
             )
 
@@ -332,7 +329,6 @@ class EitherTest : UnitSpec() {
               success = { a -> handleWithPureFunction(a, returnObject) },
               error = ::throwException,
               throwable = { t -> handleWithPureFunction(t, returnObject) },
-              handlingCaseThrows = { t -> handleWithPureFunction(t, returnObject) },
               unrecoverableState = ::handleWithPureFunction
             )
 
@@ -342,33 +338,9 @@ class EitherTest : UnitSpec() {
       }
     }
 
-    "resolve should yield a result when an exception is thrown in the throwable supplied function" {
+    "resolve should throw a Throwable when any exception is thrown in the throwable supplied function" {
       forAll(
-        Gen.suspendFunThatThrows(),
-        Gen.any()
-      ) { f: suspend () -> Either<Any, Any>,
-          returnObject: Any ->
-
-        runBlocking {
-          val result =
-            Either.resolve(
-              f = f,
-              success = { a -> handleWithPureFunction(a, returnObject) },
-              error = { e -> handleWithPureFunction(e, returnObject) },
-              throwable = ::throwException,
-              handlingCaseThrows = { t -> handleWithPureFunction(t, returnObject) },
-              unrecoverableState = ::handleWithPureFunction
-            )
-
-          result shouldBe returnObject
-        }
-        true
-      }
-    }
-
-    "resolve should throw a Throwable when any exception is thrown in the handlingCaseThrows supplied function" {
-      forAll(
-        Gen.suspendFunThatReturnsEitherAnyOrAnyOrThrows()
+        Gen.suspendFunThatThrows()
       ) { f: suspend () -> Either<Any, Any> ->
 
         runBlocking {
@@ -378,7 +350,6 @@ class EitherTest : UnitSpec() {
               success = ::throwException,
               error = ::throwException,
               throwable = ::throwException,
-              handlingCaseThrows = ::throwException,
               unrecoverableState = ::handleWithPureFunction
             )
           }

--- a/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
@@ -258,11 +258,11 @@ class EitherTest : UnitSpec() {
           val result =
             Either.resolve(
               f = f,
-              ifSuccess = { a -> handleWithPureFunction(a, returnObject) },
-              ifDomainError = { e -> handleWithPureFunction(e, returnObject) },
-              ifSystemFailure = { throwable -> handleWithPureFunction(throwable, returnObject) },
-              ifHandlingCaseThrows = { throwable -> handleWithPureFunction(throwable, returnObject) },
-              ifUnrecoverableState = ::handleWithPureFunction
+              success = { a -> handleWithPureFunction(a, returnObject) },
+              error = { e -> handleWithPureFunction(e, returnObject) },
+              throwable = { t -> handleWithPureFunction(t, returnObject) },
+              handlingCaseThrows = { throwable -> handleWithPureFunction(throwable, returnObject) },
+              unrecoverableState = ::handleWithPureFunction
             )
 
           result shouldBe returnObject
@@ -282,11 +282,11 @@ class EitherTest : UnitSpec() {
           shouldThrow<Throwable> {
             Either.resolve(
               f = f,
-              ifSuccess = { a -> handleWithPureFunction(a, returnObject) },
-              ifDomainError = { e -> handleWithPureFunction(e, returnObject) },
-              ifSystemFailure = { throwable -> handleWithPureFunction(throwable, returnObject) },
-              ifHandlingCaseThrows = { throwable -> handleWithPureFunction(throwable, returnObject) },
-              ifUnrecoverableState = ::handleWithPureFunction
+              success = { a -> handleWithPureFunction(a, returnObject) },
+              error = { e -> handleWithPureFunction(e, returnObject) },
+              throwable = { t -> handleWithPureFunction(t, returnObject) },
+              handlingCaseThrows = { t -> handleWithPureFunction(t, returnObject) },
+              unrecoverableState = ::handleWithPureFunction
             )
           }
         }
@@ -294,7 +294,7 @@ class EitherTest : UnitSpec() {
       }
     }
 
-    "resolve should yield a result when an exception is thrown in the ifSuccess supplied function" {
+    "resolve should yield a result when an exception is thrown in the success supplied function" {
       forAll(
         Gen.suspendFunThatReturnsAnyRight(),
         Gen.any()
@@ -305,11 +305,11 @@ class EitherTest : UnitSpec() {
           val result =
             Either.resolve(
               f = f,
-              ifSuccess = ::throwException,
-              ifDomainError = { e -> handleWithPureFunction(e, returnObject) },
-              ifSystemFailure = { throwable -> handleWithPureFunction(throwable, returnObject) },
-              ifHandlingCaseThrows = { throwable -> handleWithPureFunction(throwable, returnObject) },
-              ifUnrecoverableState = ::handleWithPureFunction
+              success = ::throwException,
+              error = { e -> handleWithPureFunction(e, returnObject) },
+              throwable = { t -> handleWithPureFunction(t, returnObject) },
+              handlingCaseThrows = { t -> handleWithPureFunction(t, returnObject) },
+              unrecoverableState = ::handleWithPureFunction
             )
 
           result shouldBe returnObject
@@ -318,7 +318,7 @@ class EitherTest : UnitSpec() {
       }
     }
 
-    "resolve should yield a result when an exception is thrown in the ifDomainError supplied function" {
+    "resolve should yield a result when an exception is thrown in the error supplied function" {
       forAll(
         Gen.suspendFunThatReturnsAnyLeft(),
         Gen.any()
@@ -329,11 +329,11 @@ class EitherTest : UnitSpec() {
           val result =
             Either.resolve(
               f = f,
-              ifSuccess = { a -> handleWithPureFunction(a, returnObject) },
-              ifDomainError = ::throwException,
-              ifSystemFailure = { throwable -> handleWithPureFunction(throwable, returnObject) },
-              ifHandlingCaseThrows = { throwable -> handleWithPureFunction(throwable, returnObject) },
-              ifUnrecoverableState = ::handleWithPureFunction
+              success = { a -> handleWithPureFunction(a, returnObject) },
+              error = ::throwException,
+              throwable = { t -> handleWithPureFunction(t, returnObject) },
+              handlingCaseThrows = { t -> handleWithPureFunction(t, returnObject) },
+              unrecoverableState = ::handleWithPureFunction
             )
 
           result shouldBe returnObject
@@ -342,7 +342,7 @@ class EitherTest : UnitSpec() {
       }
     }
 
-    "resolve should yield a result when an exception is thrown in the ifSystemFailure supplied function" {
+    "resolve should yield a result when an exception is thrown in the throwable supplied function" {
       forAll(
         Gen.suspendFunThatThrows(),
         Gen.any()
@@ -353,11 +353,11 @@ class EitherTest : UnitSpec() {
           val result =
             Either.resolve(
               f = f,
-              ifSuccess = { a -> handleWithPureFunction(a, returnObject) },
-              ifDomainError = { e -> handleWithPureFunction(e, returnObject) },
-              ifSystemFailure = ::throwException,
-              ifHandlingCaseThrows = { throwable -> handleWithPureFunction(throwable, returnObject) },
-              ifUnrecoverableState = ::handleWithPureFunction
+              success = { a -> handleWithPureFunction(a, returnObject) },
+              error = { e -> handleWithPureFunction(e, returnObject) },
+              throwable = ::throwException,
+              handlingCaseThrows = { t -> handleWithPureFunction(t, returnObject) },
+              unrecoverableState = ::handleWithPureFunction
             )
 
           result shouldBe returnObject
@@ -366,7 +366,7 @@ class EitherTest : UnitSpec() {
       }
     }
 
-    "resolve should throw a Throwable when any exception is thrown in the ifHandlingCaseThrows supplied function" {
+    "resolve should throw a Throwable when any exception is thrown in the handlingCaseThrows supplied function" {
       forAll(
         Gen.suspendFunThatReturnsEitherAnyOrAnyOrThrows()
       ) { f: suspend () -> Either<Any, Any> ->
@@ -375,11 +375,11 @@ class EitherTest : UnitSpec() {
           shouldThrow<Throwable> {
             Either.resolve(
               f = f,
-              ifSuccess = ::throwException,
-              ifDomainError = ::throwException,
-              ifSystemFailure = ::throwException,
-              ifHandlingCaseThrows = ::throwException,
-              ifUnrecoverableState = ::handleWithPureFunction
+              success = ::throwException,
+              error = ::throwException,
+              throwable = ::throwException,
+              handlingCaseThrows = ::throwException,
+              unrecoverableState = ::handleWithPureFunction
             )
           }
         }

--- a/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
@@ -401,4 +401,4 @@ suspend fun handleWithPureFunction(throwable: Throwable): Either<Throwable, Unit
 private suspend fun <A> throwException(
   a: A
 ): Either<Throwable, Any> =
-  throw RuntimeException("An Exception is thrown while handling the result of the domain logic.")
+  throw RuntimeException("An Exception is thrown while handling the result of the supplied function.")

--- a/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
@@ -274,10 +274,8 @@ class EitherTest : UnitSpec() {
               throwable = { t -> handleWithPureFunction(t, returnObject) },
               unrecoverableState = ::handleWithPureFunction
             )
-
-          result shouldBe returnObject
+          result == returnObject
         }
-        true
       }
     }
 
@@ -319,10 +317,8 @@ class EitherTest : UnitSpec() {
               throwable = { t -> handleWithPureFunction(t, returnObject) },
               unrecoverableState = ::handleWithPureFunction
             )
-
-          result shouldBe returnObject
+          result == returnObject
         }
-        true
       }
     }
 
@@ -342,10 +338,8 @@ class EitherTest : UnitSpec() {
               throwable = { t -> handleWithPureFunction(t, returnObject) },
               unrecoverableState = ::handleWithPureFunction
             )
-
-          result shouldBe returnObject
+          result == returnObject
         }
-        true
       }
     }
 

--- a/arrow-core-test/src/main/kotlin/arrow/core/test/generators/Generators.kt
+++ b/arrow-core-test/src/main/kotlin/arrow/core/test/generators/Generators.kt
@@ -31,6 +31,8 @@ import arrow.core.extensions.listk.semialign.semialign
 import arrow.core.extensions.sequencek.semialign.semialign
 import arrow.core.fix
 import arrow.core.k
+import arrow.core.left
+import arrow.core.right
 import arrow.core.toOption
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.ApplicativeError
@@ -201,3 +203,41 @@ private fun <A, B, R> Gen<A>.alignWith(genB: Gen<B>, transform: (Ior<A, B>) -> R
         alignWith(this@alignWith.random().k(), genB.random().k(), transform)
       }.fix()
   }
+
+fun Gen.Companion.suspendFunThatReturnsEitherAnyOrAnyOrThrows(): Gen<suspend () -> Either<Any, Any>> =
+  oneOf(
+    suspendFunThatReturnsAnyRight(),
+    suspendFunThatReturnsAnyLeft(),
+    suspendFunThatThrows()
+  )
+
+fun Gen.Companion.suspendFunThatReturnsAnyRight(): Gen<suspend () -> Either<Any, Any>> =
+  any().map { suspend { it.right() } }
+
+fun Gen.Companion.suspendFunThatReturnsAnyLeft(): Gen<suspend () -> Either<Any, Any>> =
+  any().map { suspend { it.left() } }
+
+fun Gen.Companion.suspendFunThatThrows(): Gen<suspend () -> Either<Any, Any>> =
+  throwable().map { suspend { throw it } } as Gen<suspend () -> Either<Any, Any>>
+
+fun Gen.Companion.suspendFunThatThrowsFatalThrowable(): Gen<suspend () -> Either<Any, Any>> =
+  fatalThrowable().map { suspend { throw it } } as Gen<suspend () -> Either<Any, Any>>
+
+fun Gen.Companion.any(): Gen<Any> =
+  oneOf(
+    string() as Gen<Any>,
+    int() as Gen<Any>,
+    long() as Gen<Any>,
+    float() as Gen<Any>,
+    double() as Gen<Any>,
+    bool() as Gen<Any>,
+    uuid() as Gen<Any>,
+    file() as Gen<Any>,
+    localDate() as Gen<Any>,
+    localTime() as Gen<Any>,
+    localDateTime() as Gen<Any>,
+    period() as Gen<Any>,
+    throwable() as Gen<Any>,
+    fatalThrowable() as Gen<Any>,
+    unit() as Gen<Any>
+  )


### PR DESCRIPTION
Same implementation as the handle function in https://github.com/sparetimedevs/pofpaf/blob/master/src/main/kotlin/com/sparetimedevs/pofpaf/handler/Handler.kt.

I did rename the function to `resolve`, because I like it better than `handle` in combination with `Either`; `Either.resolve`. But I am open to naming suggestions.

Concerning the tests. I wrote the original tests using Kotest. I quickly ported the tests to KotlinTest and they are not optimal. I did see that there is an open PR to upgrade the project to Kotest (https://github.com/arrow-kt/arrow-core/pull/188). If that is merged soon, there won't be a need for the `runBlocking` workaround.
