### PR TITLE
Bugfix suspended computation blocks

### DIFF
--- a/arrow-continuations/src/main/kotlin/arrow/continuations/generic/DelimContScope.kt
+++ b/arrow-continuations/src/main/kotlin/arrow/continuations/generic/DelimContScope.kt
@@ -118,9 +118,11 @@ internal open class DelimContScope<R>(private val f: suspend RestrictedScope<R>.
     // Return the final result
     return resultVar as R
   }
+}
 
-  companion object {
-    @Suppress("ClassName")
-    private object EMPTY_VALUE
-  }
+@Suppress("ClassName")
+internal object EMPTY_VALUE {
+  @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
+  inline fun <T> unbox(value: Any?): T =
+    if (value === this) null as T else value as T
 }

--- a/arrow-continuations/src/main/kotlin/arrow/continuations/generic/SuspendingComputation.kt
+++ b/arrow-continuations/src/main/kotlin/arrow/continuations/generic/SuspendingComputation.kt
@@ -33,15 +33,7 @@ internal open class SuspendMonadContinuation<R>(
     _decision.loop { decision ->
       when (decision) {
         UNDECIDED -> {
-          val r: R? = when {
-            result.isFailure -> {
-              val e = result.exceptionOrNull()
-              if (e is ShortCircuit && e.token === token) e.raiseValue as R else null
-            }
-            result.isSuccess -> result.getOrNull()
-            else -> throw RuntimeException("Internal Arrow Exception")
-          }
-
+          val r: R? = result.fold({ it }) { it.shiftedOrNull() }
           when {
             r == null -> {
               parent.resumeWithException(result.exceptionOrNull()!!)
@@ -55,8 +47,7 @@ internal open class SuspendMonadContinuation<R>(
         }
         else -> { // If not `UNDECIDED` then we need to pass result to `parent`
           val res: Result<R> = result.fold({ Result.success(it) }, { t ->
-            if (t is ShortCircuit && t.token === token) Result.success(t.raiseValue as R)
-            else Result.failure(t)
+            t.shiftedOrNull()?.let(Result.Companion::success) ?: Result.failure(t)
           })
           parent.resumeWith(res)
           return
@@ -74,6 +65,20 @@ internal open class SuspendMonadContinuation<R>(
       }
     }
 
+  // If ShortCircuit causes CancellationException, we also want to shift back to R
+  private tailrec fun Throwable.shortCircuitCause(): ShortCircuit? =
+    when (val cause = this.cause) {
+      null -> null
+      is ShortCircuit -> cause
+      else -> cause.shortCircuitCause()
+    }
+
+  private fun Throwable.shiftedOrNull(): R? {
+    val shortCircuit = if (this is ShortCircuit) this else shortCircuitCause()
+    return if (shortCircuit != null && shortCircuit.token === token) shortCircuit.raiseValue as R
+    else null
+  }
+
   override suspend fun <A> shift(r: R): A =
     throw ShortCircuit(token, r)
 
@@ -84,7 +89,6 @@ internal open class SuspendMonadContinuation<R>(
         else it
       }
     } catch (e: Throwable) {
-      if (e is ShortCircuit && e.token === token) e.raiseValue as R
-      else throw e
+      e.shiftedOrNull() ?: throw e
     }
 }

--- a/arrow-continuations/src/main/kotlin/arrow/continuations/generic/SuspendingComputation.kt
+++ b/arrow-continuations/src/main/kotlin/arrow/continuations/generic/SuspendingComputation.kt
@@ -4,7 +4,6 @@ import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.loop
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
 import kotlin.coroutines.intrinsics.startCoroutineUninterceptedOrReturn
 import kotlin.coroutines.resumeWithException

--- a/arrow-continuations/src/main/kotlin/arrow/continuations/generic/SuspendingComputation.kt
+++ b/arrow-continuations/src/main/kotlin/arrow/continuations/generic/SuspendingComputation.kt
@@ -27,7 +27,7 @@ internal open class SuspendMonadContinuation<R>(
   private val _decision = atomic<Any>(UNDECIDED)
   private val token: Token = Token()
 
-  override val context: CoroutineContext = EmptyCoroutineContext
+  override val context: CoroutineContext = parent.context
 
   override fun resumeWith(result: Result<R>) {
     _decision.loop { decision ->

--- a/arrow-continuations/src/test/kotlin/generic/SuspendingComputationTest.kt
+++ b/arrow-continuations/src/test/kotlin/generic/SuspendingComputationTest.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
 import kotlin.coroutines.intrinsics.intercepted
 import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
@@ -166,7 +167,17 @@ class SuspendingComputationTest : StringSpec({
 
     cancelled.await()
   }
+
+  "Computation blocks run on parent context" {
+    val parentCtx = currentContext()
+    either<String, Unit> {
+      currentContext() shouldBe parentCtx
+    }
+  }
 })
+
+suspend fun currentContext(): CoroutineContext =
+  kotlin.coroutines.coroutineContext
 
 suspend fun completeOnCancellation(latch: CompletableDeferred<Unit>, cancelled: CompletableDeferred<Unit>): Unit =
   suspendCancellableCoroutine { cont ->


### PR DESCRIPTION
1. KotlinX Coroutines throws `CancellationException` with `cause` when propagating cancellation by exception from `async` to it's parent. Since we cause the `CancellationException` with `ShortCircuit` we need to look if `ShortCircuit` can be found within the causes to return the excepted shifted value. If the cancellation is immediate, then it doesn't wrap in `CancellationException`, that caused the test to be flaky. Now it passes consitently on a loop.

2. Suspended computation blocks were running on `EmptyCoroutineContext`, they need to run on the parents `ctx` to correctly propogate  the state from outside to  inside the computation block.