### PR TITLE
Make Either's handleErrorWith able to change error type

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -996,8 +996,7 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
       return when (ev) {
         is Left -> Left(ev.a)
         is Right -> {
-          val b: Either<A, B> = ev.b
-          when (b) {
+          when (val b = ev.b) {
             is Left -> tailRecM(b.a, f)
             is Right -> Right(b.b)
           }
@@ -1262,9 +1261,7 @@ inline fun <A> Any?.rightIfNull(default: () -> A): Either<A, Nothing?> = when (t
  * This is like `flatMap` for the exception.
  */
 inline fun <A, B, C> EitherOf<A, B>.handleErrorWith(f: (A) -> EitherOf<C, B>): Either<C, B> =
-  fix().let {
-    when (it) {
-      is Left -> f(it.a).fix()
-      is Right -> it
-    }
+  when (val either = fix()) {
+    is Left -> f(either.a).fix()
+    is Right -> either
   }

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -904,7 +904,7 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
    * ```
    */
   inline fun exists(predicate: (B) -> Boolean): Boolean =
-    fold({ false }, { predicate(it) })
+    fold({ false }, predicate)
 
   /**
    * Returns a [Some] containing the [Right] value
@@ -1209,16 +1209,16 @@ inline fun <A, B> EitherOf<A, B?>.leftIfNull(default: () -> A): Either<A, B> =
  *
  * Example:
  * ```
- * Right("something").contains { "something" } // Result: true
- * Right("something").contains { "anything" }  // Result: false
- * Left("something").contains { "something" }  // Result: false
+ * Right("something").contains("something") // Result: true
+ * Right("something").contains("anything")  // Result: false
+ * Left("something").contains("something")  // Result: false
  *  ```
  *
  * @param elem the element to test.
  * @return `true` if the option has an element that is equal (as determined by `==`) to `elem`, `false` otherwise.
  */
 fun <A, B> EitherOf<A, B>.contains(elem: B): Boolean =
-  fix().fold({ false }, { it == elem })
+  fix().exists { it == elem }
 
 fun <A, B, C> EitherOf<A, B>.ap(ff: EitherOf<A, (B) -> C>): Either<A, C> =
   flatMap { a -> ff.fix().map { f -> f(a) } }

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -1261,7 +1261,7 @@ inline fun <A> Any?.rightIfNull(default: () -> A): Either<A, Nothing?> = when (t
  * Applies the given function `f` if this is a [Left], otherwise returns this if this is a [Right].
  * This is like `flatMap` for the exception.
  */
-inline fun <A, B> EitherOf<A, B>.handleErrorWith(f: (A) -> EitherOf<A, B>): Either<A, B> =
+inline fun <A, B, C> EitherOf<A, B>.handleErrorWith(f: (A) -> EitherOf<C, B>): Either<C, B> =
   fix().let {
     when (it) {
       is Left -> f(it.a).fix()

--- a/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
@@ -229,6 +229,12 @@ class EitherTest : UnitSpec() {
       }
     }
 
+    "handleErrorWith should be able to change error type" {
+      forAll { a: Int, b: String ->
+        Left(a).handleErrorWith { Left(b) } == Left(b)
+      }
+    }
+
     "handleErrorWith should handle left instance otherwise return Right" {
       forAll { a: Int, b: Int ->
         Left(a).handleErrorWith { Right(b) } == Right(b) &&

--- a/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
@@ -229,16 +229,11 @@ class EitherTest : UnitSpec() {
       }
     }
 
-    "handleErrorWith should be able to change error type" {
-      forAll { a: Int, b: String ->
-        Left(a).handleErrorWith { Left(b) } == Left(b)
-      }
-    }
-
     "handleErrorWith should handle left instance otherwise return Right" {
-      forAll { a: Int, b: Int ->
+      forAll { a: Int, b: String ->
         Left(a).handleErrorWith { Right(b) } == Right(b) &&
-          Right(a).handleErrorWith { Right(b) } == Right(a)
+          Right(a).handleErrorWith { Right(b) } == Right(a) &&
+          Left(a).handleErrorWith { Left(b) } == Left(b)
       }
     }
 
@@ -268,8 +263,7 @@ class EitherTest : UnitSpec() {
       forAll(
         Gen.suspendFunThatReturnsEitherAnyOrAnyOrThrows(),
         Gen.any()
-      ) { f: suspend () -> Either<Any, Any>,
-        returnObject: Any ->
+      ) { f: suspend () -> Either<Any, Any>, returnObject: Any ->
 
         runBlocking {
           val result =
@@ -289,8 +283,7 @@ class EitherTest : UnitSpec() {
       forAll(
         Gen.suspendFunThatThrowsFatalThrowable(),
         Gen.any()
-      ) { f: suspend () -> Either<Any, Any>,
-        returnObject: Any ->
+      ) { f: suspend () -> Either<Any, Any>, returnObject: Any ->
 
         runBlocking {
           shouldThrow<Throwable> {
@@ -311,8 +304,7 @@ class EitherTest : UnitSpec() {
       forAll(
         Gen.suspendFunThatReturnsAnyRight(),
         Gen.any()
-      ) { f: suspend () -> Either<Any, Any>,
-        returnObject: Any ->
+      ) { f: suspend () -> Either<Any, Any>, returnObject: Any ->
 
         runBlocking {
           val result =
@@ -332,8 +324,7 @@ class EitherTest : UnitSpec() {
       forAll(
         Gen.suspendFunThatReturnsAnyLeft(),
         Gen.any()
-      ) { f: suspend () -> Either<Any, Any>,
-        returnObject: Any ->
+      ) { f: suspend () -> Either<Any, Any>, returnObject: Any ->
 
         runBlocking {
           val result =


### PR DESCRIPTION
In the function doc it says: "This is like `flatMap` for the exception.", but in reality is not because we cannot change the error type to something else, like we can do in flatMap for the right side.

Also fixes `contains` docs and simplifies `contains` and `exists` implementations.