### PR TITLE
Deprecate @higherkind & @extension for Validated and offer concrete implementations

### DIFF
--- a/arrow-core-data/build.gradle
+++ b/arrow-core-data/build.gradle
@@ -11,7 +11,7 @@ apply from: "$DOC_CREATION"
 
 dependencies {
     api project(":arrow-annotations")
-    implementation project(":arrow-continuations")
+    api project(":arrow-continuations")
     kapt project(":arrow-meta")
     kaptTest project(":arrow-meta")
     compileOnly project(":arrow-meta")

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -869,7 +869,6 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
    * Left(12).map { "flower" }  // Result: Left(12)
    * ```
    */
-  @Suppress("UNCHECKED_CAST")
   inline fun <C> map(f: (B) -> C): Either<A, C> =
     flatMap { Right(f(it)) }
 
@@ -996,6 +995,12 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
 
     fun <R> right(right: R): Either<Nothing, R> = Right(right)
 
+    val leftUnit: Either<Unit, Nothing> = left(Unit)
+
+    val unit: Either<Nothing, Unit> = right(Unit)
+
+    fun <L> unit(): Either<L, Unit> = unit
+
     fun <A> fromNullable(a: A?): Either<Unit, A> = a?.right() ?: Unit.left()
 
     tailrec fun <L, A, B> tailRecM(a: A, f: (A) -> Kind<EitherPartialOf<L>, Either<A, B>>): Either<L, B> {
@@ -1077,6 +1082,12 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
         .fold({ t: Throwable -> throwable(t) }, { b: B -> b.right() })
         .fold({ t: Throwable -> unrecoverableState(t); throw t }, { b: B -> b })
   }
+
+  fun <C> mapConst(b: C): Either<A, C> =
+    map { b }
+
+  fun void(): Either<A, Unit> =
+    mapConst(Unit)
 }
 
 fun <L> Left(left: L): Either<L, Nothing> = Left(left)

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -1083,8 +1083,8 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
         .fold({ t: Throwable -> unrecoverableState(t); throw t }, { b: B -> b })
   }
 
-  fun <C> mapConst(b: C): Either<A, C> =
-    map { b }
+  fun <C> mapConst(c: C): Either<A, C> =
+    map { c }
 
   fun void(): Either<A, Unit> =
     mapConst(Unit)

--- a/arrow-core-data/src/main/kotlin/arrow/core/ListK.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/ListK.kt
@@ -482,3 +482,9 @@ fun <A> List<A>.k(): ListK<A> = ListK(this)
 
 fun <A> listKOf(vararg elements: A): ListK<A> =
   listOf(*elements).k()
+
+fun <A, B> Iterable<A>.mapConst(b: B): List<B> =
+  map { b }
+
+fun <A> Iterable<A>.void(): List<Unit> =
+  mapConst(Unit)

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -464,17 +464,17 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
     inline fun <E, A> fromNullable(value: A?, ifNull: () -> E): Validated<E, A> =
       value?.let(::Valid) ?: Invalid(ifNull())
 
-    suspend fun <A> catch(f: () -> A): Validated<Throwable, A> =
+    suspend fun <A> catch(f: suspend () -> A): Validated<Throwable, A> =
       try {
         f().valid()
       } catch (e: Throwable) {
         e.nonFatalOrThrow().invalid()
       }
 
-    suspend fun <E, A> catch(recover: (Throwable) -> E, f: () -> A): Validated<E, A> =
-      catch(f).mapLeft(recover)
+//    fun <E, A> catch(recover: (Throwable) -> E, f: () -> A): Validated<E, A> =
+//      catch(f).mapLeft(recover)
 
-    suspend fun <A> catchNel(f: () -> A): ValidatedNel<Throwable, A> =
+    suspend fun <A> catchNel(f: suspend () -> A): ValidatedNel<Throwable, A> =
       try {
         f().validNel()
       } catch (e: Throwable) {

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -464,17 +464,17 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
     inline fun <E, A> fromNullable(value: A?, ifNull: () -> E): Validated<E, A> =
       value?.let(::Valid) ?: Invalid(ifNull())
 
-    inline fun <A> catch(f: () -> A): Validated<Throwable, A> =
+    suspend fun <A> catch(f: () -> A): Validated<Throwable, A> =
       try {
         f().valid()
       } catch (e: Throwable) {
         e.nonFatalOrThrow().invalid()
       }
 
-    inline fun <E, A> catch(recover: (Throwable) -> E, f: () -> A): Validated<E, A> =
+    suspend fun <E, A> catch(recover: (Throwable) -> E, f: () -> A): Validated<E, A> =
       catch(f).mapLeft(recover)
 
-    inline fun <A> catchNel(f: () -> A): ValidatedNel<Throwable, A> =
+    suspend fun <A> catchNel(f: () -> A): ValidatedNel<Throwable, A> =
       try {
         f().validNel()
       } catch (e: Throwable) {

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -720,6 +720,9 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
     fun <L, R> show(SL: Show<L>, SR: Show<R>): Show<Validated<L, R>> =
       ValidatedShow(SL, SR)
 
+    fun <L, R> order(OL: Order<L>, OR: Order<R>): Order<Validated<L, R>> =
+      ValidatedOrder(OL, OR)
+
     /**
      * Lifts a function `A -> B` to the [Validated] structure.
      *

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -295,7 +295,7 @@ inline fun <E, A> ValidatedOf<E, A>.fix(): Validated<E, A> =
  *  val config = Config(mapOf("url" to "127.0.0.1", "port" to "1337"))
  *
  *  val valid = Validated.mapN(
- *    NonEmptyList.semigroup<ConfigError>()
+ *    NonEmptyList.semigroup<ConfigError>(),
  *    config.parse(Read.stringRead, "url"),
  *    config.parse(Read.intRead, "port")
  *  ) { (url, port) -> ConnectionParams(url, port) }

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -717,6 +717,9 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
     fun <L, R> hash(HL: Hash<L>, HR: Hash<R>): Hash<Validated<L, R>> =
       ValidatedHash(HL, HR)
 
+    fun <L, R> show(SL: Show<L>, SR: Show<R>): Show<Validated<L, R>> =
+      ValidatedShow(SL, SR)
+
     /**
      * Lifts a function `A -> B` to the [Validated] structure.
      *

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -233,7 +233,7 @@ inline fun <E, A> ValidatedOf<E, A>.fix(): Validated<E, A> =
  * //sampleStart
  * val parallelValidate = Validated
  *   .mapN(NonEmptyList.semigroup<ConfigError>(), 1.validNel(), 2.validNel())
- *     { (a, b) -> /* combine the result */ }
+ *     { a, b -> /* combine the result */ }
  * //sampleEnd
  * ```
  *
@@ -298,7 +298,7 @@ inline fun <E, A> ValidatedOf<E, A>.fix(): Validated<E, A> =
  *    NonEmptyList.semigroup<ConfigError>(),
  *    config.parse(Read.stringRead, "url"),
  *    config.parse(Read.intRead, "port")
- *  ) { (url, port) -> ConnectionParams(url, port) }
+ *  ) { url, port -> ConnectionParams(url, port) }
  * //sampleEnd
  *  println("valid = $valid")
  * }
@@ -360,7 +360,7 @@ inline fun <E, A> ValidatedOf<E, A>.fix(): Validated<E, A> =
  *  NonEmptyList.semigroup<ConfigError>(),
  *  config.parse(Read.stringRead, "url"),
  *  config.parse(Read.intRead, "port")
- *  ) { (url, port) -> ConnectionParams(url, port) }
+ *  ) { url, port -> ConnectionParams(url, port) }
  * //sampleEnd
  *  println("valid = $valid")
  * }

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -345,7 +345,7 @@ inline fun <E, A> ValidatedOf<E, A>.fix(): Validated<E, A> =
  *     val value = Validated.fromNullable(map[key]) {
  *       ConfigError.MissingConfig(key)
  *     }()
- *     val readVal = Validated.fromOption(read.read(value)) {
+ *     val readVal = Validated.fromNullable(read.read(value)) {
  *       ConfigError.ParseConfig(key)
  *     }()
  *     readVal
@@ -405,7 +405,7 @@ inline fun <E, A> ValidatedOf<E, A>.fix(): Validated<E, A> =
  *     val value = Validated.fromNullable(map[key]) {
  *       ConfigError.MissingConfig(key)
  *     }()
- *     val readVal = Validated.fromOption(read.read(value)) {
+ *     val readVal = Validated.fromNullable(read.read(value)) {
  *       ConfigError.ParseConfig(key)
  *     }()
  *     readVal

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -546,7 +546,7 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
       b: Validated<EE, B>,
       f: (A, B) -> Z
     ): Validated<EE, Z> =
-      tupledN(SE, a, b,)
+      tupledN(SE, a, b)
         .map { (a, b) -> f(a, b) }
 
     fun <EE, A, B, C, Z> mapN(

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -544,18 +544,20 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
       SE: Semigroup<EE>,
       a: Validated<EE, A>,
       b: Validated<EE, B>,
-      lbd: (Tuple2<A, B>) -> Z
+      f: (A, B) -> Z
     ): Validated<EE, Z> =
-      tupledN(SE, a, b).map(lbd)
+      tupledN(SE, a, b,)
+        .map { (a, b) -> f(a, b) }
 
     fun <EE, A, B, C, Z> mapN(
       SE: Semigroup<EE>,
       a: Validated<EE, A>,
       b: Validated<EE, B>,
       c: Validated<EE, C>,
-      lbd: (Tuple3<A, B, C>) -> Z
+      f: (A, B, C) -> Z
     ): Validated<EE, Z> =
-      tupledN(SE, a, b, c).map(lbd)
+      tupledN(SE, a, b, c)
+        .map { (a, b, c) -> f(a, b, c) }
 
     fun <EE, A, B, C, D, Z> mapN(
       SE: Semigroup<EE>,
@@ -563,9 +565,10 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
       b: Validated<EE, B>,
       c: Validated<EE, C>,
       d: Validated<EE, D>,
-      lbd: (Tuple4<A, B, C, D>) -> Z
+      f: (A, B, C, D) -> Z
     ): Validated<EE, Z> =
-      tupledN(SE, a, b, c, d).map(lbd)
+      tupledN(SE, a, b, c, d)
+        .map { (a, b, c, d) -> f(a, b, c, d) }
 
     fun <EE, A, B, C, D, E, Z> mapN(
       SE: Semigroup<EE>,
@@ -574,9 +577,10 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
       c: Validated<EE, C>,
       d: Validated<EE, D>,
       e: Validated<EE, E>,
-      lbd: (Tuple5<A, B, C, D, E>) -> Z
+      f: (A, B, C, D, E) -> Z
     ): Validated<EE, Z> =
-      tupledN(SE, a, b, c, d, e).map(lbd)
+      tupledN(SE, a, b, c, d, e)
+        .map { (a, b, c, d, e) -> f(a, b, c, d, e) }
 
     fun <EE, A, B, C, D, E, FF, Z> mapN(
       SE: Semigroup<EE>,
@@ -585,10 +589,11 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
       c: Validated<EE, C>,
       d: Validated<EE, D>,
       e: Validated<EE, E>,
-      f: Validated<EE, FF>,
-      lbd: (Tuple6<A, B, C, D, E, FF>) -> Z
+      ff: Validated<EE, FF>,
+      f: (A, B, C, D, E, FF) -> Z
     ): Validated<EE, Z> =
-      tupledN(SE, a, b, c, d, e, f).map(lbd)
+      tupledN(SE, a, b, c, d, e, ff)
+        .map { (a, b, c, d, e, ff) -> f(a, b, c, d, e, ff) }
 
     fun <EE, A, B, C, D, E, FF, G, Z> mapN(
       SE: Semigroup<EE>,
@@ -597,11 +602,12 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
       c: Validated<EE, C>,
       d: Validated<EE, D>,
       e: Validated<EE, E>,
-      f: Validated<EE, FF>,
+      ff: Validated<EE, FF>,
       g: Validated<EE, G>,
-      lbd: (Tuple7<A, B, C, D, E, FF, G>) -> Z
+      f: (A, B, C, D, E, FF, G) -> Z
     ): Validated<EE, Z> =
-      tupledN(SE, a, b, c, d, e, f, g).map(lbd)
+      tupledN(SE, a, b, c, d, e, ff, g)
+        .map { (a, b, c, d, e, ff, g) -> f(a, b, c, d, e, ff, g) }
 
     fun <EE, A, B, C, D, E, FF, G, H, Z> mapN(
       SE: Semigroup<EE>,
@@ -610,12 +616,13 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
       c: Validated<EE, C>,
       d: Validated<EE, D>,
       e: Validated<EE, E>,
-      f: Validated<EE, FF>,
+      ff: Validated<EE, FF>,
       g: Validated<EE, G>,
       h: Validated<EE, H>,
-      lbd: (Tuple8<A, B, C, D, E, FF, G, H>) -> Z
+      f: (A, B, C, D, E, FF, G, H) -> Z
     ): Validated<EE, Z> =
-      tupledN(SE, a, b, c, d, e, f, g, h).map(lbd)
+      tupledN(SE, a, b, c, d, e, ff, g, h)
+        .map { (a, b, c, d, e, ff, g, h) -> f(a, b, c, d, e, ff, g, h) }
 
     fun <EE, A, B, C, D, E, FF, G, H, I, Z> mapN(
       SE: Semigroup<EE>,
@@ -624,13 +631,14 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
       c: Validated<EE, C>,
       d: Validated<EE, D>,
       e: Validated<EE, E>,
-      f: Validated<EE, FF>,
+      ff: Validated<EE, FF>,
       g: Validated<EE, G>,
       h: Validated<EE, H>,
       i: Validated<EE, I>,
-      lbd: (Tuple9<A, B, C, D, E, FF, G, H, I>) -> Z
+      f: (A, B, C, D, E, FF, G, H, I) -> Z
     ): Validated<EE, Z> =
-      tupledN(SE, a, b, c, d, e, f, g, h, i).map(lbd)
+      tupledN(SE, a, b, c, d, e, ff, g, h, i)
+        .map { (a, b, c, d, e, ff, g, h, i) -> f(a, b, c, d, e, ff, g, h, i) }
 
     fun <EE, A, B, C, D, E, FF, G, H, I, J, Z> mapN(
       SE: Semigroup<EE>,
@@ -639,14 +647,15 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
       c: Validated<EE, C>,
       d: Validated<EE, D>,
       e: Validated<EE, E>,
-      f: Validated<EE, FF>,
+      ff: Validated<EE, FF>,
       g: Validated<EE, G>,
       h: Validated<EE, H>,
       i: Validated<EE, I>,
       j: Validated<EE, J>,
-      lbd: (Tuple10<A, B, C, D, E, FF, G, H, I, J>) -> Z
+      f: (A, B, C, D, E, FF, G, H, I, J) -> Z
     ): Validated<EE, Z> =
-      tupledN(SE, a, b, c, d, e, f, g, h, i, j).map(lbd)
+      tupledN(SE, a, b, c, d, e, ff, g, h, i, j)
+        .map { (a, b, c, d, e, ff, g, h, i, j) -> f(a, b, c, d, e, ff, g, h, i, j) }
 
     fun <EE, A, B> tupledN(
       SE: Semigroup<EE>,
@@ -1074,11 +1083,11 @@ fun <EE, E : EE, A> Validated<E, A>.leftWiden(): Validated<EE, A> =
 
 fun <E, A> Validated<E, A>.replicate(SE: Semigroup<E>, n: Int): Validated<E, List<A>> =
   if (n <= 0) emptyList<A>().valid()
-  else Validated.mapN(SE, this, replicate(SE, n - 1)) { (a, xs) -> listOf(a) + xs }
+  else Validated.mapN(SE, this, replicate(SE, n - 1)) { a, xs -> listOf(a) + xs }
 
 fun <E, A> Validated<E, A>.replicate(SE: Semigroup<E>, n: Int, MA: Monoid<A>): Validated<E, A> =
   if (n <= 0) MA.empty().valid()
-  else Validated.mapN(SE, this@replicate, replicate(SE, n - 1, MA)) { (a, xs) -> MA.run { a + xs } }
+  else Validated.mapN(SE, this@replicate, replicate(SE, n - 1, MA)) { a, xs -> MA.run { a + xs } }
 
 fun <E, A, B> Validated<E, A>.product(SE: Semigroup<E>, fb: Validated<E, B>): Validated<E, Tuple2<A, B>> =
   ap(SE, fb.map { b: B -> { a: A -> Tuple2(a, b) } })

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -464,6 +464,14 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
     inline fun <E, A> fromNullable(value: A?, ifNull: () -> E): Validated<E, A> =
       value?.let(::Valid) ?: Invalid(ifNull())
 
+    inline fun <A> catch(f: () -> A): Validated<Throwable, A> =
+      try {
+        f().valid()
+      } catch (e: Throwable) {
+        e.nonFatalOrThrow().invalid()
+      }
+
+    @Deprecated("Use the inline version. Hidden for binary compat", level = DeprecationLevel.HIDDEN)
     suspend fun <A> catch(f: suspend () -> A): Validated<Throwable, A> =
       try {
         f().valid()
@@ -471,9 +479,17 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
         e.nonFatalOrThrow().invalid()
       }
 
-//    fun <E, A> catch(recover: (Throwable) -> E, f: () -> A): Validated<E, A> =
-//      catch(f).mapLeft(recover)
+    inline fun <E, A> catch(recover: (Throwable) -> E, f: () -> A): Validated<E, A> =
+      catch(f).mapLeft(recover)
 
+    inline fun <A> catchNel(f: () -> A): ValidatedNel<Throwable, A> =
+      try {
+        f().validNel()
+      } catch (e: Throwable) {
+        e.nonFatalOrThrow().invalidNel()
+      }
+
+    @Deprecated("Use the inline version. Hidden for binary compat", level = DeprecationLevel.HIDDEN)
     suspend fun <A> catchNel(f: suspend () -> A): ValidatedNel<Throwable, A> =
       try {
         f().validNel()

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -481,18 +481,18 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
         e.nonFatalOrThrow().invalidNel()
       }
 
-    /** Construct an [Eq] instance which use [EQL] and [EQR] to compare the [Invalid] and [Valid] cases **/
-    fun <L, R> eq(EQL: Eq<L>, EQR: Eq<R>): Eq<Validated<L, R>> =
-      ValidatedEq(EQL, EQR)
+    /** Construct an [Eq] instance which use [EQE] and [EQA] to compare the [Invalid] and [Valid] cases **/
+    fun <E, A> eq(EQE: Eq<E>, EQA: Eq<A>): Eq<Validated<E, A>> =
+      ValidatedEq(EQE, EQA)
 
-    fun <L, R> hash(HL: Hash<L>, HR: Hash<R>): Hash<Validated<L, R>> =
-      ValidatedHash(HL, HR)
+    fun <E, A> hash(HE: Hash<E>, HA: Hash<A>): Hash<Validated<E, A>> =
+      ValidatedHash(HE, HA)
 
-    fun <L, R> show(SL: Show<L>, SR: Show<R>): Show<Validated<L, R>> =
-      ValidatedShow(SL, SR)
+    fun <E, A> show(SE: Show<E>, SA: Show<A>): Show<Validated<E, A>> =
+      ValidatedShow(SE, SA)
 
-    fun <L, R> order(OL: Order<L>, OR: Order<R>): Order<Validated<L, R>> =
-      ValidatedOrder(OL, OR)
+    fun <E, A> order(OE: Order<E>, OA: Order<A>): Order<Validated<E, A>> =
+      ValidatedOrder(OE, OA)
 
     /**
      * Lifts a function `A -> B` to the [Validated] structure.
@@ -540,220 +540,220 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
 
     fun <E> unit(): Validated<E, Unit> = unit
 
-    fun <EE, A, B, Z> mapN(
-      SE: Semigroup<EE>,
-      a: Validated<EE, A>,
-      b: Validated<EE, B>,
+    fun <E, A, B, Z> mapN(
+      SE: Semigroup<E>,
+      a: Validated<E, A>,
+      b: Validated<E, B>,
       f: (A, B) -> Z
-    ): Validated<EE, Z> =
+    ): Validated<E, Z> =
       tupledN(SE, a, b)
         .map { (a, b) -> f(a, b) }
 
-    fun <EE, A, B, C, Z> mapN(
-      SE: Semigroup<EE>,
-      a: Validated<EE, A>,
-      b: Validated<EE, B>,
-      c: Validated<EE, C>,
+    fun <E, A, B, C, Z> mapN(
+      SE: Semigroup<E>,
+      a: Validated<E, A>,
+      b: Validated<E, B>,
+      c: Validated<E, C>,
       f: (A, B, C) -> Z
-    ): Validated<EE, Z> =
+    ): Validated<E, Z> =
       tupledN(SE, a, b, c)
         .map { (a, b, c) -> f(a, b, c) }
 
-    fun <EE, A, B, C, D, Z> mapN(
-      SE: Semigroup<EE>,
-      a: Validated<EE, A>,
-      b: Validated<EE, B>,
-      c: Validated<EE, C>,
-      d: Validated<EE, D>,
+    fun <E, A, B, C, D, Z> mapN(
+      SE: Semigroup<E>,
+      a: Validated<E, A>,
+      b: Validated<E, B>,
+      c: Validated<E, C>,
+      d: Validated<E, D>,
       f: (A, B, C, D) -> Z
-    ): Validated<EE, Z> =
+    ): Validated<E, Z> =
       tupledN(SE, a, b, c, d)
         .map { (a, b, c, d) -> f(a, b, c, d) }
 
-    fun <EE, A, B, C, D, E, Z> mapN(
-      SE: Semigroup<EE>,
-      a: Validated<EE, A>,
-      b: Validated<EE, B>,
-      c: Validated<EE, C>,
-      d: Validated<EE, D>,
-      e: Validated<EE, E>,
-      f: (A, B, C, D, E) -> Z
-    ): Validated<EE, Z> =
+    fun <E, A, B, C, D, EE, Z> mapN(
+      SE: Semigroup<E>,
+      a: Validated<E, A>,
+      b: Validated<E, B>,
+      c: Validated<E, C>,
+      d: Validated<E, D>,
+      e: Validated<E, EE>,
+      f: (A, B, C, D, EE) -> Z
+    ): Validated<E, Z> =
       tupledN(SE, a, b, c, d, e)
         .map { (a, b, c, d, e) -> f(a, b, c, d, e) }
 
-    fun <EE, A, B, C, D, E, FF, Z> mapN(
-      SE: Semigroup<EE>,
-      a: Validated<EE, A>,
-      b: Validated<EE, B>,
-      c: Validated<EE, C>,
-      d: Validated<EE, D>,
-      e: Validated<EE, E>,
-      ff: Validated<EE, FF>,
-      f: (A, B, C, D, E, FF) -> Z
-    ): Validated<EE, Z> =
+    fun <E, A, B, C, D, EE, FF, Z> mapN(
+      SE: Semigroup<E>,
+      a: Validated<E, A>,
+      b: Validated<E, B>,
+      c: Validated<E, C>,
+      d: Validated<E, D>,
+      e: Validated<E, EE>,
+      ff: Validated<E, FF>,
+      f: (A, B, C, D, EE, FF) -> Z
+    ): Validated<E, Z> =
       tupledN(SE, a, b, c, d, e, ff)
         .map { (a, b, c, d, e, ff) -> f(a, b, c, d, e, ff) }
 
-    fun <EE, A, B, C, D, E, FF, G, Z> mapN(
-      SE: Semigroup<EE>,
-      a: Validated<EE, A>,
-      b: Validated<EE, B>,
-      c: Validated<EE, C>,
-      d: Validated<EE, D>,
-      e: Validated<EE, E>,
-      ff: Validated<EE, FF>,
-      g: Validated<EE, G>,
-      f: (A, B, C, D, E, FF, G) -> Z
-    ): Validated<EE, Z> =
+    fun <E, A, B, C, D, EE, F, G, Z> mapN(
+      SE: Semigroup<E>,
+      a: Validated<E, A>,
+      b: Validated<E, B>,
+      c: Validated<E, C>,
+      d: Validated<E, D>,
+      e: Validated<E, EE>,
+      ff: Validated<E, F>,
+      g: Validated<E, G>,
+      f: (A, B, C, D, EE, F, G) -> Z
+    ): Validated<E, Z> =
       tupledN(SE, a, b, c, d, e, ff, g)
         .map { (a, b, c, d, e, ff, g) -> f(a, b, c, d, e, ff, g) }
 
-    fun <EE, A, B, C, D, E, FF, G, H, Z> mapN(
-      SE: Semigroup<EE>,
-      a: Validated<EE, A>,
-      b: Validated<EE, B>,
-      c: Validated<EE, C>,
-      d: Validated<EE, D>,
-      e: Validated<EE, E>,
-      ff: Validated<EE, FF>,
-      g: Validated<EE, G>,
-      h: Validated<EE, H>,
-      f: (A, B, C, D, E, FF, G, H) -> Z
-    ): Validated<EE, Z> =
+    fun <E, A, B, C, D, EE, F, G, H, Z> mapN(
+      SE: Semigroup<E>,
+      a: Validated<E, A>,
+      b: Validated<E, B>,
+      c: Validated<E, C>,
+      d: Validated<E, D>,
+      e: Validated<E, EE>,
+      ff: Validated<E, F>,
+      g: Validated<E, G>,
+      h: Validated<E, H>,
+      f: (A, B, C, D, EE, F, G, H) -> Z
+    ): Validated<E, Z> =
       tupledN(SE, a, b, c, d, e, ff, g, h)
         .map { (a, b, c, d, e, ff, g, h) -> f(a, b, c, d, e, ff, g, h) }
 
-    fun <EE, A, B, C, D, E, FF, G, H, I, Z> mapN(
-      SE: Semigroup<EE>,
-      a: Validated<EE, A>,
-      b: Validated<EE, B>,
-      c: Validated<EE, C>,
-      d: Validated<EE, D>,
-      e: Validated<EE, E>,
-      ff: Validated<EE, FF>,
-      g: Validated<EE, G>,
-      h: Validated<EE, H>,
-      i: Validated<EE, I>,
-      f: (A, B, C, D, E, FF, G, H, I) -> Z
-    ): Validated<EE, Z> =
+    fun <E, A, B, C, D, EE, F, G, H, I, Z> mapN(
+      SE: Semigroup<E>,
+      a: Validated<E, A>,
+      b: Validated<E, B>,
+      c: Validated<E, C>,
+      d: Validated<E, D>,
+      e: Validated<E, EE>,
+      ff: Validated<E, F>,
+      g: Validated<E, G>,
+      h: Validated<E, H>,
+      i: Validated<E, I>,
+      f: (A, B, C, D, EE, F, G, H, I) -> Z
+    ): Validated<E, Z> =
       tupledN(SE, a, b, c, d, e, ff, g, h, i)
         .map { (a, b, c, d, e, ff, g, h, i) -> f(a, b, c, d, e, ff, g, h, i) }
 
-    fun <EE, A, B, C, D, E, FF, G, H, I, J, Z> mapN(
-      SE: Semigroup<EE>,
-      a: Validated<EE, A>,
-      b: Validated<EE, B>,
-      c: Validated<EE, C>,
-      d: Validated<EE, D>,
-      e: Validated<EE, E>,
-      ff: Validated<EE, FF>,
-      g: Validated<EE, G>,
-      h: Validated<EE, H>,
-      i: Validated<EE, I>,
-      j: Validated<EE, J>,
-      f: (A, B, C, D, E, FF, G, H, I, J) -> Z
-    ): Validated<EE, Z> =
+    fun <E, A, B, C, D, EE, F, G, H, I, J, Z> mapN(
+      SE: Semigroup<E>,
+      a: Validated<E, A>,
+      b: Validated<E, B>,
+      c: Validated<E, C>,
+      d: Validated<E, D>,
+      e: Validated<E, EE>,
+      ff: Validated<E, F>,
+      g: Validated<E, G>,
+      h: Validated<E, H>,
+      i: Validated<E, I>,
+      j: Validated<E, J>,
+      f: (A, B, C, D, EE, F, G, H, I, J) -> Z
+    ): Validated<E, Z> =
       tupledN(SE, a, b, c, d, e, ff, g, h, i, j)
         .map { (a, b, c, d, e, ff, g, h, i, j) -> f(a, b, c, d, e, ff, g, h, i, j) }
 
-    fun <EE, A, B> tupledN(
-      SE: Semigroup<EE>,
-      a: Validated<EE, A>,
-      b: Validated<EE, B>
-    ): Validated<EE, Tuple2<A, B>> =
+    fun <E, A, B> tupledN(
+      SE: Semigroup<E>,
+      a: Validated<E, A>,
+      b: Validated<E, B>
+    ): Validated<E, Tuple2<A, B>> =
       a.product(SE, b)
 
-    fun <EE, A, B, C> tupledN(
-      SE: Semigroup<EE>,
-      a: Validated<EE, A>,
-      b: Validated<EE, B>,
-      c: Validated<EE, C>
-    ): Validated<EE, Tuple3<A, B, C>> =
+    fun <E, A, B, C> tupledN(
+      SE: Semigroup<E>,
+      a: Validated<E, A>,
+      b: Validated<E, B>,
+      c: Validated<E, C>
+    ): Validated<E, Tuple3<A, B, C>> =
       a.product(SE, b).product(SE, c)
 
-    fun <EE, A, B, C, D> tupledN(
-      SE: Semigroup<EE>,
-      a: Validated<EE, A>,
-      b: Validated<EE, B>,
-      c: Validated<EE, C>,
-      d: Validated<EE, D>
-    ): Validated<EE, Tuple4<A, B, C, D>> =
+    fun <E, A, B, C, D> tupledN(
+      SE: Semigroup<E>,
+      a: Validated<E, A>,
+      b: Validated<E, B>,
+      c: Validated<E, C>,
+      d: Validated<E, D>
+    ): Validated<E, Tuple4<A, B, C, D>> =
       a.product(SE, b).product(SE, c).product(SE, d)
 
-    fun <EE, A, B, C, D, E> tupledN(
-      SE: Semigroup<EE>,
-      a: Validated<EE, A>,
-      b: Validated<EE, B>,
-      c: Validated<EE, C>,
-      d: Validated<EE, D>,
-      e: Validated<EE, E>
-    ): Validated<EE, Tuple5<A, B, C, D, E>> =
+    fun <E, A, B, C, D, EE> tupledN(
+      SE: Semigroup<E>,
+      a: Validated<E, A>,
+      b: Validated<E, B>,
+      c: Validated<E, C>,
+      d: Validated<E, D>,
+      e: Validated<E, EE>
+    ): Validated<E, Tuple5<A, B, C, D, EE>> =
       a.product(SE, b).product(SE, c).product(SE, d).product(SE, e)
 
-    fun <EE, A, B, C, D, E, FF> tupledN(
-      SE: Semigroup<EE>,
-      a: Validated<EE, A>,
-      b: Validated<EE, B>,
-      c: Validated<EE, C>,
-      d: Validated<EE, D>,
-      e: Validated<EE, E>,
-      f: Validated<EE, FF>
-    ): Validated<EE, Tuple6<A, B, C, D, E, FF>> =
+    fun <E, A, B, C, D, EE, F> tupledN(
+      SE: Semigroup<E>,
+      a: Validated<E, A>,
+      b: Validated<E, B>,
+      c: Validated<E, C>,
+      d: Validated<E, D>,
+      e: Validated<E, EE>,
+      f: Validated<E, F>
+    ): Validated<E, Tuple6<A, B, C, D, EE, F>> =
       a.product(SE, b).product(SE, c).product(SE, d).product(SE, e).product(SE, f)
 
-    fun <EE, A, B, C, D, E, FF, G> tupledN(
-      SE: Semigroup<EE>,
-      a: Validated<EE, A>,
-      b: Validated<EE, B>,
-      c: Validated<EE, C>,
-      d: Validated<EE, D>,
-      e: Validated<EE, E>,
-      f: Validated<EE, FF>,
-      g: Validated<EE, G>
-    ): Validated<EE, Tuple7<A, B, C, D, E, FF, G>> =
+    fun <E, A, B, C, D, EE, F, G> tupledN(
+      SE: Semigroup<E>,
+      a: Validated<E, A>,
+      b: Validated<E, B>,
+      c: Validated<E, C>,
+      d: Validated<E, D>,
+      e: Validated<E, EE>,
+      f: Validated<E, F>,
+      g: Validated<E, G>
+    ): Validated<E, Tuple7<A, B, C, D, EE, F, G>> =
       a.product(SE, b).product(SE, c).product(SE, d).product(SE, e).product(SE, f).product(SE, g)
 
-    fun <EE, A, B, C, D, E, FF, G, H> tupledN(
-      SE: Semigroup<EE>,
-      a: Validated<EE, A>,
-      b: Validated<EE, B>,
-      c: Validated<EE, C>,
-      d: Validated<EE, D>,
-      e: Validated<EE, E>,
-      f: Validated<EE, FF>,
-      g: Validated<EE, G>,
-      h: Validated<EE, H>
-    ): Validated<EE, Tuple8<A, B, C, D, E, FF, G, H>> =
+    fun <E, A, B, C, D, EE, F, G, H> tupledN(
+      SE: Semigroup<E>,
+      a: Validated<E, A>,
+      b: Validated<E, B>,
+      c: Validated<E, C>,
+      d: Validated<E, D>,
+      e: Validated<E, EE>,
+      f: Validated<E, F>,
+      g: Validated<E, G>,
+      h: Validated<E, H>
+    ): Validated<E, Tuple8<A, B, C, D, EE, F, G, H>> =
       a.product(SE, b).product(SE, c).product(SE, d).product(SE, e).product(SE, f).product(SE, g).product(SE, h)
 
-    fun <EE, A, B, C, D, E, FF, G, H, I> tupledN(
-      SE: Semigroup<EE>,
-      a: Validated<EE, A>,
-      b: Validated<EE, B>,
-      c: Validated<EE, C>,
-      d: Validated<EE, D>,
-      e: Validated<EE, E>,
-      f: Validated<EE, FF>,
-      g: Validated<EE, G>,
-      h: Validated<EE, H>,
-      i: Validated<EE, I>
-    ): Validated<EE, Tuple9<A, B, C, D, E, FF, G, H, I>> =
+    fun <E, A, B, C, D, EE, F, G, H, I> tupledN(
+      SE: Semigroup<E>,
+      a: Validated<E, A>,
+      b: Validated<E, B>,
+      c: Validated<E, C>,
+      d: Validated<E, D>,
+      e: Validated<E, EE>,
+      f: Validated<E, F>,
+      g: Validated<E, G>,
+      h: Validated<E, H>,
+      i: Validated<E, I>
+    ): Validated<E, Tuple9<A, B, C, D, EE, F, G, H, I>> =
       a.product(SE, b).product(SE, c).product(SE, d).product(SE, e).product(SE, f).product(SE, g).product(SE, h).product(SE, i)
 
-    fun <EE, A, B, C, D, E, FF, G, H, I, J> tupledN(
-      SE: Semigroup<EE>,
-      a: Validated<EE, A>,
-      b: Validated<EE, B>,
-      c: Validated<EE, C>,
-      d: Validated<EE, D>,
-      e: Validated<EE, E>,
-      f: Validated<EE, FF>,
-      g: Validated<EE, G>,
-      h: Validated<EE, H>,
-      i: Validated<EE, I>,
-      j: Validated<EE, J>
-    ): Validated<EE, Tuple10<A, B, C, D, E, FF, G, H, I, J>> =
+    fun <E, A, B, C, D, EE, F, G, H, I, J> tupledN(
+      SE: Semigroup<E>,
+      a: Validated<E, A>,
+      b: Validated<E, B>,
+      c: Validated<E, C>,
+      d: Validated<E, D>,
+      e: Validated<E, EE>,
+      f: Validated<E, F>,
+      g: Validated<E, G>,
+      h: Validated<E, H>,
+      i: Validated<E, I>,
+      j: Validated<E, J>
+    ): Validated<E, Tuple10<A, B, C, D, EE, F, G, H, I, J>> =
       a.product(SE, b).product(SE, c).product(SE, d).product(SE, e).product(SE, f).product(SE, g)
         .product(SE, h).product(SE, i).product(SE, j)
   }
@@ -851,46 +851,46 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
   fun <B> tupleRight(b: B): Validated<E, Tuple2<A, B>> =
     map { a -> Tuple2(a, b) }
 
-  inline fun <D> traverse(fa: (A) -> Iterable<D>): List<Validated<E, D>> =
+  inline fun <B> traverse(fa: (A) -> Iterable<B>): List<Validated<E, B>> =
     fold({ emptyList() }, { fa(it).map { Valid(it) } })
 
-  inline fun <D> traverse_(fa: (A) -> Iterable<D>): List<Unit> =
+  inline fun <B> traverse_(fa: (A) -> Iterable<B>): List<Unit> =
     fold({ emptyList() }, { fa(it).void() })
 
-  inline fun <EE, D> traverseEither(fa: (A) -> Either<EE, D>): Either<EE, Validated<E, D>> =
+  inline fun <EE, B> traverseEither(fa: (A) -> Either<EE, B>): Either<EE, Validated<E, B>> =
     when (this) {
       is Valid -> fa(this.a).map { Valid(it) }
       is Invalid -> this.right()
     }
 
-  inline fun <EE, D> traverseEither_(fa: (A) -> Either<EE, D>): Either<EE, Unit> =
+  inline fun <EE, B> traverseEither_(fa: (A) -> Either<EE, B>): Either<EE, Unit> =
     fold({ Either.right(Unit) }, { fa(it).void() })
 
-  inline fun <C> bifoldLeft(
-    c: C,
-    fe: (C, E) -> C,
-    fa: (C, A) -> C
-  ): C =
+  inline fun <B> bifoldLeft(
+    c: B,
+    fe: (B, E) -> B,
+    fa: (B, A) -> B
+  ): B =
     fold({ fe(c, it) }, { fa(c, it) })
 
-  inline fun <C> bifoldRight(
-    c: Eval<C>,
-    fe: (E, Eval<C>) -> Eval<C>,
-    fa: (A, Eval<C>) -> Eval<C>
-  ): Eval<C> =
+  inline fun <B> bifoldRight(
+    c: Eval<B>,
+    fe: (E, Eval<B>) -> Eval<B>,
+    fa: (A, Eval<B>) -> Eval<B>
+  ): Eval<B> =
     fold({ fe(it, c) }, { fa(it, c) })
 
-  inline fun <C> bifoldMap(MN: Monoid<C>, g: (E) -> C, f: (A) -> C) = MN.run {
+  inline fun <B> bifoldMap(MN: Monoid<B>, g: (E) -> B, f: (A) -> B) = MN.run {
     bifoldLeft(MN.empty(), { c, b -> c.combine(g(b)) }) { c, a -> c.combine(f(a)) }
   }
 
-  fun <C, D> bitraverse(fe: (E) -> Iterable<C>, fa: (A) -> Iterable<D>): List<Validated<C, D>> =
+  fun <EE, B> bitraverse(fe: (E) -> Iterable<EE>, fa: (A) -> Iterable<B>): List<Validated<EE, B>> =
     fold({ fe(it).map { Invalid(it) } }, { fa(it).map { Valid(it) } })
 
-  fun <C, D, EE> bitraverseEither(
-    fe: (E) -> Either<EE, D>,
+  fun <EE, B, C> bitraverseEither(
+    fe: (E) -> Either<EE, B>,
     fa: (A) -> Either<EE, C>
-  ): Either<EE, Validated<D, C>> =
+  ): Either<EE, Validated<B, C>> =
     fold({ fe(it).map { Invalid(it) } }, { fa(it).map { Valid(it) } })
 
   fun <B> foldMap(MB: Monoid<B>, f: (A) -> B): B =
@@ -986,7 +986,7 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
    *
    * Apply a function to an Invalid or Valid value, returning a new Invalid or Valid value respectively.
    */
-  inline fun <EE, AA> bimap(fe: (E) -> EE, fa: (A) -> AA): Validated<EE, AA> =
+  inline fun <EE, B> bimap(fe: (E) -> EE, fa: (A) -> B): Validated<EE, B> =
     fold({ Invalid(fe(it)) }, { Valid(fa(it)) })
 
   /**
@@ -1054,7 +1054,7 @@ fun <E, B> Validated<E, B>.eqv(
 }
 
 /**
- * Replaces the [B] value inside [F] with [A] resulting in a Kind<F, A>
+ * Replaces the [B] value inside [Validated] with [A] resulting in Validated<E, A>
  */
 fun <E, A, B> A.mapConst(fb: Validated<E, B>): Validated<E, A> =
   fb.mapConst(this)
@@ -1096,65 +1096,65 @@ fun <E, A, B, Z> Validated<E, A>.map2(SE: Semigroup<E>, fb: Validated<E, B>, f: 
   product(SE, fb).map(f)
 
 @JvmName("product3")
-fun <EE, A, B, Z> Validated<EE, Tuple2<A, B>>.product(
-  SE: Semigroup<EE>,
-  other: Validated<EE, Z>,
-): Validated<EE, Tuple3<A, B, Z>> =
+fun <E, A, B, C> Validated<E, Tuple2<A, B>>.product(
+  SE: Semigroup<E>,
+  other: Validated<E, C>,
+): Validated<E, Tuple3<A, B, C>> =
   map2(SE, other) { (ab, c) -> Tuple3(ab.a, ab.b, c) }
 
 @JvmName("product4")
-fun <EE, A, B, C, Z> Validated<EE, Tuple3<A, B, C>>.product(
-  SE: Semigroup<EE>,
-  other: Validated<EE, Z>,
-): Validated<EE, Tuple4<A, B, C, Z>> =
+fun <E, A, B, C, D> Validated<E, Tuple3<A, B, C>>.product(
+  SE: Semigroup<E>,
+  other: Validated<E, D>,
+): Validated<E, Tuple4<A, B, C, D>> =
   map2(SE, other) { (abc, d) -> Tuple4(abc.a, abc.b, abc.c, d) }
 
 @JvmName("product5")
-fun <EE, A, B, C, D, Z> Validated<EE, Tuple4<A, B, C, D>>.product(
-  SE: Semigroup<EE>,
-  other: Validated<EE, Z>,
-): Validated<EE, Tuple5<A, B, C, D, Z>> =
+fun <E, A, B, C, D, EE> Validated<E, Tuple4<A, B, C, D>>.product(
+  SE: Semigroup<E>,
+  other: Validated<E, EE>,
+): Validated<E, Tuple5<A, B, C, D, EE>> =
   map2(SE, other) { (abcd, e) -> Tuple5(abcd.a, abcd.b, abcd.c, abcd.d, e) }
 
 @JvmName("product6")
-fun <EE, A, B, C, D, E, Z> Validated<EE, Tuple5<A, B, C, D, E>>.product(
-  SE: Semigroup<EE>,
-  other: Validated<EE, Z>,
-): Validated<EE, Tuple6<A, B, C, D, E, Z>> =
+fun <E, A, B, C, D, EE, F> Validated<E, Tuple5<A, B, C, D, EE>>.product(
+  SE: Semigroup<E>,
+  other: Validated<E, F>,
+): Validated<E, Tuple6<A, B, C, D, EE, F>> =
   map2(SE, other) { (abcde, f) -> Tuple6(abcde.a, abcde.b, abcde.c, abcde.d, abcde.e, f) }
 
 @JvmName("product7")
-fun <EE, A, B, C, D, E, FF, Z> Validated<EE, Tuple6<A, B, C, D, E, FF>>.product(
-  SE: Semigroup<EE>,
-  other: Validated<EE, Z>,
-): Validated<EE, Tuple7<A, B, C, D, E, FF, Z>> =
+fun <E, A, B, C, D, EE, F, G> Validated<E, Tuple6<A, B, C, D, EE, F>>.product(
+  SE: Semigroup<E>,
+  other: Validated<E, G>,
+): Validated<E, Tuple7<A, B, C, D, EE, F, G>> =
   map2(SE, other) { (abcdef, g) -> Tuple7(abcdef.a, abcdef.b, abcdef.c, abcdef.d, abcdef.e, abcdef.f, g) }
 
 @JvmName("product8")
-fun <EE, A, B, C, D, E, FF, G, Z> Validated<EE, Tuple7<A, B, C, D, E, FF, G>>.product(
-  SE: Semigroup<EE>,
-  other: Validated<EE, Z>,
-): Validated<EE, Tuple8<A, B, C, D, E, FF, G, Z>> =
+fun <E, A, B, C, D, EE, F, G, H> Validated<E, Tuple7<A, B, C, D, EE, F, G>>.product(
+  SE: Semigroup<E>,
+  other: Validated<E, H>,
+): Validated<E, Tuple8<A, B, C, D, EE, F, G, H>> =
   map2(SE, other) { (abcdefg, h) -> Tuple8(abcdefg.a, abcdefg.b, abcdefg.c, abcdefg.d, abcdefg.e, abcdefg.f, abcdefg.g, h) }
 
 @JvmName("product9")
-fun <EE, A, B, C, D, E, FF, G, H, Z> Validated<EE, Tuple8<A, B, C, D, E, FF, G, H>>.product(
-  SE: Semigroup<EE>,
-  other: Validated<EE, Z>,
-): Validated<EE, Tuple9<A, B, C, D, E, FF, G, H, Z>> =
+fun <E, A, B, C, D, EE, F, G, H, I> Validated<E, Tuple8<A, B, C, D, EE, F, G, H>>.product(
+  SE: Semigroup<E>,
+  other: Validated<E, I>,
+): Validated<E, Tuple9<A, B, C, D, EE, F, G, H, I>> =
   map2(SE, other) { (abcdefgh, i) -> Tuple9(abcdefgh.a, abcdefgh.b, abcdefgh.c, abcdefgh.d, abcdefgh.e, abcdefgh.f, abcdefgh.g, abcdefgh.h, i) }
 
 @JvmName("product10")
-fun <EE, A, B, C, D, E, FF, G, H, I, Z> Validated<EE, Tuple9<A, B, C, D, E, FF, G, H, I>>.product(
-  SE: Semigroup<EE>,
-  other: Validated<EE, Z>,
-): Validated<EE, Tuple10<A, B, C, D, E, FF, G, H, I, Z>> =
+fun <E, A, B, C, D, EE, F, G, H, I, J> Validated<E, Tuple9<A, B, C, D, EE, F, G, H, I>>.product(
+  SE: Semigroup<E>,
+  other: Validated<E, J>,
+): Validated<E, Tuple10<A, B, C, D, EE, F, G, H, I, J>> =
   map2(SE, other) { (abcdefghi, j) -> Tuple10(abcdefghi.a, abcdefghi.b, abcdefghi.c, abcdefghi.d, abcdefghi.e, abcdefghi.f, abcdefghi.g, abcdefghi.h, abcdefghi.i, j) }
 
-fun <A, B> Validated<Iterable<A>, Iterable<B>>.bisequence(): List<Validated<A, B>> =
+fun <E, A> Validated<Iterable<E>, Iterable<A>>.bisequence(): List<Validated<E, A>> =
   bitraverse(::identity, ::identity)
 
-fun <A, B, E> Validated<Either<E, A>, Either<E, B>>.bisequenceEither(): Either<E, Validated<A, B>> =
+fun <E, A, B> Validated<Either<E, A>, Either<E, B>>.bisequenceEither(): Either<E, Validated<A, B>> =
   bitraverseEither(::identity, ::identity)
 
 fun <E, A> Validated<E, A>.fold(MA: Monoid<A>): A = MA.run {
@@ -1164,10 +1164,10 @@ fun <E, A> Validated<E, A>.fold(MA: Monoid<A>): A = MA.run {
 fun <E, A> Validated<E, A>.combineAll(MA: Monoid<A>): A =
   fold(MA)
 
-fun <A, B> Validated<A, Iterable<B>>.sequence(): List<Validated<A, B>> =
+fun <E, A> Validated<E, Iterable<A>>.sequence(): List<Validated<E, A>> =
   traverse(::identity)
 
-fun <A, B> Validated<A, Iterable<B>>.sequence_(): List<Unit> =
+fun <E, A> Validated<E, Iterable<A>>.sequence_(): List<Unit> =
   traverse_(::identity)
 
 fun <E, A, B> Validated<A, Either<E, B>>.sequenceEither(): Either<E, Validated<A, B>> =
@@ -1176,34 +1176,34 @@ fun <E, A, B> Validated<A, Either<E, B>>.sequenceEither(): Either<E, Validated<A
 fun <E, A, B> Validated<A, Either<E, B>>.traverseEither_(): Either<E, Unit> =
   traverseEither_(::identity)
 
-fun <L, R> Validated<L, R>.compare(OL: Order<L>, OR: Order<R>, b: Validated<L, R>): Ordering = fold(
-  { l1 -> b.fold({ l2 -> OL.run { l1.compare(l2) } }, { LT }) },
-  { r1 -> b.fold({ GT }, { r2 -> OR.run { r1.compare(r2) } }) }
+fun <E, A> Validated<E, A>.compare(OE: Order<E>, OA: Order<A>, b: Validated<E, A>): Ordering = fold(
+  { l1 -> b.fold({ l2 -> OE.run { l1.compare(l2) } }, { LT }) },
+  { r1 -> b.fold({ GT }, { r2 -> OA.run { r1.compare(r2) } }) }
 )
 
-fun <L, R> Validated<L, R>.compareTo(OL: Order<L>, OR: Order<R>, b: Validated<L, R>): Int =
-  compare(OL, OR, b).toInt()
+fun <E, A> Validated<E, A>.compareTo(OE: Order<E>, OA: Order<A>, b: Validated<E, A>): Int =
+  compare(OE, OA, b).toInt()
 
-fun <L, R> Validated<L, R>.lt(OL: Order<L>, OR: Order<R>, b: Validated<L, R>): Boolean =
-  compare(OL, OR, b) == LT
+fun <E, A> Validated<E, A>.lt(OE: Order<E>, OA: Order<A>, b: Validated<E, A>): Boolean =
+  compare(OE, OA, b) == LT
 
-fun <L, R> Validated<L, R>.lte(OL: Order<L>, OR: Order<R>, b: Validated<L, R>): Boolean =
-  compare(OL, OR, b) != GT
+fun <E, A> Validated<E, A>.lte(OE: Order<E>, OA: Order<A>, b: Validated<E, A>): Boolean =
+  compare(OE, OA, b) != GT
 
-fun <L, R> Validated<L, R>.gt(OL: Order<L>, OR: Order<R>, b: Validated<L, R>): Boolean =
-  compare(OL, OR, b) == GT
+fun <E, A> Validated<E, A>.gt(OE: Order<E>, OA: Order<A>, b: Validated<E, A>): Boolean =
+  compare(OE, OA, b) == GT
 
-fun <L, R> Validated<L, R>.gte(OL: Order<L>, OR: Order<R>, b: Validated<L, R>): Boolean =
-  compare(OL, OR, b) != LT
+fun <E, A> Validated<E, A>.gte(OE: Order<E>, OA: Order<A>, b: Validated<E, A>): Boolean =
+  compare(OE, OA, b) != LT
 
-fun <L, R> Validated<L, R>.max(OL: Order<L>, OR: Order<R>, b: Validated<L, R>): Validated<L, R> =
-  if (gt(OL, OR, b)) this else b
+fun <E, A> Validated<E, A>.max(OE: Order<E>, OA: Order<A>, b: Validated<E, A>): Validated<E, A> =
+  if (gt(OE, OA, b)) this else b
 
-fun <L, R> Validated<L, R>.min(OL: Order<L>, OR: Order<R>, b: Validated<L, R>): Validated<L, R> =
-  if (lt(OL, OR, b)) this else b
+fun <E, A> Validated<E, A>.min(OE: Order<E>, OA: Order<A>, b: Validated<E, A>): Validated<E, A> =
+  if (lt(OE, OA, b)) this else b
 
-fun <L, R> Validated<L, R>.sort(OL: Order<L>, OR: Order<R>, b: Validated<L, R>): Tuple2<Validated<L, R>, Validated<L, R>> =
-  if (gte(OL, OR, b)) Tuple2(this, b) else Tuple2(b, this)
+fun <E, A> Validated<E, A>.sort(OE: Order<E>, OA: Order<A>, b: Validated<E, A>): Tuple2<Validated<E, A>, Validated<E, A>> =
+  if (gte(OE, OA, b)) Tuple2(this, b) else Tuple2(b, this)
 
 fun <E, A, B> Validated<E, Either<A, B>>.select(f: Validated<E, (A) -> B>): Validated<E, B> =
   fold({ Invalid(it) }, { it.fold({ l -> f.map { ff -> ff(l) } }, { r -> r.valid() }) })
@@ -1235,19 +1235,19 @@ fun <E> Validated<E, Boolean>.andS(f: Validated<E, Boolean>): Validated<E, Boole
 /**
  * Return the Valid value, or the default if Invalid
  */
-inline fun <E, B> ValidatedOf<E, B>.getOrElse(default: () -> B): B =
+inline fun <E, A> ValidatedOf<E, A>.getOrElse(default: () -> A): A =
   fix().fold({ default() }, ::identity)
 
 /**
  * Return the Valid value, or null if Invalid
  */
-fun <E, B> ValidatedOf<E, B>.orNull(): B? =
+fun <E, A> ValidatedOf<E, A>.orNull(): A? =
   getOrElse { null }
 
 /**
  * Return the Valid value, or the result of f if Invalid
  */
-inline fun <E, B> ValidatedOf<E, B>.valueOr(f: (E) -> B): B =
+inline fun <E, A> ValidatedOf<E, A>.valueOr(f: (E) -> A): A =
   fix().fold({ f(it) }, ::identity)
 
 /**
@@ -1320,10 +1320,12 @@ inline fun <E, A, B> Validated<E, A>.redeem(fe: (E) -> B, fa: (A) -> B): Validat
 fun <E, A> Validated<E, A>.attempt(): Validated<Nothing, Either<E, A>> =
   map { Right(it) }.handleError { Left(it) }
 
+@Deprecated("@extension kinded projected functions are deprecated. Replace with traverse or traverseEither from arrow.core.*")
 fun <G, E, A, B> ValidatedOf<E, A>.traverse(GA: Applicative<G>, f: (A) -> Kind<G, B>): Kind<G, Validated<E, B>> = GA.run {
   fix().fold({ e -> just(Invalid(e)) }, { a -> f(a).map(::Valid) })
 }
 
+@Deprecated("@extension kinded projected functions are deprecated. Replace with sequence or sequenceEither from arrow.core.*")
 fun <G, E, A> ValidatedOf<E, Kind<G, A>>.sequence(GA: Applicative<G>): Kind<G, Validated<E, A>> =
   fix().traverse(GA, ::identity)
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -1,7 +1,6 @@
 package arrow.core
 
 import arrow.Kind
-import arrow.higherkind
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
@@ -9,6 +8,20 @@ import arrow.typeclasses.Show
 typealias ValidatedNel<E, A> = Validated<Nel<E>, A>
 typealias Valid<A> = Validated.Valid<A>
 typealias Invalid<E> = Validated.Invalid<E>
+
+@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
+class ForValidated private constructor() {
+  companion object
+}
+@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
+typealias ValidatedOf<E, A> = arrow.Kind2<ForValidated, E, A>
+@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
+typealias ValidatedPartialOf<E> = arrow.Kind<ForValidated, E>
+
+@Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
+@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
+inline fun <E, A> ValidatedOf<E, A>.fix(): Validated<E, A> =
+  this as Validated<E, A>
 
 /**
  *
@@ -644,7 +657,6 @@ typealias Invalid<E> = Validated.Invalid<E>
  * DataType(Validated::class).tcMarkdownList()
  * ```
  */
-@higherkind
 sealed class Validated<out E, out A> : ValidatedOf<E, A> {
 
   companion object {

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -1088,27 +1088,28 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
 
   inline fun <C> bifoldLeft(
     c: C,
-    fa: (C, A) -> C,
-    fe: (C, E) -> C
-  ): C = fold({ fe(c, it) }, { fa(c, it) })
+    fe: (C, E) -> C,
+    fa: (C, A) -> C
+  ): C =
+    fold({ fe(c, it) }, { fa(c, it) })
 
   inline fun <C> bifoldRight(
     c: Eval<C>,
-    fa: (A, Eval<C>) -> Eval<C>,
-    fe: (E, Eval<C>) -> Eval<C>
+    fe: (E, Eval<C>) -> Eval<C>,
+    fa: (A, Eval<C>) -> Eval<C>
   ): Eval<C> =
     fold({ fe(it, c) }, { fa(it, c) })
 
-  inline fun <C> bifoldMap(MN: Monoid<C>, f: (A) -> C, g: (E) -> C) = MN.run {
-    bifoldLeft(MN.empty(), { c, a -> c.combine(f(a)) }, { c, b -> c.combine(g(b)) })
+  inline fun <C> bifoldMap(MN: Monoid<C>, g: (E) -> C, f: (A) -> C) = MN.run {
+    bifoldLeft(MN.empty(), { c, b -> c.combine(g(b)) }) { c, a -> c.combine(f(a)) }
   }
 
-  fun <C, D> bitraverse(fa: (A) -> Iterable<D>, fe: (E) -> Iterable<C>): List<Validated<C, D>> =
+  fun <C, D> bitraverse(fe: (E) -> Iterable<C>, fa: (A) -> Iterable<D>): List<Validated<C, D>> =
     fold({ fe(it).map { Invalid(it) } }, { fa(it).map { Valid(it) } })
 
   fun <C, D, EE> bitraverseEither(
-    fa: (A) -> Either<EE, C>,
-    fe: (E) -> Either<EE, D>
+    fe: (E) -> Either<EE, D>,
+    fa: (A) -> Either<EE, C>
   ): Either<EE, Validated<D, C>> =
     fold({ fe(it).map { Invalid(it) } }, { fa(it).map { Valid(it) } })
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -226,7 +226,7 @@ inline fun <E, A> ValidatedOf<E, A>.fix(): Validated<E, A> =
  * The above function can be rewritten as follows:
  *
  * ```kotlin:ank:silent
- * import arrow.core.Validate
+ * import arrow.core.Validated
  * import arrow.core.validNel
  * import arrow.core.extensions.nonemptylist.semigroup.semigroup
  *

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -1314,87 +1314,59 @@ fun <E, A, B> Validated<E, A>.product(SE: Semigroup<E>, fb: Validated<E, B>): Va
 fun <E, A, B, Z> Validated<E, A>.map2(SE: Semigroup<E>, fb: Validated<E, B>, f: (Tuple2<A, B>) -> Z): Validated<E, Z> =
   product(SE, fb).map(f)
 
+@JvmName("product3")
 fun <EE, A, B, Z> Validated<EE, Tuple2<A, B>>.product(
   SE: Semigroup<EE>,
   other: Validated<EE, Z>,
-  dummyImplicit: Unit = Unit
 ): Validated<EE, Tuple3<A, B, Z>> =
   map2(SE, other) { (ab, c) -> Tuple3(ab.a, ab.b, c) }
 
+@JvmName("product4")
 fun <EE, A, B, C, Z> Validated<EE, Tuple3<A, B, C>>.product(
   SE: Semigroup<EE>,
   other: Validated<EE, Z>,
-  dummyImplicit: Unit = Unit,
-  dummyImplicit2: Unit = Unit
 ): Validated<EE, Tuple4<A, B, C, Z>> =
   map2(SE, other) { (abc, d) -> Tuple4(abc.a, abc.b, abc.c, d) }
 
+@JvmName("product5")
 fun <EE, A, B, C, D, Z> Validated<EE, Tuple4<A, B, C, D>>.product(
   SE: Semigroup<EE>,
   other: Validated<EE, Z>,
-  dummyImplicit: Unit = Unit,
-  dummyImplicit2: Unit = Unit,
-  dummyImplicit3: Unit = Unit
 ): Validated<EE, Tuple5<A, B, C, D, Z>> =
   map2(SE, other) { (abcd, e) -> Tuple5(abcd.a, abcd.b, abcd.c, abcd.d, e) }
 
+@JvmName("product6")
 fun <EE, A, B, C, D, E, Z> Validated<EE, Tuple5<A, B, C, D, E>>.product(
   SE: Semigroup<EE>,
   other: Validated<EE, Z>,
-  dummyImplicit: Unit = Unit,
-  dummyImplicit2: Unit = Unit,
-  dummyImplicit3: Unit = Unit,
-  dummyImplicit4: Unit = Unit
 ): Validated<EE, Tuple6<A, B, C, D, E, Z>> =
   map2(SE, other) { (abcde, f) -> Tuple6(abcde.a, abcde.b, abcde.c, abcde.d, abcde.e, f) }
 
+@JvmName("product7")
 fun <EE, A, B, C, D, E, FF, Z> Validated<EE, Tuple6<A, B, C, D, E, FF>>.product(
   SE: Semigroup<EE>,
   other: Validated<EE, Z>,
-  dummyImplicit: Unit = Unit,
-  dummyImplicit2: Unit = Unit,
-  dummyImplicit3: Unit = Unit,
-  dummyImplicit4: Unit = Unit,
-  dummyImplicit5: Unit = Unit
 ): Validated<EE, Tuple7<A, B, C, D, E, FF, Z>> =
   map2(SE, other) { (abcdef, g) -> Tuple7(abcdef.a, abcdef.b, abcdef.c, abcdef.d, abcdef.e, abcdef.f, g) }
 
+@JvmName("product8")
 fun <EE, A, B, C, D, E, FF, G, Z> Validated<EE, Tuple7<A, B, C, D, E, FF, G>>.product(
   SE: Semigroup<EE>,
   other: Validated<EE, Z>,
-  dummyImplicit: Unit = Unit,
-  dummyImplicit2: Unit = Unit,
-  dummyImplicit3: Unit = Unit,
-  dummyImplicit4: Unit = Unit,
-  dummyImplicit5: Unit = Unit,
-  dummyImplicit6: Unit = Unit
 ): Validated<EE, Tuple8<A, B, C, D, E, FF, G, Z>> =
   map2(SE, other) { (abcdefg, h) -> Tuple8(abcdefg.a, abcdefg.b, abcdefg.c, abcdefg.d, abcdefg.e, abcdefg.f, abcdefg.g, h) }
 
+@JvmName("product9")
 fun <EE, A, B, C, D, E, FF, G, H, Z> Validated<EE, Tuple8<A, B, C, D, E, FF, G, H>>.product(
   SE: Semigroup<EE>,
   other: Validated<EE, Z>,
-  dummyImplicit: Unit = Unit,
-  dummyImplicit2: Unit = Unit,
-  dummyImplicit3: Unit = Unit,
-  dummyImplicit4: Unit = Unit,
-  dummyImplicit5: Unit = Unit,
-  dummyImplicit6: Unit = Unit,
-  dummyImplicit7: Unit = Unit
 ): Validated<EE, Tuple9<A, B, C, D, E, FF, G, H, Z>> =
   map2(SE, other) { (abcdefgh, i) -> Tuple9(abcdefgh.a, abcdefgh.b, abcdefgh.c, abcdefgh.d, abcdefgh.e, abcdefgh.f, abcdefgh.g, abcdefgh.h, i) }
 
+@JvmName("product10")
 fun <EE, A, B, C, D, E, FF, G, H, I, Z> Validated<EE, Tuple9<A, B, C, D, E, FF, G, H, I>>.product(
   SE: Semigroup<EE>,
   other: Validated<EE, Z>,
-  dummyImplicit: Unit = Unit,
-  dummyImplicit2: Unit = Unit,
-  dummyImplicit3: Unit = Unit,
-  dummyImplicit4: Unit = Unit,
-  dummyImplicit5: Unit = Unit,
-  dummyImplicit6: Unit = Unit,
-  dummyImplicit7: Unit = Unit,
-  dummyImplicit9: Unit = Unit
 ): Validated<EE, Tuple10<A, B, C, D, E, FF, G, H, I, Z>> =
   map2(SE, other) { (abcdefghi, j) -> Tuple10(abcdefghi.a, abcdefghi.b, abcdefghi.c, abcdefghi.d, abcdefghi.e, abcdefghi.f, abcdefghi.g, abcdefghi.h, abcdefghi.i, j) }
 

--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Applicative.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Applicative.kt
@@ -28,6 +28,7 @@ interface Applicative<F> : Apply<F> {
     else mapN(this@replicate, replicate(n - 1, MA)) { (a, xs) -> MA.run { a + xs } }
 }
 
+@Deprecated("Applicative typeclasses is deprecated")
 fun <F, A> Monoid<A>.lift(ap: Applicative<F>): Monoid<Kind<F, A>> = object : Monoid<Kind<F, A>> {
   override fun empty(): Kind<F, A> = ap.just(this@lift.empty())
   override fun Kind<F, A>.combine(b: Kind<F, A>): Kind<F, A> = with(ap) { map2(b) { it.a.combine(it.b) } }

--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/EqK.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/EqK.kt
@@ -5,6 +5,7 @@ import arrow.Kind
 /**
  * The `EqK` typeclass abstracts the ability to lift the Eq class to unary type constructors.
  */
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
 interface EqK<F> {
 
   /**

--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/EqK2.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/EqK2.kt
@@ -5,6 +5,7 @@ import arrow.Kind2
 /**
  * The `EqK2` typeclass abstracts the ability to lift the Eq class to binary type constructors.
  */
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
 interface EqK2<F> {
 
   /**

--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Functor.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Functor.kt
@@ -135,10 +135,6 @@ interface Functor<F> : Invariant<F> {
   fun <A> Kind<F, A>.void(): Kind<F, Unit> =
     map { Unit }
 
-  @Deprecated("Deprecated due to collision with Applicative's unit(), use void() instead", ReplaceWith("void()"), DeprecationLevel.ERROR)
-  fun <A> Kind<F, A>.unit(): Kind<F, Unit> =
-    void()
-
   /**
    * Applies [f] to an [A] inside [F] and returns the [F] structure with a tuple of the [A] value and the
    * computed [B] value as result of applying [f]

--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Functor.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Functor.kt
@@ -135,6 +135,10 @@ interface Functor<F> : Invariant<F> {
   fun <A> Kind<F, A>.void(): Kind<F, Unit> =
     map { Unit }
 
+  @Deprecated("Deprecated due to collision with Applicative's unit(), use void() instead", ReplaceWith("void()"), DeprecationLevel.ERROR)
+  fun <A> Kind<F, A>.unit(): Kind<F, Unit> =
+    void()
+
   /**
    * Applies [f] to an [A] inside [F] and returns the [F] structure with a tuple of the [A] value and the
    * computed [B] value as result of applying [f]

--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Functor.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Functor.kt
@@ -135,10 +135,6 @@ interface Functor<F> : Invariant<F> {
   fun <A> Kind<F, A>.void(): Kind<F, Unit> =
     map { Unit }
 
-  @Deprecated("Deprecated due to collision with Applicative's unit(), use void() instead", ReplaceWith("void()"))
-  fun <A> Kind<F, A>.unit(): Kind<F, Unit> =
-    void()
-
   /**
    * Applies [f] to an [A] inside [F] and returns the [F] structure with a tuple of the [A] value and the
    * computed [B] value as result of applying [f]

--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Hash.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Hash.kt
@@ -135,4 +135,4 @@ private fun Int.combineHashes(h: Int): Int = (this * 16777619) xor h
  */
 fun Int.hashWithSalt(salt: Int): Int = salt.combineHashes(this.hashCode())
 
-private const val defaultSalt: Int = 0x087fc72c
+internal const val defaultSalt: Int = 0x087fc72c

--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/SemigroupK.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/SemigroupK.kt
@@ -5,6 +5,7 @@ import arrow.Kind
 /**
  * ank_macro_hierarchy(arrow.typeclasses.SemigroupK)
  */
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
 interface SemigroupK<F> {
 
   /**

--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Traverse.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Traverse.kt
@@ -332,7 +332,7 @@ import arrow.core.ValidatedNel
  * fun main() {
  *   //sampleStart
  *   val validatedList = listOf("1", "22w", "3", "33s").k()
- *     .traverse(ValidatedNel.applicative(Nel.semigroup<NumberFormatException>()), ::parseIntValidated).fix()
+ *     .traverse(ValidatedNel.applicative(Nel.semigroup<NumberFormatException>()), ::parseIntValidated)
  *   //sampleEnd
  *   println(validatedList)
  * }

--- a/arrow-core-test/src/main/kotlin/arrow/core/test/laws/FunctorLaws.kt
+++ b/arrow-core-test/src/main/kotlin/arrow/core/test/laws/FunctorLaws.kt
@@ -79,12 +79,12 @@ object FunctorLaws {
 
   fun <F> Functor<F>.unitIdentity(G: Gen<Kind<F, Int>>, EQ: Eq<Kind<F, Unit>>): Unit =
     forAll(G) { fa: Kind<F, Int> ->
-      fa.unit().equalUnderTheLaw(fa.map { Unit }, EQ)
+      fa.void().equalUnderTheLaw(fa.map { Unit }, EQ)
     }
 
   fun <F> Functor<F>.unitComposition(G: Gen<Kind<F, Int>>, EQ: Eq<Kind<F, Unit>>): Unit =
     forAll(G) { fa: Kind<F, Int> ->
-      fa.unit().unit().equalUnderTheLaw(fa.map { Unit }, EQ)
+      fa.void().void().equalUnderTheLaw(fa.map { Unit }, EQ)
     }
 
   fun <F> Functor<F>.fproductIdentity(G: Gen<Kind<F, Int>>, EQ: Eq<Kind<F, Tuple2<Int, String>>>): Unit =

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated.kt
@@ -133,7 +133,6 @@ interface ValidatedSemigroupK<E> : SemigroupK<ValidatedPartialOf<E>> {
     fix().combineK(SE(), y)
 }
 
-@extension
 interface ValidatedEq<L, R> : Eq<Validated<L, R>> {
 
   fun EQL(): Eq<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated.kt
@@ -20,7 +20,6 @@ import arrow.core.extensions.nonemptylist.semigroup.semigroup
 import arrow.core.extensions.validated.applicative.applicative
 import arrow.core.extensions.validated.eq.eq
 import arrow.core.fix
-import arrow.extension
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.ApplicativeError
 import arrow.typeclasses.Bifoldable
@@ -39,23 +38,18 @@ import arrow.typeclasses.SemigroupK
 import arrow.typeclasses.Show
 import arrow.typeclasses.Traverse
 import arrow.typeclasses.hashWithSalt
-import arrow.undocumented
 import arrow.core.handleErrorWith as validatedHandleErrorWith
 import arrow.core.traverse as validatedTraverse
 
-@extension
-@undocumented
 interface ValidatedFunctor<E> : Functor<ValidatedPartialOf<E>> {
   override fun <A, B> Kind<ValidatedPartialOf<E>, A>.map(f: (A) -> B): Validated<E, B> = fix().map(f)
 }
 
-@extension
 interface ValidatedBifunctor : Bifunctor<ForValidated> {
   override fun <A, B, C, D> ValidatedOf<A, B>.bimap(fl: (A) -> C, fr: (B) -> D): Validated<C, D> =
     fix().bimap(fl, fr)
 }
 
-@extension
 interface ValidatedApplicative<E> : Applicative<ValidatedPartialOf<E>>, ValidatedFunctor<E> {
 
   fun SE(): Semigroup<E>
@@ -67,7 +61,6 @@ interface ValidatedApplicative<E> : Applicative<ValidatedPartialOf<E>>, Validate
   override fun <A, B> Kind<ValidatedPartialOf<E>, A>.ap(ff: Kind<ValidatedPartialOf<E>, (A) -> B>): Validated<E, B> = fix().ap(SE(), ff.fix())
 }
 
-@extension
 interface ValidatedSelective<E> : Selective<ValidatedPartialOf<E>>, ValidatedApplicative<E> {
 
   override fun SE(): Semigroup<E>
@@ -76,7 +69,6 @@ interface ValidatedSelective<E> : Selective<ValidatedPartialOf<E>>, ValidatedApp
     fix().fold({ Invalid(it) }, { it.fold({ l -> f.map { ff -> ff(l) } }, { r -> just(r) }) })
 }
 
-@extension
 interface ValidatedApplicativeError<E> : ApplicativeError<ValidatedPartialOf<E>, E>, ValidatedApplicative<E> {
 
   override fun SE(): Semigroup<E>
@@ -87,7 +79,6 @@ interface ValidatedApplicativeError<E> : ApplicativeError<ValidatedPartialOf<E>,
     fix().validatedHandleErrorWith(f)
 }
 
-@extension
 interface ValidatedFoldable<E> : Foldable<ValidatedPartialOf<E>> {
 
   override fun <A, B> Kind<ValidatedPartialOf<E>, A>.foldLeft(b: B, f: (B, A) -> B): B =
@@ -97,14 +88,12 @@ interface ValidatedFoldable<E> : Foldable<ValidatedPartialOf<E>> {
     fix().foldRight(lb, f)
 }
 
-@extension
 interface ValidatedTraverse<E> : Traverse<ValidatedPartialOf<E>>, ValidatedFoldable<E> {
 
   override fun <G, A, B> Kind<ValidatedPartialOf<E>, A>.traverse(AP: Applicative<G>, f: (A) -> Kind<G, B>): Kind<G, Validated<E, B>> =
     fix().validatedTraverse(AP, f)
 }
 
-@extension
 interface ValidatedBifoldable : Bifoldable<ForValidated> {
   override fun <A, B, C> ValidatedOf<A, B>.bifoldLeft(c: C, f: (C, A) -> C, g: (C, B) -> C): C =
     fix().fold({ f(c, it) }, { g(c, it) })
@@ -113,7 +102,6 @@ interface ValidatedBifoldable : Bifoldable<ForValidated> {
     fix().fold({ f(it, c) }, { g(it, c) })
 }
 
-@extension
 interface ValidatedBitraverse : Bitraverse<ForValidated>, ValidatedBifoldable {
   override fun <G, A, B, C, D> ValidatedOf<A, B>.bitraverse(AP: Applicative<G>, f: (A) -> Kind<G, C>, g: (B) -> Kind<G, D>): Kind<G, ValidatedOf<C, D>> =
     fix().let {
@@ -124,7 +112,6 @@ interface ValidatedBitraverse : Bitraverse<ForValidated>, ValidatedBifoldable {
     }
 }
 
-@extension
 interface ValidatedSemigroupK<E> : SemigroupK<ValidatedPartialOf<E>> {
 
   fun SE(): Semigroup<E>
@@ -151,7 +138,6 @@ interface ValidatedEq<L, R> : Eq<Validated<L, R>> {
   }
 }
 
-@extension
 interface ValidatedEqK<L> : EqK<ValidatedPartialOf<L>> {
   fun EQL(): Eq<L>
 
@@ -161,7 +147,6 @@ interface ValidatedEqK<L> : EqK<ValidatedPartialOf<L>> {
     }
 }
 
-@extension
 interface ValidatedEqK2 : EqK2<ForValidated> {
   override fun <A, B> Kind2<ForValidated, A, B>.eqK(other: Kind2<ForValidated, A, B>, EQA: Eq<A>, EQB: Eq<B>): Boolean =
     (this.fix() to other.fix()).let {
@@ -171,14 +156,12 @@ interface ValidatedEqK2 : EqK2<ForValidated> {
     }
 }
 
-@extension
 interface ValidatedShow<L, R> : Show<Validated<L, R>> {
   fun SL(): Show<L>
   fun SR(): Show<R>
   override fun Validated<L, R>.show(): String = show(SL(), SR())
 }
 
-@extension
 interface ValidatedHash<L, R> : Hash<Validated<L, R>> {
   fun HL(): Hash<L>
   fun HR(): Hash<R>
@@ -190,7 +173,6 @@ interface ValidatedHash<L, R> : Hash<Validated<L, R>> {
     )
 }
 
-@extension
 interface ValidatedOrder<L, R> : Order<Validated<L, R>> {
   fun OL(): Order<L>
   fun OR(): Order<R>
@@ -201,5 +183,6 @@ interface ValidatedOrder<L, R> : Order<Validated<L, R>> {
   })
 }
 
+@Deprecated("Applicative typeclasses is deprecated. Use concrete methods on Validated")
 fun <E> Validated.Companion.applicativeNel(): ValidatedApplicative<NonEmptyList<E>> =
   Validated.applicative(NonEmptyList.semigroup())

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/applicative/ValidatedApplicative.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/applicative/ValidatedApplicative.kt
@@ -1,0 +1,87 @@
+package arrow.core.extensions.validated.applicative
+
+import arrow.Kind
+import arrow.core.ForValidated
+import arrow.core.Validated
+import arrow.core.Validated.Companion
+import arrow.core.extensions.ValidatedApplicative
+import arrow.core.fix
+import arrow.core.valid
+import arrow.core.replicate as _replicate
+import arrow.typeclasses.Monoid
+import arrow.typeclasses.Semigroup
+import kotlin.Function1
+import kotlin.Int
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.List
+import kotlin.jvm.JvmName
+
+@JvmName("just1")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("valid<A>()", "arrow.core.valid"))
+fun <E, A> A.just(SE: Semigroup<E>): Validated<E, A> =
+  valid()
+
+@JvmName("unit")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.unit<E>()", "arrow.core.Validated"))
+fun <E> unit(SE: Semigroup<E>): Validated<E, Unit> =
+  Validated.unit()
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("map(arg1)"))
+fun <E, A, B> Kind<Kind<ForValidated, E>, A>.map(SE: Semigroup<E>, arg1: Function1<A, B>):
+    Validated<E, B> = arrow.core.Validated.applicative<E>(SE).run {
+  this@map.map<A, B>(arg1) as arrow.core.Validated<E, B>
+}
+
+@JvmName("replicate")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("replicate(SE, arg1)", "arrow.core.replicate"))
+fun <E, A> Kind<Kind<ForValidated, E>, A>.replicate(SE: Semigroup<E>, arg1: Int): Validated<E, List<A>> =
+  fix()._replicate(SE, arg1)
+
+@JvmName("replicate")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("replicate(SE, arg1, arg2)", "arrow.core.replicate"))
+fun <E, A> Kind<Kind<ForValidated, E>, A>.replicate(
+  SE: Semigroup<E>,
+  arg1: Int,
+  arg2: Monoid<A>
+): Validated<E, A> = fix()._replicate(SE, arg1, arg2)
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated("Applicative typeclasses is deprecated. Use concrete methods on Validated")
+inline fun <E> Companion.applicative(SE: Semigroup<E>): ValidatedApplicative<E> = object :
+    arrow.core.extensions.ValidatedApplicative<E> { override fun SE():
+    arrow.typeclasses.Semigroup<E> = SE }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/applicative/ValidatedApplicative.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/applicative/ValidatedApplicative.kt
@@ -48,9 +48,7 @@ fun <E> unit(SE: Semigroup<E>): Validated<E, Unit> =
 )
 @Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("map(arg1)"))
 fun <E, A, B> Kind<Kind<ForValidated, E>, A>.map(SE: Semigroup<E>, arg1: Function1<A, B>):
-    Validated<E, B> = arrow.core.Validated.applicative<E>(SE).run {
-  this@map.map<A, B>(arg1) as arrow.core.Validated<E, B>
-}
+    Validated<E, B> = fix().map(arg1)
 
 @JvmName("replicate")
 @Suppress(

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/applicativeError/ValidatedApplicativeError.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/applicativeError/ValidatedApplicativeError.kt
@@ -125,7 +125,6 @@ fun <E, A> catch(
   "UNUSED_PARAMETER"
 )
 
-
 @Deprecated("This methods is invalid for Validated. ApplicativeError<F, Throwable> is inconsistent in `F`")
 fun <E, A> ApplicativeError<Kind<ForValidated, E>, Throwable>.catch(
   SE: Semigroup<E>,

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/applicativeError/ValidatedApplicativeError.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/applicativeError/ValidatedApplicativeError.kt
@@ -1,0 +1,178 @@
+package arrow.core.extensions.validated.applicativeError
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.ForOption
+import arrow.core.ForValidated
+import arrow.core.Validated
+import arrow.core.handleErrorWith as _handleErrorWith
+import arrow.core.handleError as _handleError
+import arrow.core.attempt as _attempt
+import arrow.core.Validated.Companion
+import arrow.core.extensions.ValidatedApplicativeError
+import arrow.core.fix
+import arrow.core.invalid
+import arrow.core.redeem
+import arrow.typeclasses.ApplicativeError
+import arrow.typeclasses.Semigroup
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.jvm.JvmName
+
+@JvmName("handleErrorWith")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("handleErrorWith(arg1)", "arrow.core.handleErrorWith"))
+fun <E, A> Kind<Kind<ForValidated, E>, A>.handleErrorWith(SE: Semigroup<E>, arg1: Function1<E, Kind<Kind<ForValidated, E>, A>>): Validated<E, A> =
+  fix()._handleErrorWith(arg1)
+
+@JvmName("raiseError1")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("invalid()", "arrow.core.invalid"))
+fun <E, A> E.raiseError(SE: Semigroup<E>): Validated<E, A> =
+  invalid()
+
+@JvmName("fromOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.fromOption(this, arg1)", "arrow.core.fromOption"))
+fun <E, A> Kind<ForOption, A>.fromOption(SE: Semigroup<E>, arg1: Function0<E>): Validated<E, A> =
+  Validated.fromOption(fix(), arg1)
+
+@JvmName("fromEither")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.fromEither(this).mapLeft(arg1)", "arrow.core.fromEither"))
+fun <E, A, EE> Either<EE, A>.fromEither(SE: Semigroup<E>, arg1: Function1<EE, E>): Validated<E, A> =
+  Validated.fromEither(this).mapLeft(arg1)
+
+@JvmName("handleError")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("handleError(arg1)", "arrow.core.handleError"))
+fun <E, A> Kind<Kind<ForValidated, E>, A>.handleError(SE: Semigroup<E>, arg1: Function1<E, A>): Validated<E, A> =
+  fix()._handleError(arg1)
+
+@JvmName("redeem")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("redeem(arg1, arg2)", "arrow.core.redeem"))
+fun <E, A, B> Kind<Kind<ForValidated, E>, A>.redeem(
+  SE: Semigroup<E>,
+  arg1: Function1<E, B>,
+  arg2: Function1<A, B>
+): Validated<E, B> =
+  fix().redeem(arg1, arg2)
+
+@JvmName("attempt")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("attempt()", "arrow.core.attempt"))
+fun <E, A> Kind<Kind<ForValidated, E>, A>.attempt(SE: Semigroup<E>): Validated<E, Either<E, A>> =
+  fix()._attempt()
+
+@JvmName("catch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.catch(arg0, arg1)", "arrow.core.catch"))
+fun <E, A> catch(
+  SE: Semigroup<E>,
+  arg0: Function1<Throwable, E>,
+  arg1: Function0<A>
+): Validated<E, A> =
+  Validated.catch(arg0, arg1)
+
+@JvmName("catch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+// TODO check signature. Should return Validated<Throwable, A>
+// The `ApplicativeError<Kind<ForValidated, E>, Throwable>` instance doens't exist for Validated, only `ApplicativeError<Kind<ForValidated, Throwable>, Throwable>`
+// @Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.catch(arg0, arg1)", "arrow.core.catch"))
+fun <E, A> ApplicativeError<Kind<ForValidated, E>, Throwable>.catch(
+  SE: Semigroup<E>,
+  arg1: Function0<A>
+): Validated<E, A> = arrow.core.Validated.applicativeError<E>(SE).run {
+  this@catch.catch<A>(arg1) as arrow.core.Validated<E, A>
+}
+
+@JvmName("effectCatch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.catch(arg0, arg1)", "arrow.core.catch"))
+suspend fun <E, A> effectCatch(
+  SE: Semigroup<E>,
+  arg0: Function1<Throwable, E>,
+  arg1: suspend () -> A
+): Validated<E, A> = arrow.core.Validated
+  .applicativeError<E>(SE)
+  .effectCatch<A>(arg0, arg1) as arrow.core.Validated<E, A>
+
+@JvmName("effectCatch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+// TODO check signature. Should return Validated<Throwable, A>
+// The `ApplicativeError<Kind<ForValidated, E>, Throwable>` instance doens't exist for Validated, only `ApplicativeError<Kind<ForValidated, Throwable>, Throwable>`
+suspend fun <E, F, A> ApplicativeError<F, Throwable>.effectCatch(
+  SE: Semigroup<E>,
+  arg1: suspend () -> A
+): Kind<F, A> = arrow.core.Validated.applicativeError<E>(SE).run {
+  this@effectCatch.effectCatch<F, A>(arg1) as arrow.Kind<F, A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated("ApplicativeError typeclasses is deprecated. Use concrete methods on Validated")
+inline fun <E> Companion.applicativeError(SE: Semigroup<E>): ValidatedApplicativeError<E> = object :
+  arrow.core.extensions.ValidatedApplicativeError<E> {
+  override fun SE():
+    arrow.typeclasses.Semigroup<E> = SE
+}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/applicativeError/ValidatedApplicativeError.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/applicativeError/ValidatedApplicativeError.kt
@@ -110,7 +110,7 @@ fun <E, A> Kind<Kind<ForValidated, E>, A>.attempt(SE: Semigroup<E>): Validated<E
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-//@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.catch(arg0, arg1)", "arrow.core.catch"))
+// @Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.catch(arg0, arg1)", "arrow.core.catch"))
 // TODO refactor suspend fun Validated.catch to inline fun Validated.catch, binary breaking
 fun <E, A> catch(
   SE: Semigroup<E>,
@@ -146,7 +146,7 @@ fun <E, A> ApplicativeError<Kind<ForValidated, E>, Throwable>.catch(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-//@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.catch(arg0) { arg1() } ", "arrow.core.catch"))
+// @Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.catch(arg0) { arg1() } ", "arrow.core.catch"))
 // TODO refactor suspend fun Validated.catch to inline fun Validated.catch, binary breaking
 suspend fun <E, A> effectCatch(
   SE: Semigroup<E>,

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/applicativeError/ValidatedApplicativeError.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/applicativeError/ValidatedApplicativeError.kt
@@ -141,14 +141,12 @@ fun <E, A> ApplicativeError<Kind<ForValidated, E>, Throwable>.catch(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.catch(arg0, arg1)", "arrow.core.catch"))
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.catch(arg0) { arg1() } ", "arrow.core.catch"))
 suspend fun <E, A> effectCatch(
   SE: Semigroup<E>,
   arg0: Function1<Throwable, E>,
   arg1: suspend () -> A
-): Validated<E, A> = arrow.core.Validated
-  .applicativeError<E>(SE)
-  .effectCatch<A>(arg0, arg1) as arrow.core.Validated<E, A>
+): Validated<E, A> = Validated.catch(arg0) { arg1() }
 
 @JvmName("effectCatch")
 @Suppress(

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/applicativeError/ValidatedApplicativeError.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/applicativeError/ValidatedApplicativeError.kt
@@ -13,7 +13,6 @@ import arrow.core.extensions.ValidatedApplicativeError
 import arrow.core.fix
 import arrow.core.invalid
 import arrow.core.redeem
-import arrow.core.valid
 import arrow.typeclasses.ApplicativeError
 import arrow.typeclasses.Semigroup
 import kotlin.Function0
@@ -110,18 +109,13 @@ fun <E, A> Kind<Kind<ForValidated, E>, A>.attempt(SE: Semigroup<E>): Validated<E
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-// @Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.catch(arg0, arg1)", "arrow.core.catch"))
-// TODO refactor suspend fun Validated.catch to inline fun Validated.catch, binary breaking
+ @Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.catch(arg0, arg1)", "arrow.core.catch"))
 fun <E, A> catch(
   SE: Semigroup<E>,
   arg0: Function1<Throwable, E>,
   arg1: Function0<A>
 ): Validated<E, A> =
-  try {
-    arg1.invoke().valid()
-  } catch (e: Throwable) {
-    arg0.invoke(e).invalid()
-  }
+  Companion.catch(arg0, arg1)
 
 @JvmName("catch")
 @Suppress(
@@ -130,7 +124,6 @@ fun <E, A> catch(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-
 @Deprecated("This methods is invalid for Validated. ApplicativeError<F, Throwable> is inconsistent in `F`")
 fun <E, A> ApplicativeError<Kind<ForValidated, E>, Throwable>.catch(
   SE: Semigroup<E>,
@@ -146,13 +139,13 @@ fun <E, A> ApplicativeError<Kind<ForValidated, E>, Throwable>.catch(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
- @Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.catch(arg1).mapLeft(arg0)", "arrow.core.catch"))
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.catch(arg0) { arg1() }", "arrow.core.catch"))
 suspend fun <E, A> effectCatch(
   SE: Semigroup<E>,
   arg0: Function1<Throwable, E>,
   arg1: suspend () -> A
 ): Validated<E, A> =
-  Validated.catch(arg1).mapLeft(arg0)
+   Validated.catch(arg0) { arg1() }
 
 @JvmName("effectCatch")
 @Suppress(

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/applicativeError/ValidatedApplicativeError.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/applicativeError/ValidatedApplicativeError.kt
@@ -146,17 +146,13 @@ fun <E, A> ApplicativeError<Kind<ForValidated, E>, Throwable>.catch(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-// @Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.catch(arg0) { arg1() } ", "arrow.core.catch"))
-// TODO refactor suspend fun Validated.catch to inline fun Validated.catch, binary breaking
+ @Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.catch(arg1).mapLeft(arg0)", "arrow.core.catch"))
 suspend fun <E, A> effectCatch(
   SE: Semigroup<E>,
   arg0: Function1<Throwable, E>,
   arg1: suspend () -> A
-): Validated<E, A> = try {
-  arg1.invoke().valid()
-} catch (e: Throwable) {
-  arg0.invoke(e).invalid()
-}
+): Validated<E, A> =
+  Validated.catch(arg1).mapLeft(arg0)
 
 @JvmName("effectCatch")
 @Suppress(

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/applicativeError/ValidatedApplicativeError.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/applicativeError/ValidatedApplicativeError.kt
@@ -124,9 +124,9 @@ fun <E, A> catch(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-// TODO check signature. Should return Validated<Throwable, A>
-// The `ApplicativeError<Kind<ForValidated, E>, Throwable>` instance doens't exist for Validated, only `ApplicativeError<Kind<ForValidated, Throwable>, Throwable>`
-// @Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.catch(arg0, arg1)", "arrow.core.catch"))
+
+
+@Deprecated("This methods is invalid for Validated. ApplicativeError<F, Throwable> is inconsistent in `F`")
 fun <E, A> ApplicativeError<Kind<ForValidated, E>, Throwable>.catch(
   SE: Semigroup<E>,
   arg1: Function0<A>
@@ -157,8 +157,7 @@ suspend fun <E, A> effectCatch(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-// TODO check signature. Should return Validated<Throwable, A>
-// The `ApplicativeError<Kind<ForValidated, E>, Throwable>` instance doens't exist for Validated, only `ApplicativeError<Kind<ForValidated, Throwable>, Throwable>`
+@Deprecated("This methods is invalid for Validated. ApplicativeError<F, Throwable> is inconsistent in `F`")
 suspend fun <E, F, A> ApplicativeError<F, Throwable>.effectCatch(
   SE: Semigroup<E>,
   arg1: suspend () -> A

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/applicativeError/ValidatedApplicativeError.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/applicativeError/ValidatedApplicativeError.kt
@@ -13,6 +13,7 @@ import arrow.core.extensions.ValidatedApplicativeError
 import arrow.core.fix
 import arrow.core.invalid
 import arrow.core.redeem
+import arrow.core.valid
 import arrow.typeclasses.ApplicativeError
 import arrow.typeclasses.Semigroup
 import kotlin.Function0
@@ -109,13 +110,18 @@ fun <E, A> Kind<Kind<ForValidated, E>, A>.attempt(SE: Semigroup<E>): Validated<E
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.catch(arg0, arg1)", "arrow.core.catch"))
+//@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.catch(arg0, arg1)", "arrow.core.catch"))
+// TODO refactor suspend fun Validated.catch to inline fun Validated.catch, binary breaking
 fun <E, A> catch(
   SE: Semigroup<E>,
   arg0: Function1<Throwable, E>,
   arg1: Function0<A>
 ): Validated<E, A> =
-  Validated.catch(arg0, arg1)
+  try {
+    arg1.invoke().valid()
+  } catch (e: Throwable) {
+    arg0.invoke(e).invalid()
+  }
 
 @JvmName("catch")
 @Suppress(
@@ -140,12 +146,17 @@ fun <E, A> ApplicativeError<Kind<ForValidated, E>, Throwable>.catch(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.catch(arg0) { arg1() } ", "arrow.core.catch"))
+//@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.catch(arg0) { arg1() } ", "arrow.core.catch"))
+// TODO refactor suspend fun Validated.catch to inline fun Validated.catch, binary breaking
 suspend fun <E, A> effectCatch(
   SE: Semigroup<E>,
   arg0: Function1<Throwable, E>,
   arg1: suspend () -> A
-): Validated<E, A> = Validated.catch(arg0) { arg1() }
+): Validated<E, A> = try {
+  arg1.invoke().valid()
+} catch (e: Throwable) {
+  arg0.invoke(e).invalid()
+}
 
 @JvmName("effectCatch")
 @Suppress(

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/bifoldable/ValidatedBifoldable.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/bifoldable/ValidatedBifoldable.kt
@@ -5,6 +5,7 @@ import arrow.core.Eval
 import arrow.core.ForValidated
 import arrow.core.Validated.Companion
 import arrow.core.extensions.ValidatedBifoldable
+import arrow.core.fix
 import arrow.typeclasses.Monoid
 import kotlin.Function1
 import kotlin.Function2
@@ -26,14 +27,13 @@ internal val bifoldable_singleton: ValidatedBifoldable = object :
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+
 @Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("bifoldLeft(arg1, arg2, arg3)"))
 fun <A, B, C> Kind<Kind<ForValidated, A>, B>.bifoldLeft(
   arg1: C,
   arg2: Function2<C, A, C>,
   arg3: Function2<C, B, C>
-): C = arrow.core.Validated.bifoldable().run {
-  this@bifoldLeft.bifoldLeft<A, B, C>(arg1, arg2, arg3) as C
-}
+): C = fix().bifoldLeft(arg1, arg2, arg3)
 
 @JvmName("bifoldRight")
 @Suppress(
@@ -47,9 +47,7 @@ fun <A, B, C> Kind<Kind<ForValidated, A>, B>.bifoldRight(
   arg1: Eval<C>,
   arg2: Function2<A, Eval<C>, Eval<C>>,
   arg3: Function2<B, Eval<C>, Eval<C>>
-): Eval<C> = arrow.core.Validated.bifoldable().run {
-  this@bifoldRight.bifoldRight<A, B, C>(arg1, arg2, arg3) as arrow.core.Eval<C>
-}
+): Eval<C> = fix().bifoldRight(arg1, arg2, arg3)
 
 @JvmName("bifoldMap")
 @Suppress(
@@ -63,9 +61,7 @@ fun <A, B, C> Kind<Kind<ForValidated, A>, B>.bifoldMap(
   arg1: Monoid<C>,
   arg2: Function1<A, C>,
   arg3: Function1<B, C>
-): C = arrow.core.Validated.bifoldable().run {
-  this@bifoldMap.bifoldMap<A, B, C>(arg1, arg2, arg3) as C
-}
+): C = fix().bifoldMap(arg1, arg2, arg3)
 
 @Suppress(
   "UNCHECKED_CAST",

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/bifoldable/ValidatedBifoldable.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/bifoldable/ValidatedBifoldable.kt
@@ -1,0 +1,75 @@
+package arrow.core.extensions.validated.bifoldable
+
+import arrow.Kind
+import arrow.core.Eval
+import arrow.core.ForValidated
+import arrow.core.Validated.Companion
+import arrow.core.extensions.ValidatedBifoldable
+import arrow.typeclasses.Monoid
+import kotlin.Function1
+import kotlin.Function2
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val bifoldable_singleton: ValidatedBifoldable = object :
+    arrow.core.extensions.ValidatedBifoldable {}
+
+@JvmName("bifoldLeft")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("bifoldLeft(arg1, arg2, arg3)"))
+fun <A, B, C> Kind<Kind<ForValidated, A>, B>.bifoldLeft(
+  arg1: C,
+  arg2: Function2<C, A, C>,
+  arg3: Function2<C, B, C>
+): C = arrow.core.Validated.bifoldable().run {
+  this@bifoldLeft.bifoldLeft<A, B, C>(arg1, arg2, arg3) as C
+}
+
+@JvmName("bifoldRight")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("bifoldRight(arg1, arg2, arg3)"))
+fun <A, B, C> Kind<Kind<ForValidated, A>, B>.bifoldRight(
+  arg1: Eval<C>,
+  arg2: Function2<A, Eval<C>, Eval<C>>,
+  arg3: Function2<B, Eval<C>, Eval<C>>
+): Eval<C> = arrow.core.Validated.bifoldable().run {
+  this@bifoldRight.bifoldRight<A, B, C>(arg1, arg2, arg3) as arrow.core.Eval<C>
+}
+
+@JvmName("bifoldMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("bifoldMap(arg1, arg2, arg3)"))
+fun <A, B, C> Kind<Kind<ForValidated, A>, B>.bifoldMap(
+  arg1: Monoid<C>,
+  arg2: Function1<A, C>,
+  arg3: Function1<B, C>
+): C = arrow.core.Validated.bifoldable().run {
+  this@bifoldMap.bifoldMap<A, B, C>(arg1, arg2, arg3) as C
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated("Bifoldable typeclasses is deprecated. Use concrete methods on Validated")
+inline fun Companion.bifoldable(): ValidatedBifoldable = bifoldable_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/bifunctor/ValidatedBifunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/bifunctor/ValidatedBifunctor.kt
@@ -1,0 +1,100 @@
+package arrow.core.extensions.validated.bifunctor
+
+import arrow.Kind
+import arrow.core.ForValidated
+import arrow.core.Validated
+import arrow.core.Validated.Companion
+import arrow.core.extensions.ValidatedBifunctor
+import arrow.core.fix
+import arrow.core.leftWiden
+import arrow.typeclasses.Conested
+import arrow.typeclasses.Functor
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val bifunctor_singleton: ValidatedBifunctor = object :
+  arrow.core.extensions.ValidatedBifunctor {}
+
+@JvmName("bimap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("bimap(arg1, arg2)"))
+fun <A, B, C, D> Kind<Kind<ForValidated, A>, B>.bimap(arg1: Function1<A, C>, arg2: Function1<B, D>): Validated<C, D> =
+  fix().bimap(arg1, arg2)
+
+@JvmName("lift")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.lift(arg0, arg1)", "arrow.core.lift"))
+fun <A, B, C, D> lift(arg0: Function1<A, C>, arg1: Function1<B, D>): Function1<Kind<Kind<ForValidated, A>, B>, Kind<Kind<ForValidated, C>, D>> = arrow.core.Validated
+  .bifunctor()
+  .lift<A, B, C, D>(arg0, arg1) as kotlin.Function1<arrow.Kind<arrow.Kind<arrow.core.ForValidated,
+  A>, B>, arrow.Kind<arrow.Kind<arrow.core.ForValidated, C>, D>>
+
+@JvmName("mapLeft")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("mapLeft(arg1)", "arrow.core.mapLeft"))
+fun <A, B, C> Kind<Kind<ForValidated, A>, B>.mapLeft(arg1: Function1<A, C>): Validated<C, B> =
+  fix().mapLeft(arg1)
+
+@JvmName("rightFunctor")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("Functor typeclasses is deprecated. Use concrete methods on Validated")
+fun <X> rightFunctor(): Functor<Kind<ForValidated, X>> = arrow.core.Validated
+  .bifunctor()
+  .rightFunctor<X>() as arrow.typeclasses.Functor<arrow.Kind<arrow.core.ForValidated, X>>
+
+@JvmName("leftFunctor")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("Functor typeclasses is deprecated. Use concrete methods on Validated")
+fun <X> leftFunctor(): Functor<Conested<ForValidated, X>> = arrow.core.Validated
+  .bifunctor()
+  .leftFunctor<X>() as
+  arrow.typeclasses.Functor<arrow.typeclasses.Conested<arrow.core.ForValidated, X>>
+
+@JvmName("leftWiden")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("leftWiden()", "arrow.core.leftWiden"))
+fun <AA, B, A : AA> Kind<Kind<ForValidated, A>, B>.leftWiden(): Validated<AA, B> =
+  fix().leftWiden()
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated("Functor typeclasses is deprecated. Use concrete methods on Validated")
+inline fun Companion.bifunctor(): ValidatedBifunctor = bifunctor_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/bitraverse/ValidatedBitraverse.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/bitraverse/ValidatedBitraverse.kt
@@ -1,0 +1,114 @@
+package arrow.core.extensions.validated.bitraverse
+
+import arrow.Kind
+import arrow.core.ForValidated
+import arrow.core.Validated
+import arrow.core.Validated.Companion
+import arrow.core.extensions.ValidatedBitraverse
+import arrow.core.fix
+import arrow.typeclasses.Applicative
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val bitraverse_singleton: ValidatedBitraverse = object :
+    arrow.core.extensions.ValidatedBitraverse {}
+
+@JvmName("bitraverse")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated. Replace with bitraverse or bitraverseEither from arrow.core.*")
+fun <G, A, B, C, D> Kind<Kind<ForValidated, A>, B>.bitraverse(
+  arg1: Applicative<G>,
+  arg2: Function1<A, Kind<G, C>>,
+  arg3: Function1<B, Kind<G, D>>
+): Kind<G, Kind<Kind<ForValidated, C>, D>> = arrow.core.Validated.bitraverse().run {
+  this@bitraverse.bitraverse<G, A, B, C, D>(arg1, arg2, arg3) as arrow.Kind<G,
+    arrow.Kind<arrow.Kind<arrow.core.ForValidated, C>, D>>
+}
+
+@JvmName("bisequence")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated. Replace with bisequence or bisequenceEither from arrow.core.*")
+fun <G, A, B> Kind<Kind<ForValidated, Kind<G, A>>, Kind<G, B>>.bisequence(arg1: Applicative<G>):
+    Kind<G, Kind<Kind<ForValidated, A>, B>> = arrow.core.Validated.bitraverse().run {
+  this@bisequence.bisequence<G, A, B>(arg1) as arrow.Kind<G,
+    arrow.Kind<arrow.Kind<arrow.core.ForValidated, A>, B>>
+}
+
+@JvmName("bimap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("bimap(arg1, arg2)"))
+fun <A, B, C, D> Kind<Kind<ForValidated, A>, B>.bimap(arg1: Function1<A, C>, arg2: Function1<B, D>): Validated<C, D> =
+  fix().bimap(arg1, arg2)
+
+/**
+ *  ank_macro_hierarchy(arrow.typeclasses.Bitraverse)
+ *
+ *  The type class `Bitraverse` defines the behaviour of two separetes `Traverse` over a data type.
+ *
+ *  Every instance of `Bitraverse<F>` must contains the next functions:
+ *
+ *  ## Bitraverse
+ *
+ *  `Bitraverse` perfoms a`Traverse` over both side of the Data type which is `Bifoldable`.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.core.*
+ *  import arrow.core.extensions.option.applicative.applicative
+ *  import arrow.core.extensions.*
+ *  import arrow.core.extensions.tuple2.bitraverse.bitraverse
+ *  fun main() {
+ *  //sampleStart
+ *  val f: (Int) -> Option<Int> = { Some(it + 1) }
+ * 3) }
+ *
+ *  val tuple = Tuple2(1, 2)
+ *  val bitraverseResult = tuple.bitraverse(Option.applicative(), f, g)
+ *  //sampleEnd
+ *  println(bitraverseResult)
+ *  }
+ *  ```
+ *
+ *  ## Bisequence
+ *
+ *  `Bisequence` invert the original structure `F<G<A,B>>` to `G<F<A>,F<B>>`
+ *  ```kotlin:ank:playground
+ *  import arrow.core.*
+ *  import arrow.core.extensions.*
+ *  import arrow.core.extensions.option.applicative.applicative
+ *  import arrow.core.extensions.tuple2.bitraverse.bisequence
+ *  fun main() {
+ *  //sampleStart
+ *  val tuple = Tuple2(Some(1), Some(2))
+ *  val sequenceResult = tuple.bisequence(Option.applicative())
+ *  //sampleEnd
+ *  println(sequenceResult)
+ *  }
+ *  ```
+ */
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated("Functor typeclasses is deprecated. Use concrete methods on Validated")
+inline fun Companion.bitraverse(): ValidatedBitraverse = bitraverse_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/bitraverse/ValidatedBitraverse.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/bitraverse/ValidatedBitraverse.kt
@@ -80,7 +80,7 @@ fun <A, B, C, D> Kind<Kind<ForValidated, A>, B>.bimap(arg1: Function1<A, C>, arg
  *  fun main() {
  *  //sampleStart
  *  val f: (Int) -> Option<Int> = { Some(it + 1) }
- * 3) }
+ *  val g: (Int) -> Option<Int> = { Some(it * 3) }
  *
  *  val tuple = Tuple2(1, 2)
  *  val bitraverseResult = tuple.bitraverse(Option.applicative(), f, g)

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/eq/ValidatedEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/eq/ValidatedEq.kt
@@ -1,0 +1,37 @@
+package arrow.core.extensions.validated.eq
+
+import arrow.core.Validated
+import arrow.core.Validated.Companion
+import arrow.core.extensions.ValidatedEq
+import arrow.typeclasses.Eq
+import kotlin.Boolean
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+@JvmName("neqv")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension projected functions are deprecated", ReplaceWith("neqv(EQL, EQR, arg1)", "arrow.core.neqv"))
+fun <L, R> Validated<L, R>.neqv(
+  EQL: Eq<L>,
+  EQR: Eq<R>,
+  arg1: Validated<L, R>
+): Boolean = arrow.core.Validated.eq<L, R>(EQL, EQR).run {
+  this@neqv.neqv(arg1) as kotlin.Boolean
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated("@extension projected functions are deprecated", ReplaceWith("eq(EQL, EQR)", "arrow.core.eq"))
+inline fun <L, R> Companion.eq(EQL: Eq<L>, EQR: Eq<R>): ValidatedEq<L, R> = object :
+  arrow.core.extensions.ValidatedEq<L, R> {
+  override fun EQL(): arrow.typeclasses.Eq<L> = EQL
+
+  override fun EQR(): arrow.typeclasses.Eq<R> = EQR
+}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/eq/ValidatedEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/eq/ValidatedEq.kt
@@ -3,6 +3,8 @@ package arrow.core.extensions.validated.eq
 import arrow.core.Validated
 import arrow.core.Validated.Companion
 import arrow.core.extensions.ValidatedEq
+import arrow.core.fix
+import arrow.core.neqv
 import arrow.typeclasses.Eq
 import kotlin.Boolean
 import kotlin.Suppress
@@ -20,9 +22,8 @@ fun <L, R> Validated<L, R>.neqv(
   EQL: Eq<L>,
   EQR: Eq<R>,
   arg1: Validated<L, R>
-): Boolean = arrow.core.Validated.eq<L, R>(EQL, EQR).run {
-  this@neqv.neqv(arg1) as kotlin.Boolean
-}
+): Boolean =
+  fix().neqv(EQL, EQR, arg1)
 
 @Suppress(
   "UNCHECKED_CAST",

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/eqK/ValidatedEqK.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/eqK/ValidatedEqK.kt
@@ -1,0 +1,47 @@
+package arrow.core.extensions.validated.eqK
+
+import arrow.Kind
+import arrow.core.ForValidated
+import arrow.core.Validated.Companion
+import arrow.core.extensions.ValidatedEqK
+import arrow.typeclasses.Eq
+import kotlin.Boolean
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+@JvmName("eqK")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
+fun <L, A> Kind<Kind<ForValidated, L>, A>.eqK(
+  EQL: Eq<L>,
+  arg1: Kind<Kind<ForValidated, L>, A>,
+  arg2: Eq<A>
+): Boolean = arrow.core.Validated.eqK<L>(EQL).run {
+  this@eqK.eqK<A>(arg1, arg2) as kotlin.Boolean
+}
+
+@JvmName("liftEq")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
+fun <L, A> liftEq(EQL: Eq<L>, arg0: Eq<A>): Eq<Kind<Kind<ForValidated, L>, A>> =
+    arrow.core.Validated
+   .eqK<L>(EQL)
+   .liftEq<A>(arg0) as arrow.typeclasses.Eq<arrow.Kind<arrow.Kind<arrow.core.ForValidated, L>, A>>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
+inline fun <L> Companion.eqK(EQL: Eq<L>): ValidatedEqK<L> = object :
+    arrow.core.extensions.ValidatedEqK<L> { override fun EQL(): arrow.typeclasses.Eq<L> = EQL }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/eqK2/ValidatedEqK2.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/eqK2/ValidatedEqK2.kt
@@ -1,0 +1,54 @@
+package arrow.core.extensions.validated.eqK2
+
+import arrow.Kind
+import arrow.core.ForValidated
+import arrow.core.Validated.Companion
+import arrow.core.extensions.ValidatedEqK2
+import arrow.typeclasses.Eq
+import kotlin.Boolean
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val eqK2_singleton: ValidatedEqK2 = object : arrow.core.extensions.ValidatedEqK2 {}
+
+@JvmName("eqK")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
+fun <A, B> Kind<Kind<ForValidated, A>, B>.eqK(
+  arg1: Kind<Kind<ForValidated, A>, B>,
+  arg2: Eq<A>,
+  arg3: Eq<B>
+): Boolean = arrow.core.Validated.eqK2().run {
+  this@eqK.eqK<A, B>(arg1, arg2, arg3) as kotlin.Boolean
+}
+
+@JvmName("liftEq")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
+fun <A, B> liftEq(arg0: Eq<A>, arg1: Eq<B>): Eq<Kind<Kind<ForValidated, A>, B>> =
+    arrow.core.Validated
+   .eqK2()
+   .liftEq<A, B>(arg0, arg1) as arrow.typeclasses.Eq<arrow.Kind<arrow.Kind<arrow.core.ForValidated,
+    A>, B>>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
+inline fun Companion.eqK2(): ValidatedEqK2 = eqK2_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/foldable/ValidatedFoldable.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/foldable/ValidatedFoldable.kt
@@ -3,7 +3,9 @@ package arrow.core.extensions.validated.foldable
 import arrow.Kind
 import arrow.core.Eval
 import arrow.core.ForValidated
+import arrow.core.None
 import arrow.core.Option
+import arrow.core.Some
 import arrow.core.fold as _fold
 import arrow.core.combineAll as _combineAll
 import arrow.core.Validated
@@ -124,7 +126,7 @@ fun <E, A> Kind<Kind<ForValidated, E>, A>.reduceRightOption(arg1: Function2<A, E
 )
 @Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("combineAll(arg1)", "arrow.core.combineAll"))
 fun <E, A> Kind<Kind<ForValidated, E>, A>.combineAll(arg1: Monoid<A>): A =
-   fix()._combineAll(arg1)
+  fix()._combineAll(arg1)
 
 @JvmName("foldMap")
 @Suppress(
@@ -267,7 +269,7 @@ fun <E, A> Kind<Kind<ForValidated, E>, A>.size(arg1: Monoid<Long>): Long =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-// TODO
+@Deprecated("Applicative typeclasses is deprecated. Use concrete methods on Validated")
 fun <E, G, A, B, AP : Applicative<G>, MO : Monoid<B>> Kind<Kind<ForValidated, E>, A>.foldMapA(
   arg1: AP,
   arg2: MO,
@@ -283,7 +285,7 @@ fun <E, G, A, B, AP : Applicative<G>, MO : Monoid<B>> Kind<Kind<ForValidated, E>
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-// TODO
+@Deprecated("Monad typeclasses is deprecated. Use concrete methods on Validated")
 fun <E, G, A, B, MA : Monad<G>, MO : Monoid<B>> Kind<Kind<ForValidated, E>, A>.foldMapM(
   arg1: MA,
   arg2: MO,
@@ -299,7 +301,7 @@ fun <E, G, A, B, MA : Monad<G>, MO : Monoid<B>> Kind<Kind<ForValidated, E>, A>.f
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-// TODO
+@Deprecated("Monad typeclasses is deprecated. Use concrete methods on Validated")
 fun <E, G, A, B> Kind<Kind<ForValidated, E>, A>.foldM(
   arg1: Monad<G>,
   arg2: B,
@@ -315,11 +317,12 @@ fun <E, G, A, B> Kind<Kind<ForValidated, E>, A>.foldM(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-// TODO
+@Deprecated(
+  "@extension kinded projected functions are deprecated.",
+  ReplaceWith("if (arg1 < 0L) None else fix().fold({ None }, { if(arg1 == 0L) Some(it) else None })", "arrow.core.None", "arrow.core.Some")
+)
 fun <E, A> Kind<Kind<ForValidated, E>, A>.get(arg1: Long): Option<A> =
-  arrow.core.Validated.foldable<E>().run {
-    this@get.get<A>(arg1) as arrow.core.Option<A>
-  }
+  if (arg1 < 0L) None else fix().fold({ None }, { if (arg1 == 0L) Some(it) else None })
 
 @JvmName("firstOption")
 @Suppress(

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/foldable/ValidatedFoldable.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/foldable/ValidatedFoldable.kt
@@ -1,0 +1,387 @@
+package arrow.core.extensions.validated.foldable
+
+import arrow.Kind
+import arrow.core.Eval
+import arrow.core.ForValidated
+import arrow.core.Option
+import arrow.core.fold as _fold
+import arrow.core.combineAll as _combineAll
+import arrow.core.Validated
+import arrow.core.Validated.Companion
+import arrow.core.extensions.ValidatedFoldable
+import arrow.core.fix
+import arrow.core.orNull
+import arrow.core.valid
+import arrow.typeclasses.Applicative
+import arrow.typeclasses.Monad
+import arrow.typeclasses.Monoid
+import kotlin.Any
+import kotlin.Boolean
+import kotlin.Function1
+import kotlin.Function2
+import kotlin.Long
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.List
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val foldable_singleton: ValidatedFoldable<Any?> = object : ValidatedFoldable<Any?> {}
+
+@JvmName("foldLeft")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("foldLeft(arg1, arg2)"))
+fun <E, A, B> Kind<Kind<ForValidated, E>, A>.foldLeft(arg1: B, arg2: Function2<B, A, B>): B =
+  fix().foldLeft(arg1, arg2)
+
+@JvmName("foldRight")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("foldRight(arg1, arg2)"))
+fun <E, A, B> Kind<Kind<ForValidated, E>, A>.foldRight(arg1: Eval<B>, arg2: Function2<A, Eval<B>, Eval<B>>): Eval<B> =
+  fix().foldRight(arg1, arg2)
+
+@JvmName("fold")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("fold(arg1)", "arrow.core.fold"))
+fun <E, A> Kind<Kind<ForValidated, E>, A>.fold(arg1: Monoid<A>): A =
+  fix()._fold(arg1)
+
+@JvmName("reduceLeftToOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Option.fromNullable(map(arg1).orNull())", "arrow.core.Option", "arrow.core.orNull"))
+fun <E, A, B> Kind<Kind<ForValidated, E>, A>.reduceLeftToOption(
+  arg1: Function1<A, B>,
+  arg2: Function2<B, A, B>
+): Option<B> =
+  Option.fromNullable(fix().map(arg1).orNull())
+
+@JvmName("reduceRightToOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Eval.now(Option.fromNullable(map(arg1).orNull()))", "arrow.core.Option", "arrow.core.Eval", "arrow.core.orNull"))
+fun <E, A, B> Kind<Kind<ForValidated, E>, A>.reduceRightToOption(
+  arg1: Function1<A, B>,
+  arg2: Function2<A, Eval<B>, Eval<B>>
+): Eval<Option<B>> =
+  Eval.now(Option.fromNullable(fix().map(arg1).orNull()))
+
+@JvmName("reduceLeftOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Option.fromNullable(orNull())", "arrow.core.Option", "arrow.core.orNull"))
+fun <E, A> Kind<Kind<ForValidated, E>, A>.reduceLeftOption(arg1: Function2<A, A, A>): Option<A> =
+  Option.fromNullable(orNull())
+
+@JvmName("reduceRightOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Eval.now(Option.fromNullable(orNull()))", "arrow.core.Option", "arrow.core.Eval", "arrow.core.orNull"))
+fun <E, A> Kind<Kind<ForValidated, E>, A>.reduceRightOption(arg1: Function2<A, Eval<A>, Eval<A>>): Eval<Option<A>> =
+  Eval.now(Option.fromNullable(orNull()))
+
+@JvmName("combineAll")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("combineAll(arg1)", "arrow.core.combineAll"))
+fun <E, A> Kind<Kind<ForValidated, E>, A>.combineAll(arg1: Monoid<A>): A =
+   fix()._combineAll(arg1)
+
+@JvmName("foldMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("foldMap(arg1, arg2)"))
+fun <E, A, B> Kind<Kind<ForValidated, E>, A>.foldMap(arg1: Monoid<B>, arg2: Function1<A, B>): B =
+  fix().foldMap(arg1, arg2)
+
+@JvmName("orEmpty")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg1.empty().valid()", "arrow.core.valid"))
+fun <E, A> orEmpty(arg0: Applicative<Kind<ForValidated, E>>, arg1: Monoid<A>): Validated<E, A> =
+  arg1.empty().valid()
+
+@JvmName("traverse_")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated. Replace with traverse_ or traverseEither_ from arrow.core.*")
+fun <E, G, A, B> Kind<Kind<ForValidated, E>, A>.traverse_(arg1: Applicative<G>, arg2: Function1<A, Kind<G, B>>): Kind<G, Unit> = arrow.core.Validated.foldable<E>().run {
+  this@traverse_.traverse_<G, A, B>(arg1, arg2) as arrow.Kind<G, kotlin.Unit>
+}
+
+@JvmName("sequence_")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated. Replace with sequence_ or sequenceEither_ from arrow.core.*")
+fun <E, G, A> Kind<Kind<ForValidated, E>, Kind<G, A>>.sequence_(arg1: Applicative<G>): Kind<G, Unit> = arrow.core.Validated.foldable<E>().run {
+  this@sequence_.sequence_<G, A>(arg1) as arrow.Kind<G, kotlin.Unit>
+}
+
+@JvmName("find")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated.", ReplaceWith("Option.fromNullable(findOrNull(arg1))", "arrow.core.Option"))
+fun <E, A> Kind<Kind<ForValidated, E>, A>.find(arg1: Function1<A, Boolean>): Option<A> =
+  Option.fromNullable(fix().findOrNull(arg1))
+
+@JvmName("exists")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated.", ReplaceWith("exists(arg1)"))
+fun <E, A> Kind<Kind<ForValidated, E>, A>.exists(arg1: Function1<A, Boolean>): Boolean =
+  fix().exist(arg1)
+
+@JvmName("forAll")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated.", ReplaceWith("all(arg1)"))
+fun <E, A> Kind<Kind<ForValidated, E>, A>.forAll(arg1: Function1<A, Boolean>): Boolean =
+  fix().all(arg1)
+
+@JvmName("all")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated.", ReplaceWith("all(arg1)"))
+fun <E, A> Kind<Kind<ForValidated, E>, A>.all(arg1: Function1<A, Boolean>): Boolean =
+  fix().all(arg1)
+
+@JvmName("isEmpty")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated.", ReplaceWith("isEmpty()"))
+fun <E, A> Kind<Kind<ForValidated, E>, A>.isEmpty(): Boolean =
+  fix().isEmpty()
+
+@JvmName("nonEmpty")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated.", ReplaceWith("isNotEmpty()"))
+fun <E, A> Kind<Kind<ForValidated, E>, A>.nonEmpty(): Boolean =
+  fix().isNotEmpty()
+
+@JvmName("isNotEmpty")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated.", ReplaceWith("isNotEmpty()"))
+fun <E, A> Kind<Kind<ForValidated, E>, A>.isNotEmpty(): Boolean =
+  fix().isNotEmpty()
+
+@JvmName("size")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated.", ReplaceWith("fold({ 0 }, { 1 })"))
+fun <E, A> Kind<Kind<ForValidated, E>, A>.size(arg1: Monoid<Long>): Long =
+  fix().fold({ 0 }, { 1 })
+
+@JvmName("foldMapA")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+// TODO
+fun <E, G, A, B, AP : Applicative<G>, MO : Monoid<B>> Kind<Kind<ForValidated, E>, A>.foldMapA(
+  arg1: AP,
+  arg2: MO,
+  arg3: Function1<A, Kind<G, B>>
+): Kind<G, B> = arrow.core.Validated.foldable<E>().run {
+  this@foldMapA.foldMapA<G, A, B, AP, MO>(arg1, arg2, arg3) as arrow.Kind<G, B>
+}
+
+@JvmName("foldMapM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+// TODO
+fun <E, G, A, B, MA : Monad<G>, MO : Monoid<B>> Kind<Kind<ForValidated, E>, A>.foldMapM(
+  arg1: MA,
+  arg2: MO,
+  arg3: Function1<A, Kind<G, B>>
+): Kind<G, B> = arrow.core.Validated.foldable<E>().run {
+  this@foldMapM.foldMapM<G, A, B, MA, MO>(arg1, arg2, arg3) as arrow.Kind<G, B>
+}
+
+@JvmName("foldM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+// TODO
+fun <E, G, A, B> Kind<Kind<ForValidated, E>, A>.foldM(
+  arg1: Monad<G>,
+  arg2: B,
+  arg3: Function2<B, A, Kind<G, B>>
+): Kind<G, B> = arrow.core.Validated.foldable<E>().run {
+  this@foldM.foldM<G, A, B>(arg1, arg2, arg3) as arrow.Kind<G, B>
+}
+
+@JvmName("get")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+// TODO
+fun <E, A> Kind<Kind<ForValidated, E>, A>.get(arg1: Long): Option<A> =
+  arrow.core.Validated.foldable<E>().run {
+    this@get.get<A>(arg1) as arrow.core.Option<A>
+  }
+
+@JvmName("firstOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated.", ReplaceWith("Option.fromNullable(orNull())", "arrow.core.Option"))
+fun <E, A> Kind<Kind<ForValidated, E>, A>.firstOption(): Option<A> =
+  arrow.core.Validated.foldable<E>().run {
+    this@firstOption.firstOption<A>() as arrow.core.Option<A>
+  }
+
+@JvmName("firstOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated.", ReplaceWith("Option.fromNullable(findOrNull(arg1))", "arrow.core.Option"))
+fun <E, A> Kind<Kind<ForValidated, E>, A>.firstOption(arg1: Function1<A, Boolean>): Option<A> =
+  Option.fromNullable(fix().findOrNull(arg1))
+
+@JvmName("firstOrNone")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated.", ReplaceWith("Option.fromNullable(orNull())", "arrow.core.Option"))
+fun <E, A> Kind<Kind<ForValidated, E>, A>.firstOrNone(): Option<A> =
+  Option.fromNullable(orNull())
+
+@JvmName("firstOrNone")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated.", ReplaceWith("Option.fromNullable(findOrNull(arg1))", "arrow.core.Option"))
+fun <E, A> Kind<Kind<ForValidated, E>, A>.firstOrNone(arg1: Function1<A, Boolean>): Option<A> =
+  Option.fromNullable(fix().findOrNull(arg1))
+
+@JvmName("toList")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated.", ReplaceWith("listOfNotNull(orNull())"))
+fun <E, A> Kind<Kind<ForValidated, E>, A>.toList(): List<A> =
+  listOfNotNull(orNull())
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated("Foldable typeclasses is deprecated. Use concrete methods on Validated")
+inline fun <E> Companion.foldable(): ValidatedFoldable<E> = foldable_singleton as
+  arrow.core.extensions.ValidatedFoldable<E>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/functor/ValidatedFunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/functor/ValidatedFunctor.kt
@@ -1,0 +1,161 @@
+package arrow.core.extensions.validated.functor
+
+import arrow.Kind
+import arrow.core.ForValidated
+import arrow.core.Tuple2
+import arrow.core.Validated
+import arrow.core.Validated.Companion
+import arrow.core.extensions.ValidatedFunctor
+import arrow.core.fix
+import arrow.core.widen
+import arrow.core.mapConst as _mapConst
+import kotlin.Any
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val functor_singleton: ValidatedFunctor<Any?> = object : ValidatedFunctor<Any?> {}
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("map(arg1)"))
+fun <E, A, B> Kind<Kind<ForValidated, E>, A>.map(arg1: Function1<A, B>): Validated<E, B> =
+    arrow.core.Validated.functor<E>().run {
+  this@map.map<A, B>(arg1) as arrow.core.Validated<E, B>
+}
+
+@JvmName("imap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("map(arg1)"))
+fun <E, A, B> Kind<Kind<ForValidated, E>, A>.imap(arg1: Function1<A, B>, arg2: Function1<B, A>):
+    Validated<E, B> = arrow.core.Validated.functor<E>().run {
+  this@imap.imap<A, B>(arg1, arg2) as arrow.core.Validated<E, B>
+}
+
+@JvmName("lift")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.lift(arg1)", "arrow.core.lift"))
+fun <E, A, B> lift(arg0: Function1<A, B>): Function1<Kind<Kind<ForValidated, E>, A>,
+    Kind<Kind<ForValidated, E>, B>> = arrow.core.Validated
+   .functor<E>()
+   .lift<A, B>(arg0) as kotlin.Function1<arrow.Kind<arrow.Kind<arrow.core.ForValidated, E>, A>,
+    arrow.Kind<arrow.Kind<arrow.core.ForValidated, E>, B>>
+
+@JvmName("void")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("void()"))
+fun <E, A> Kind<Kind<ForValidated, E>, A>.void(): Validated<E, Unit> =
+  fix().void()
+
+// TODO is unit still generated? Not present in Functor interface
+// @JvmName("unit")
+// @Suppress(
+//  "UNCHECKED_CAST",
+//  "USELESS_CAST",
+//  "EXTENSION_SHADOWED_BY_MEMBER",
+//  "UNUSED_PARAMETER"
+// )
+// fun <E, A> Kind<Kind<ForValidated, E>, A>.unit(): Validated<E, Unit> =
+//    arrow.core.Validated.functor<E>().run {
+//  this@unit.unit<A>() as arrow.core.Validated<E, kotlin.Unit>
+// }
+
+@JvmName("fproduct")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("fproduct(arg1)"))
+fun <E, A, B> Kind<Kind<ForValidated, E>, A>.fproduct(arg1: Function1<A, B>): Validated<E, Tuple2<A, B>> =
+  fix().fproduct(arg1)
+
+@JvmName("mapConst")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("mapConst(arg1)"))
+fun <E, A, B> Kind<Kind<ForValidated, E>, A>.mapConst(arg1: B): Validated<E, B> =
+  fix().mapConst(arg1)
+
+@JvmName("mapConst")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("mapConst(arg1)", "arrow.core.mapConst"))
+fun <E, A, B> A.mapConst(arg1: Kind<Kind<ForValidated, E>, B>): Validated<E, A> =
+  _mapConst(arg1.fix())
+
+@JvmName("tupleLeft")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("tupleLeft(arg1)"))
+fun <E, A, B> Kind<Kind<ForValidated, E>, A>.tupleLeft(arg1: B): Validated<E, Tuple2<B, A>> =
+  fix().tupleLeft(arg1)
+
+@JvmName("tupleRight")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("tupleRight(arg1)"))
+fun <E, A, B> Kind<Kind<ForValidated, E>, A>.tupleRight(arg1: B): Validated<E, Tuple2<A, B>> =
+  fix().tupleRight(arg1)
+
+@JvmName("widen")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("widen()", "arrow.core.widen"))
+fun <E, B, A : B> Kind<Kind<ForValidated, E>, A>.widen(): Validated<E, B> =
+  fix().widen<E, B, A>()
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated("Functor typeclasses is deprecated. Use concrete methods on Validated")
+inline fun <E> Companion.functor(): ValidatedFunctor<E> = functor_singleton as
+    arrow.core.extensions.ValidatedFunctor<E>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/functor/ValidatedFunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/functor/ValidatedFunctor.kt
@@ -73,19 +73,6 @@ fun <E, A, B> lift(arg0: Function1<A, B>): Function1<Kind<Kind<ForValidated, E>,
 fun <E, A> Kind<Kind<ForValidated, E>, A>.void(): Validated<E, Unit> =
   fix().void()
 
-// TODO is unit still generated? Not present in Functor interface
-// @JvmName("unit")
-// @Suppress(
-//  "UNCHECKED_CAST",
-//  "USELESS_CAST",
-//  "EXTENSION_SHADOWED_BY_MEMBER",
-//  "UNUSED_PARAMETER"
-// )
-// fun <E, A> Kind<Kind<ForValidated, E>, A>.unit(): Validated<E, Unit> =
-//    arrow.core.Validated.functor<E>().run {
-//  this@unit.unit<A>() as arrow.core.Validated<E, kotlin.Unit>
-// }
-
 @JvmName("fproduct")
 @Suppress(
   "UNCHECKED_CAST",

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/functor/ValidatedFunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/functor/ValidatedFunctor.kt
@@ -73,6 +73,17 @@ fun <E, A, B> lift(arg0: Function1<A, B>): Function1<Kind<Kind<ForValidated, E>,
 fun <E, A> Kind<Kind<ForValidated, E>, A>.void(): Validated<E, Unit> =
   fix().void()
 
+@JvmName("unit")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("void()"))
+fun <E, A> Kind<Kind<ForValidated, E>, A>.unit(): Validated<E, Unit> =
+  fix().void()
+
 @JvmName("fproduct")
 @Suppress(
   "UNCHECKED_CAST",

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/functor/ValidatedFunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/functor/ValidatedFunctor.kt
@@ -73,17 +73,6 @@ fun <E, A, B> lift(arg0: Function1<A, B>): Function1<Kind<Kind<ForValidated, E>,
 fun <E, A> Kind<Kind<ForValidated, E>, A>.void(): Validated<E, Unit> =
   fix().void()
 
-@JvmName("unit")
-@Suppress(
-  "UNCHECKED_CAST",
-  "USELESS_CAST",
-  "EXTENSION_SHADOWED_BY_MEMBER",
-  "UNUSED_PARAMETER"
-)
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("void()"))
-fun <E, A> Kind<Kind<ForValidated, E>, A>.unit(): Validated<E, Unit> =
-  fix().void()
-
 @JvmName("fproduct")
 @Suppress(
   "UNCHECKED_CAST",

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/hash/ValidatedHash.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/hash/ValidatedHash.kt
@@ -1,0 +1,32 @@
+package arrow.core.extensions.validated.hash
+
+import arrow.core.Validated
+import arrow.core.Validated.Companion
+import arrow.core.extensions.ValidatedHash
+import arrow.typeclasses.Hash
+import kotlin.Int
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+@JvmName("hash")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("hash(HL, HR)"))
+fun <L, R> Validated<L, R>.hash(HL: Hash<L>, HR: Hash<R>): Int =
+  hash(HL, HR)
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.hash(HL, HR)", "arrow.core.hash"))
+inline fun <L, R> Companion.hash(HL: Hash<L>, HR: Hash<R>): ValidatedHash<L, R> = object :
+  arrow.core.extensions.ValidatedHash<L, R> {
+  override fun HL(): arrow.typeclasses.Hash<L> = HL
+
+  override fun HR(): arrow.typeclasses.Hash<R> = HR
+}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/order/ValidatedOrder.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/order/ValidatedOrder.kt
@@ -1,0 +1,159 @@
+package arrow.core.extensions.validated.order
+
+import arrow.core.Tuple2
+import arrow.core.Validated
+import arrow.core.Validated.Companion
+import arrow.core.compareTo
+import arrow.core.eqv
+import arrow.core.lt
+import arrow.core.lte
+import arrow.core.gt
+import arrow.core.gte
+import arrow.core.sort
+import arrow.core.min
+import arrow.core.max
+import arrow.core.extensions.ValidatedOrder
+import arrow.typeclasses.Order
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+@JvmName("compareTo")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("compareTo(OL, OR, arg1)", "arrow.core.compareTo"))
+fun <L, R> Validated<L, R>.compareTo(
+  OL: Order<L>,
+  OR: Order<R>,
+  arg1: Validated<L, R>
+): Int = compareTo(OL, OR, arg1)
+
+@JvmName("eqv")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("eqv(OL, OR, arg1)", "arrow.core.eqv"))
+fun <L, R> Validated<L, R>.eqv(
+  OL: Order<L>,
+  OR: Order<R>,
+  arg1: Validated<L, R>
+): Boolean = eqv(OL, OR, arg1)
+
+@JvmName("lt")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("lt(OL, OR, arg1)", "arrow.core.lt"))
+fun <L, R> Validated<L, R>.lt(
+  OL: Order<L>,
+  OR: Order<R>,
+  arg1: Validated<L, R>
+): Boolean = lt(OL, OR, arg1)
+
+@JvmName("lte")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("lte(OL, OR, arg1)", "arrow.core.lte"))
+fun <L, R> Validated<L, R>.lte(
+  OL: Order<L>,
+  OR: Order<R>,
+  arg1: Validated<L, R>
+): Boolean = lte(OL, OR, arg1)
+
+@JvmName("gt")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("gt(OL, OR, arg1)", "arrow.core.gt"))
+fun <L, R> Validated<L, R>.gt(
+  OL: Order<L>,
+  OR: Order<R>,
+  arg1: Validated<L, R>
+): Boolean = gt(OL, OR, arg1)
+
+@JvmName("gte")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("gte(OL, OR, arg1)", "arrow.core.gte"))
+fun <L, R> Validated<L, R>.gte(
+  OL: Order<L>,
+  OR: Order<R>,
+  arg1: Validated<L, R>
+): Boolean = gte(OL, OR, arg1)
+
+@JvmName("max")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("max(OL, OR, arg1)", "arrow.core.max"))
+fun <L, R> Validated<L, R>.max(
+  OL: Order<L>,
+  OR: Order<R>,
+  arg1: Validated<L, R>
+): Validated<L, R> = max(OL, OR, arg1)
+
+@JvmName("min")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("min(OL, OR, arg1)", "arrow.core.min"))
+fun <L, R> Validated<L, R>.min(
+  OL: Order<L>,
+  OR: Order<R>,
+  arg1: Validated<L, R>
+): Validated<L, R> = min(OL, OR, arg1)
+
+@JvmName("sort")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("sort(OL, OR, arg1)", "arrow.core.sort"))
+fun <L, R> Validated<L, R>.sort(
+  OL: Order<L>,
+  OR: Order<R>,
+  arg1: Validated<L, R>
+): Tuple2<Validated<L, R>, Validated<L, R>> =
+  sort(OL, OR, arg1)
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.order(OL, OR)", "arrow.core.order"))
+inline fun <L, R> Companion.order(OL: Order<L>, OR: Order<R>): ValidatedOrder<L, R> = object :
+  arrow.core.extensions.ValidatedOrder<L, R> {
+  override fun OL(): arrow.typeclasses.Order<L> = OL
+
+  override fun OR(): arrow.typeclasses.Order<R> = OR
+}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/selective/ValidatedSelective.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/selective/ValidatedSelective.kt
@@ -1,0 +1,119 @@
+package arrow.core.extensions.validated.selective
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.ForValidated
+import arrow.core.Validated
+import arrow.core.select
+import arrow.core.branch
+import arrow.core.Validated.Companion
+import arrow.core.extensions.ValidatedSelective
+import arrow.core.fix
+import arrow.core.ifS
+import arrow.core.andS
+import arrow.core.orS
+import arrow.core.whenS
+import arrow.typeclasses.Semigroup
+import kotlin.Boolean
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+@JvmName("select")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("select(arg1)", "arrow.core.select"))
+fun <E, A, B> Kind<Kind<ForValidated, E>, Either<A, B>>.select(
+  SE: Semigroup<E>,
+  arg1: Kind<Kind<ForValidated, E>, Function1<A, B>>
+): Validated<E, B> =
+  fix().select(arg1.fix())
+
+@JvmName("branch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("branch(arg1, arg2)", "arrow.core.branch"))
+fun <E, A, B, C> Kind<Kind<ForValidated, E>, Either<A, B>>.branch(
+  SE: Semigroup<E>,
+  arg1: Kind<Kind<ForValidated, E>, Function1<A, C>>,
+  arg2: Kind<Kind<ForValidated, E>, Function1<B, C>>
+): Validated<E, C> =
+  fix().branch(arg1.fix(), arg2.fix())
+
+@JvmName("whenS")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("whenS(arg1)", "arrow.core.whenS"))
+fun <E> Kind<Kind<ForValidated, E>, Boolean>.whenS(
+  SE: Semigroup<E>,
+  arg1: Kind<Kind<ForValidated, E>, Function0<Unit>>
+): Validated<E, Unit> =
+  fix().whenS(arg1.fix())
+
+@JvmName("ifS")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("ifS(arg1, arg2)", "arrow.core.ifS"))
+fun <E, A> Kind<Kind<ForValidated, E>, Boolean>.ifS(
+  SE: Semigroup<E>,
+  arg1: Kind<Kind<ForValidated, E>, A>,
+  arg2: Kind<Kind<ForValidated, E>, A>
+): Validated<E, A> =
+  fix().ifS(arg1.fix(), arg2.fix())
+
+@JvmName("orS")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("orS(arg1)", "arrow.core.ifS"))
+fun <E, A> Kind<Kind<ForValidated, E>, Boolean>.orS(
+  SE: Semigroup<E>,
+  arg1: Kind<Kind<ForValidated, E>, Boolean>
+): Validated<E, Boolean> =
+  fix().orS(arg1.fix())
+
+@JvmName("andS")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <E, A> Kind<Kind<ForValidated, E>, Boolean>.andS(
+  SE: Semigroup<E>,
+  arg1: Kind<Kind<ForValidated,
+    E>, Boolean>
+): Validated<E, Boolean> =
+  fix().andS(arg1.fix())
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated("Selective typeclasses is deprecated. Use concrete methods on Validated")
+inline fun <E> Companion.selective(SE: Semigroup<E>): ValidatedSelective<E> = object :
+  arrow.core.extensions.ValidatedSelective<E> {
+  override fun SE(): arrow.typeclasses.Semigroup<E> =
+    SE
+}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/semigroupK/ValidatedSemigroupK.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/semigroupK/ValidatedSemigroupK.kt
@@ -1,0 +1,50 @@
+package arrow.core.extensions.validated.semigroupK
+
+import arrow.Kind
+import arrow.core.ForValidated
+import arrow.core.Validated
+import arrow.core.Validated.Companion
+import arrow.core.extensions.ValidatedSemigroupK
+import arrow.typeclasses.Semigroup
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+@JvmName("combineK")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
+fun <E, A> Kind<Kind<ForValidated, E>, A>.combineK(
+  SE: Semigroup<E>,
+  arg1: Kind<Kind<ForValidated, E>, A>
+): Validated<E, A> = arrow.core.Validated.semigroupK<E>(SE).run {
+  this@combineK.combineK<A>(arg1) as arrow.core.Validated<E, A>
+}
+
+@JvmName("algebra")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
+fun <E, A> algebra(SE: Semigroup<E>): Semigroup<Kind<Kind<ForValidated, E>, A>> =
+  arrow.core.Validated
+    .semigroupK<E>(SE)
+    .algebra<A>() as arrow.typeclasses.Semigroup<arrow.Kind<arrow.Kind<arrow.core.ForValidated, E>,
+    A>>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
+inline fun <E> Companion.semigroupK(SE: Semigroup<E>): ValidatedSemigroupK<E> = object :
+  arrow.core.extensions.ValidatedSemigroupK<E> {
+  override fun SE(): arrow.typeclasses.Semigroup<E> =
+    SE
+}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/show/ValidatedShow.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/show/ValidatedShow.kt
@@ -1,0 +1,16 @@
+package arrow.core.extensions.validated.show
+
+import arrow.core.Validated.Companion
+import arrow.core.extensions.ValidatedShow
+import arrow.typeclasses.Show
+import kotlin.Suppress
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.show(SL, SR)", "arrow.core.show"))
+inline fun <L, R> Companion.show(SL: Show<L>, SR: Show<R>): ValidatedShow<L, R> = object :
+    arrow.core.extensions.ValidatedShow<L, R> { override fun SL(): arrow.typeclasses.Show<L> = SL
+
+  override fun SR(): arrow.typeclasses.Show<R> = SR }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/traverse/ValidatedTraverse.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/traverse/ValidatedTraverse.kt
@@ -1,0 +1,87 @@
+package arrow.core.extensions.validated.traverse
+
+import arrow.Kind
+import arrow.core.ForValidated
+import arrow.core.Validated
+import arrow.core.Validated.Companion
+import arrow.core.extensions.ValidatedTraverse
+import arrow.core.fix
+import arrow.typeclasses.Applicative
+import arrow.typeclasses.Monad
+import kotlin.Any
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val traverse_singleton: ValidatedTraverse<Any?> = object : ValidatedTraverse<Any?> {}
+
+@JvmName("traverse")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated. Replace with traverse or traverseEither from arrow.core.*")
+fun <E, G, A, B> Kind<Kind<ForValidated, E>, A>.traverse(
+  arg1: Applicative<G>,
+  arg2: Function1<A, Kind<G, B>>
+): Kind<G, Kind<Kind<ForValidated, E>, B>> = arrow.core.Validated.traverse<E>().run {
+  this@traverse.traverse<G, A, B>(arg1, arg2) as arrow.Kind<G,
+    arrow.Kind<arrow.Kind<arrow.core.ForValidated, E>, B>>
+}
+
+@JvmName("sequence")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated. Replace with sequence or sequenceEither from arrow.core.*")
+fun <E, G, A> Kind<Kind<ForValidated, E>, Kind<G, A>>.sequence(arg1: Applicative<G>): Kind<G,
+  Kind<Kind<ForValidated, E>, A>> = arrow.core.Validated.traverse<E>().run {
+  this@sequence.sequence<G, A>(arg1) as arrow.Kind<G, arrow.Kind<arrow.Kind<arrow.core.ForValidated,
+    E>, A>>
+}
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("map(arg1)"))
+fun <E, A, B> Kind<Kind<ForValidated, E>, A>.map(arg1: Function1<A, B>): Validated<E, B> =
+  fix().map(arg1)
+
+@JvmName("flatTraverse")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated. This signature is not valid for Validated.")
+fun <E, G, A, B> Kind<Kind<ForValidated, E>, A>.flatTraverse(
+  arg1: Monad<Kind<ForValidated, E>>,
+  arg2: Applicative<G>,
+  arg3: Function1<A, Kind<G, Kind<Kind<ForValidated, E>, B>>>
+): Kind<G, Kind<Kind<ForValidated, E>, B>> = arrow.core.Validated.traverse<E>().run {
+  this@flatTraverse.flatTraverse<G, A, B>(arg1, arg2, arg3) as arrow.Kind<G,
+    arrow.Kind<arrow.Kind<arrow.core.ForValidated, E>, B>>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated("Traverse typeclasses is deprecated. Use concrete methods on Validated")
+inline fun <E> Companion.traverse(): ValidatedTraverse<E> = traverse_singleton as
+  arrow.core.extensions.ValidatedTraverse<E>


### PR DESCRIPTION
This PR deprecates @higherkind and @extension for Validated and offers concrete signatures for all functions exposed as `@extensions`.

- [x] Temporarly move generated code to arrow-core, and disable `@extensions` generation
- [x] Offer concrete implementations for `@extensions` generated code
- [x] Deprecate all `@extensions` generated code with proper `ReplaceWith` methods.

This PR also removes `Functor#unit` which has been deprecated in favor of `void` since `0.10.x` 