### PR TITLE
Adds deprecated bind operators to Effect impls

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/computations/const.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/computations/const.kt
@@ -1,0 +1,39 @@
+package arrow.core.computations
+
+import arrow.continuations.Effect
+import arrow.core.Const
+import arrow.core.const
+import kotlin.coroutines.RestrictsSuspension
+
+@Deprecated(
+  "Const binding doe not require suspension and this computation block will be removed."
+)
+fun interface ConstEffect<A, T> : Effect<Const<A, T>> {
+
+  @Deprecated("The monadic operator for the Arrow 1.x series will become invoke in 0.13", ReplaceWith("()"))
+  suspend fun <B> Const<A, B>.bind(): B = this()
+
+  @Deprecated("The monadic operator for the Arrow 1.x series will become invoke in 0.13", ReplaceWith("()"))
+  suspend operator fun <B> Const<A, B>.not(): B = this()
+
+  suspend operator fun <B> Const<A, B>.invoke(): B =
+    value() as B
+}
+
+@Deprecated(
+  "Const binding doe not require suspension and this computation block will be removed."
+)
+@RestrictsSuspension
+fun interface RestrictedConstEffect<E, A> : ConstEffect<E, A>
+
+@Suppress("ClassName")
+@Deprecated(
+  "Const binding doe not require suspension and this computation block will be removed."
+)
+object const {
+  inline fun <A, T> eager(crossinline c: suspend RestrictedConstEffect<A, *>.() -> A): Const<A, T> =
+    Effect.restricted(eff = { RestrictedConstEffect { it } }, f = c, just = { it.const() })
+
+  suspend inline operator fun <A, T> invoke(crossinline c: suspend ConstEffect<A, *>.() -> A): Const<A, T> =
+    Effect.suspended(eff = { ConstEffect { it } }, f = c, just = { it.const() })
+}

--- a/arrow-core-data/src/main/kotlin/arrow/core/computations/const.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/computations/const.kt
@@ -28,7 +28,7 @@ fun interface RestrictedConstEffect<E, A> : ConstEffect<E, A>
 
 @Suppress("ClassName")
 @Deprecated(
-  "Const binding doe not require suspension and this computation block will be removed."
+  "Const binding does not require suspension and this computation block will be removed."
 )
 object const {
   inline fun <A, T> eager(crossinline c: suspend RestrictedConstEffect<A, *>.() -> A): Const<A, T> =

--- a/arrow-core-data/src/main/kotlin/arrow/core/computations/const.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/computations/const.kt
@@ -6,7 +6,7 @@ import arrow.core.const
 import kotlin.coroutines.RestrictsSuspension
 
 @Deprecated(
-  "Const binding doe not require suspension and this computation block will be removed."
+  "Const binding does not require suspension and this computation block will be removed."
 )
 fun interface ConstEffect<A, T> : Effect<Const<A, T>> {
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/computations/const.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/computations/const.kt
@@ -21,7 +21,7 @@ fun interface ConstEffect<A, T> : Effect<Const<A, T>> {
 }
 
 @Deprecated(
-  "Const binding doe not require suspension and this computation block will be removed."
+  "Const binding does not require suspension and this computation block will be removed."
 )
 @RestrictsSuspension
 fun interface RestrictedConstEffect<E, A> : ConstEffect<E, A>

--- a/arrow-core-data/src/main/kotlin/arrow/core/computations/either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/computations/either.kt
@@ -8,6 +8,13 @@ import arrow.core.right
 import kotlin.coroutines.RestrictsSuspension
 
 fun interface EitherEffect<E, A> : Effect<Either<E, A>> {
+
+  @Deprecated("The monadic operator for the Arrow 1.x series will become invoke in 0.13", ReplaceWith("()"))
+  suspend fun <B> Either<E, B>.bind(): B = this()
+
+  @Deprecated("The monadic operator for the Arrow 1.x series will become invoke in 0.13", ReplaceWith("()"))
+  suspend operator fun <B> Either<E, B>.not(): B = this()
+
   suspend operator fun <B> Either<E, B>.invoke(): B =
     when (this) {
       is Either.Right -> b
@@ -22,13 +29,7 @@ fun interface EitherEffect<E, A> : Effect<Either<E, A>> {
 }
 
 @RestrictsSuspension
-fun interface RestrictedEitherEffect<E, A> : Effect<Either<E, A>> {
-  suspend operator fun <B> Either<E, B>.invoke(): B =
-    when (this) {
-      is Either.Right -> b
-      is Either.Left -> control().shift(this@invoke)
-    }
-}
+fun interface RestrictedEitherEffect<E, A> : EitherEffect<E, A>
 
 @Suppress("ClassName")
 object either {

--- a/arrow-core-data/src/main/kotlin/arrow/core/computations/eval.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/computations/eval.kt
@@ -5,6 +5,13 @@ import arrow.core.Eval
 import kotlin.coroutines.RestrictsSuspension
 
 fun interface EvalEffect<A> : Effect<Eval<A>> {
+
+  @Deprecated("The monadic operator for the Arrow 1.x series will become invoke in 0.13", ReplaceWith("()"))
+  suspend fun <B> Eval<B>.bind(): B = this()
+
+  @Deprecated("The monadic operator for the Arrow 1.x series will become invoke in 0.13", ReplaceWith("()"))
+  suspend operator fun <B> Eval<B>.not(): B = this()
+
   suspend operator fun <B> Eval<B>.invoke(): B =
     value()
 }

--- a/arrow-core-data/src/main/kotlin/arrow/core/computations/nullable.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/computations/nullable.kt
@@ -4,6 +4,13 @@ import arrow.continuations.Effect
 import kotlin.coroutines.RestrictsSuspension
 
 fun interface NullableEffect<A> : Effect<A?> {
+
+  @Deprecated("The monadic operator for the Arrow 1.x series will become invoke in 0.13", ReplaceWith("()"))
+  suspend fun <B> B?.bind(): B = this()
+
+  @Deprecated("The monadic operator for the Arrow 1.x series will become invoke in 0.13", ReplaceWith("()"))
+  suspend operator fun <B> B?.not(): B = this()
+
   suspend operator fun <B> B?.invoke(): B = this ?: control().shift(null)
 }
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/computations/validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/computations/validated.kt
@@ -10,6 +10,13 @@ import kotlin.coroutines.RestrictsSuspension
   ReplaceWith("EitherEffect", "arrow.core.computations.either.EitherEffect")
 )
 fun interface ValidatedEffect<E, A> : Effect<Validated<E, A>> {
+
+  @Deprecated("The monadic operator for the Arrow 1.x series will become invoke in 0.13", ReplaceWith("()"))
+  suspend fun <B> Validated<E, B>.bind(): B = this()
+
+  @Deprecated("The monadic operator for the Arrow 1.x series will become invoke in 0.13", ReplaceWith("()"))
+  suspend operator fun <B> Validated<E, B>.not(): B = this()
+
   suspend operator fun <B> Validated<E, B>.invoke(): B =
     when (this) {
       is Validated.Valid -> a


### PR DESCRIPTION
Adds the deprecated operators we had in BindSyntax in order to offer a deprecation cycle in 0.12 and to be removed in 0.13