### PR TITLE
Deprecate @higherkind & @extension for Either

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -1240,8 +1240,9 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
      *
      *  fun main(args: Array<String>) {
      *   //sampleStart
-     *   val f = Either.lift<String, String, String>({ s: CharSequence -> "$s World" })
-     *   val result = f("Hello".right())
+     *   val f = Either.lift<Int, CharSequence, String> { s: CharSequence -> "$s World" }
+     *   val either: Either<Int, CharSequence> = "Hello".right()
+     *   val result = f(either)
      *   //sampleEnd
      *   println(result)
      *  }
@@ -1249,6 +1250,9 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
      */
     fun <A, B, C> lift(f: (B) -> C): (Either<A, B>) -> Either<A, C> =
       { it.map(f) }
+
+    fun <A, B, C, D> lift(fa: (A) -> C, fb: (B) -> D): (Either<A, B>) -> Either<C, D> =
+      { it.bimap(fa, fb) }
 
     /** Construct an [Eq] instance which use [EQL] and [EQR] to compare the [Left] and [Right] cases **/
     fun <L, R> eq(EQL: Eq<L>, EQR: Eq<R>): Eq<Either<L, R>> =

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -4,8 +4,6 @@ import arrow.Kind
 import arrow.core.Either.Companion.resolve
 import arrow.core.Either.Left
 import arrow.core.Either.Right
-import arrow.core.Valid
-import arrow.typeclasses.Align
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -1036,6 +1036,15 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
   inline fun <AA, C> traverseValidated_(fa: (B) -> Validated<AA, C>): Validated<AA, Unit> =
     fold({ Valid(Unit) }, { fa(it).void() })
 
+  inline fun <AA, C> bitraverse(fe: (A) -> Iterable<AA>, fa: (B) -> Iterable<C>): List<Either<AA, C>> =
+    fold({ fe(it).map { Left(it) } }, { fa(it).map { Right(it) } })
+
+  inline fun <AA, C, D> bitraverseValidated(
+    fe: (A) -> Validated<AA, C>,
+    fa: (B) -> Validated<AA, D>
+  ): Validated<AA, Either<C, D>> =
+    fold({ fe(it).map { Left(it) } }, { fa(it).map {Right(it) } })
+
   /**
    * The left side of the disjoint union, as opposed to the [Right] side.
    */
@@ -1935,6 +1944,12 @@ fun <A, B, C> Either<A, Validated<B, C>>.sequenceValidated(): Validated<B, Eithe
 
 fun <A, B, C> Either<A, Validated<B, C>>.sequenceValidated_(): Validated<B, Unit> =
   traverseValidated_(::identity)
+
+fun <A, B> Either<Iterable<A>, Iterable<B>>.bisequence(): List<Either<A, B>> =
+  bitraverse(::identity, ::identity)
+
+fun <A, B, C> Either<Validated<A, B>, Validated<A, C>>.bisequenceValidated(): Validated<A, Either<B, C>> =
+  bitraverseValidated(::identity, ::identity)
 
 private class EitherEq<L, R>(
   private val EQL: Eq<L>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -1311,6 +1311,112 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
           }
         }
       }
+
+    fun <A, B, C> tupledN(
+      b: Either<A, B>,
+      c: Either<A, C>
+    ): Either<A, Tuple2<B, C>> =
+      b.product(c)
+
+    fun <A, B, C, D> tupledN(
+      b: Either<A, B>,
+      c: Either<A, C>,
+      d: Either<A, D>
+    ): Either<A, Tuple3<B, C, D>> =
+      mapN(b, c, d) { b, c, d ->
+        Tuple3(b, c, d)
+      }
+
+    fun <A, B, C, D, E> tupledN(
+      b: Either<A, B>,
+      c: Either<A, C>,
+      d: Either<A, D>,
+      e: Either<A, E>
+    ): Either<A, Tuple4<B, C, D, E>> =
+      mapN(b, c, d, e) { b, c, d, e ->
+        Tuple4(b, c, d, e)
+      }
+
+    fun <A, B, C, D, E, F> tupledN(
+      b: Either<A, B>,
+      c: Either<A, C>,
+      d: Either<A, D>,
+      e: Either<A, E>,
+      f: Either<A, F>
+    ): Either<A, Tuple5<B, C, D, E, F>> =
+      mapN(b, c, d, e, f) { b, c, d, e, f ->
+        Tuple5(b, c, d, e, f)
+      }
+
+    fun <A, B, C, D, E, F, G> tupledN(
+      b: Either<A, B>,
+      c: Either<A, C>,
+      d: Either<A, D>,
+      e: Either<A, E>,
+      f: Either<A, F>,
+      g: Either<A, G>
+    ): Either<A, Tuple6<B, C, D, E, F, G>> =
+      mapN(b, c, d, e, f, g) { b, c, d, e, f, g ->
+        Tuple6(b, c, d, e, f, g)
+      }
+
+    fun <A, B, C, D, E, F, G, H> tupledN(
+      b: Either<A, B>,
+      c: Either<A, C>,
+      d: Either<A, D>,
+      e: Either<A, E>,
+      f: Either<A, F>,
+      g: Either<A, G>,
+      h: Either<A, H>
+    ): Either<A, Tuple7<B, C, D, E, F, G, H>> =
+      mapN(b, c, d, e, f, g, h) { b, c, d, e, f, g, h ->
+        Tuple7(b, c, d, e, f, g, h)
+      }
+
+    fun <A, B, C, D, E, F, G, H, I> tupledN(
+      b: Either<A, B>,
+      c: Either<A, C>,
+      d: Either<A, D>,
+      e: Either<A, E>,
+      f: Either<A, F>,
+      g: Either<A, G>,
+      h: Either<A, H>,
+      i: Either<A, I>
+    ): Either<A, Tuple8<B, C, D, E, F, G, H, I>> =
+      mapN(b, c, d, e, f, g, h, i) { b, c, d, e, f, g, h, i ->
+        Tuple8(b, c, d, e, f, g, h, i)
+      }
+
+    fun <A, B, C, D, E, F, G, H, I, J> tupledN(
+      b: Either<A, B>,
+      c: Either<A, C>,
+      d: Either<A, D>,
+      e: Either<A, E>,
+      f: Either<A, F>,
+      g: Either<A, G>,
+      h: Either<A, H>,
+      i: Either<A, I>,
+      j: Either<A, J>
+    ): Either<A, Tuple9<B, C, D, E, F, G, H, I, J>> =
+      mapN(b, c, d, e, f, g, h, i, j) { b, c, d, e, f, g, h, i, j ->
+        Tuple9(b, c, d, e, f, g, h, i, j)
+      }
+
+    fun <A, B, C, D, E, F, G, H, I, J, K> tupledN(
+      b: Either<A, B>,
+      c: Either<A, C>,
+      d: Either<A, D>,
+      e: Either<A, E>,
+      f: Either<A, F>,
+      g: Either<A, G>,
+      h: Either<A, H>,
+      i: Either<A, I>,
+      j: Either<A, J>,
+      k: Either<A, K>
+    ): Either<A, Tuple10<B, C, D, E, F, G, H, I, J, K>> =
+      mapN(b, c, d, e, f, g, h, i, j, k) { b, c, d, e, f, g, h, i, j, k ->
+        Tuple10(b, c, d, e, f, g, h, i, j, k)
+      }
   }
 
   /**

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -1539,6 +1539,62 @@ fun <A, B> Iterable<Either<A, B>>.combineAll(MA: Monoid<A>, MB: Monoid<B>): Eith
 fun <A, C, B : C> Either<A, B>.widen(): Either<A, C> =
   this
 
+fun <A, B, C> Either<A, B>.product(fb: Either<A, C>): Either<A, Tuple2<B, C>> =
+  flatMap { a ->
+    fb.map { b -> Tuple2(a, b) }
+  }
+
+fun <A, B, C, D> Either<A, B>.map2(fb: Either<A, C>, f: (Tuple2<B, C>) -> D): Either<A, D> =
+  product(fb).map(f)
+
+@JvmName("product3")
+fun <A, B, C, D> Either<A, Tuple2<B, C>>.product(
+  other: Either<A, D>,
+): Either<A, Tuple3<B, C, D>> =
+  map2(other) { (abcdefg, h) -> Tuple3(abcdefg.a, abcdefg.b, h) }
+
+@JvmName("product4")
+fun <A, B, C, D, E> Either<A, Tuple3<B, C, D>>.product(
+  other: Either<A, E>,
+): Either<A, Tuple4<B, C, D, E>> =
+  map2(other) { (abcdefg, h) -> Tuple4(abcdefg.a, abcdefg.b, abcdefg.c, h) }
+
+@JvmName("product5")
+fun <A, B, C, D, E, F> Either<A, Tuple4<B, C, D, E>>.product(
+  other: Either<A, F>,
+): Either<A, Tuple5<B, C, D, E, F>> =
+  map2(other) { (abcdefg, h) -> Tuple5(abcdefg.a, abcdefg.b, abcdefg.c, abcdefg.d, h) }
+
+@JvmName("product6")
+fun <A, B, C, D, E, F, G> Either<A, Tuple5<B, C, D, E, F>>.product(
+  other: Either<A, G>,
+): Either<A, Tuple6<B, C, D, E, F, G>> =
+  map2(other) { (abcdefg, h) -> Tuple6(abcdefg.a, abcdefg.b, abcdefg.c, abcdefg.d, abcdefg.e, h) }
+
+@JvmName("product7")
+fun <A, B, C, D, E, F, G, H> Either<A, Tuple6<B, C, D, E, F, G>>.product(
+  other: Either<A, H>,
+): Either<A, Tuple7<B, C, D, E, F, G, H>> =
+  map2(other) { (abcdefg, h) -> Tuple7(abcdefg.a, abcdefg.b, abcdefg.c, abcdefg.d, abcdefg.e, abcdefg.f, h) }
+
+@JvmName("product8")
+fun <A, B, C, D, E, F, G, H, I> Either<A, Tuple7<B, C, D, E, F, G, H>>.product(
+  other: Either<A, I>,
+): Either<A, Tuple8<B, C, D, E, F, G, H, I>> =
+  map2(other) { (abcdefg, h) -> Tuple8(abcdefg.a, abcdefg.b, abcdefg.c, abcdefg.d, abcdefg.e, abcdefg.f, abcdefg.g, h) }
+
+@JvmName("product9")
+fun <A, B, C, D, E, F, G, H, I, J> Either<A, Tuple8<B, C, D, E, F, G, H, I>>.product(
+  other: Either<A, J>,
+): Either<A, Tuple9<B, C, D, E, F, G, H, I, J>> =
+  map2(other) { (abcdefgh, i) -> Tuple9(abcdefgh.a, abcdefgh.b, abcdefgh.c, abcdefgh.d, abcdefgh.e, abcdefgh.f, abcdefgh.g, abcdefgh.h, i) }
+
+@JvmName("product10")
+fun <A, B, C, D, E, F, G, H, I, J, K> Either<A, Tuple9<B, C, D, E, F, G, H, I, J>>.product(
+  other: Either<A, K>,
+): Either<A, Tuple10<B, C, D, E, F, G, H, I, J, K>> =
+  map2(other) { (abcdefghi, j) -> Tuple10(abcdefghi.a, abcdefghi.b, abcdefghi.c, abcdefghi.d, abcdefghi.e, abcdefghi.f, abcdefghi.g, abcdefghi.h, abcdefghi.i, j) }
+
 private class EitherEq<L, R>(
   private val EQL: Eq<L>,
   private val EQR: Eq<R>

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -5,6 +5,7 @@ import arrow.core.Either.Companion.resolve
 import arrow.core.Either.Left
 import arrow.core.Either.Right
 import arrow.core.Valid
+import arrow.typeclasses.Align
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -1845,6 +1845,9 @@ fun <A, B> Iterable<Either<A, B>>.combineAll(MA: Monoid<A>, MB: Monoid<B>): Eith
 fun <A, C, B : C> Either<A, B>.widen(): Either<A, C> =
   this
 
+fun <AA, A : AA, B> Either<A, B>.leftWiden(): Either<AA, B> =
+  this
+
 fun <A, B, C> Either<A, B>.product(fb: Either<A, C>): Either<A, Tuple2<B, C>> =
   flatMap { a ->
     fb.map { b -> Tuple2(a, b) }

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -868,6 +868,10 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
   inline fun <C> bifoldRight(c: Eval<C>, f: (A, Eval<C>) -> Eval<C>, g: (B, Eval<C>) -> Eval<C>): Eval<C> =
     fold({ f(it, c) }, { g(it, c) })
 
+  inline fun <C> bifoldMap(MN: Monoid<C>, f: (A) -> C, g: (B) -> C): C = MN.run {
+    bifoldLeft(MN.empty(), { c, a -> c.combine(f(a)) }, { c, b -> c.combine(g(b)) })
+  }
+
   /**
    * If this is a `Left`, then return the left value in `Right` or vice versa.
    *

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -1103,6 +1103,9 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
 
     fun <A, B> hash(HA: Hash<A>, HB: Hash<B>): Hash<Either<A, B>> =
       EitherHash(HA, HB)
+
+    fun <A, B> show(SA: Show<A>, SB: Show<B>): Show<Either<A, B>> =
+      EitherShow(SA, SB)
   }
 
   fun <C> mapConst(c: C): Either<A, C> =
@@ -1383,4 +1386,12 @@ private class EitherHash<L, R>(
 
   override fun Either<L, R>.hashWithSalt(salt: Int): Int =
     hashWithSalt(HL, HR, salt)
+}
+
+private class EitherShow<L, R>(
+  private val SL: Show<L>,
+  private val SR: Show<R>
+) : Show<Either<L, R>> {
+  override fun Either<L, R>.show(): String =
+    show(SL, SR)
 }

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -1013,6 +1013,13 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
   fun <C> tupleRight(c: C): Either<A, Tuple2<B, C>> =
     map { b -> Tuple2(b, c) }
 
+  fun replicate(n: Int): Either<A, List<B>> =
+    if (n <= 0) emptyList<B>().right()
+    else when(this) {
+      is Left -> this
+      is Right -> List(n) { this.b }.right()
+    }
+
   /**
    * The left side of the disjoint union, as opposed to the [Right] side.
    */
@@ -1825,6 +1832,15 @@ fun <A, B, C, D, E, F, G, H, I, J, K> Either<A, Tuple9<B, C, D, E, F, G, H, I, J
   other: Either<A, K>,
 ): Either<A, Tuple10<B, C, D, E, F, G, H, I, J, K>> =
   map2(other) { (abcdefghi, j) -> Tuple10(abcdefghi.a, abcdefghi.b, abcdefghi.c, abcdefghi.d, abcdefghi.e, abcdefghi.f, abcdefghi.g, abcdefghi.h, abcdefghi.i, j) }
+
+fun <A, B> Either<A, B>.replicate(n: Int, MB: Monoid<B>): Either<A, B> =
+  if (n <= 0) MB.empty().right()
+  else MB.run {
+    when (this@replicate) {
+      is Left -> this@replicate
+      is Right -> List(n) { this@replicate.b }.combineAll().right()
+    }
+  }
 
 private class EitherEq<L, R>(
   private val EQL: Eq<L>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -1617,6 +1617,12 @@ fun <A, B> EitherOf<A, B>.contains(elem: B): Boolean =
 fun <A, B, C> EitherOf<A, B>.ap(ff: EitherOf<A, (B) -> C>): Either<A, C> =
   flatMap { a -> ff.fix().map { f -> f(a) } }
 
+fun <A, B, C> Either<A, B>.apEval(ff: Eval<Either<A, (B) -> C>>): Eval<Either<A, C>> =
+  ff.map { this.ap(it) }
+
+fun <A, B, C, Z> Either<A, B>.map2Eval(fb: Eval<Either<A, C>>, f: (Tuple2<B, C>) -> Z): Eval<Either<A, Z>> =
+  apEval(fb.map { it.map { c -> { b: B -> f(Tuple2(b, c)) } } })
+
 fun <A, B> EitherOf<A, B>.combineK(y: EitherOf<A, B>): Either<A, B> =
   when (this) {
     is Left -> y.fix()

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -1192,6 +1192,125 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
 
     fun <A, B> monoid(MA: Monoid<A>, MB: Monoid<B>): Monoid<Either<A, B>> =
       EitherMonoid(MA, MB)
+
+    inline fun <A, B, C, D> mapN(
+      b: Either<A, B>,
+      c: Either<A, C>,
+      map: (B, C) -> D
+    ): Either<A, D> =
+      mapN(b, c, unit, unit, unit, unit, unit, unit, unit, unit) { b, c, _, _, _, _, _, _, _, _ -> map(b, c) }
+
+    inline fun <A, B, C, D, E> mapN(
+      b: Either<A, B>,
+      c: Either<A, C>,
+      d: Either<A, D>,
+      map: (B, C, D) -> E
+    ): Either<A, E> =
+      mapN(b, c, d, unit, unit, unit, unit, unit, unit, unit) { b, c, d, _, _, _, _, _, _, _ -> map(b, c, d) }
+
+    inline fun <A, B, C, D, E, F> mapN(
+      b: Either<A, B>,
+      c: Either<A, C>,
+      d: Either<A, D>,
+      e: Either<A, E>,
+      map: (B, C, D, E) -> F
+    ): Either<A, F> =
+      mapN(b, c, d, e, unit, unit, unit, unit, unit, unit) { b, c, d, e, _, _, _, _, _, _ -> map(b, c, d, e) }
+
+    inline fun <A, B, C, D, E, F, G> mapN(
+      b: Either<A, B>,
+      c: Either<A, C>,
+      d: Either<A, D>,
+      e: Either<A, E>,
+      f: Either<A, F>,
+      map: (B, C, D, E, F) -> G
+    ): Either<A, G> =
+      mapN(b, c, d, e, f, unit, unit, unit, unit, unit) { b, c, d, e, f, _, _, _, _, _ -> map(b, c, d, e, f) }
+
+    inline fun <A, B, C, D, E, F, G, H> mapN(
+      b: Either<A, B>,
+      c: Either<A, C>,
+      d: Either<A, D>,
+      e: Either<A, E>,
+      f: Either<A, F>,
+      g: Either<A, G>,
+      map: (B, C, D, E, F, G) -> H
+    ): Either<A, H> =
+      mapN(b, c, d, e, f, g, unit, unit, unit, unit) { b, c, d, e, f, g, _, _, _, _ -> map(b, c, d, e, f, g) }
+
+    inline fun <A, B, C, D, E, F, G, H, I> mapN(
+      b: Either<A, B>,
+      c: Either<A, C>,
+      d: Either<A, D>,
+      e: Either<A, E>,
+      f: Either<A, F>,
+      g: Either<A, G>,
+      h: Either<A, H>,
+      map: (B, C, D, E, F, G, H) -> I
+    ): Either<A, I> =
+      mapN(b, c, d, e, f, g, h, unit, unit, unit) { b, c, d, e, f, g, h, _, _, _ -> map(b, c, d, e, f, g, h) }
+
+    inline fun <A, B, C, D, E, F, G, H, I, J> mapN(
+      b: Either<A, B>,
+      c: Either<A, C>,
+      d: Either<A, D>,
+      e: Either<A, E>,
+      f: Either<A, F>,
+      g: Either<A, G>,
+      h: Either<A, H>,
+      i: Either<A, I>,
+      map: (B, C, D, E, F, G, H, I) -> J
+    ): Either<A, J> =
+      mapN(b, c, d, e, f, g, h, i, unit, unit) { b, c, d, e, f, g, h, i, _, _ -> map(b, c, d, e, f, g, h, i) }
+
+    inline fun <A, B, C, D, E, F, G, H, I, J, K> mapN(
+      b: Either<A, B>,
+      c: Either<A, C>,
+      d: Either<A, D>,
+      e: Either<A, E>,
+      f: Either<A, F>,
+      g: Either<A, G>,
+      h: Either<A, H>,
+      i: Either<A, I>,
+      j: Either<A, J>,
+      map: (B, C, D, E, F, G, H, I, J) -> K
+    ): Either<A, K> =
+      mapN(b, c, d, e, f, g, h, i, j, unit) { b, c, d, e, f, g, h, i, j, _ -> map(b, c, d, e, f, g, h, i, j) }
+
+    inline fun <A, B, C, D, E, F, G, H, I, J, K, L> mapN(
+      b: Either<A, B>,
+      c: Either<A, C>,
+      d: Either<A, D>,
+      e: Either<A, E>,
+      f: Either<A, F>,
+      g: Either<A, G>,
+      h: Either<A, H>,
+      i: Either<A, I>,
+      j: Either<A, J>,
+      k: Either<A, K>,
+      map: (B, C, D, E, F, G, H, I, J, K) -> L
+    ): Either<A, L> =
+      b.flatMap { bb ->
+        c.flatMap { cc ->
+          d.flatMap { dd ->
+            e.flatMap { ee ->
+              f.flatMap { ff ->
+                g.flatMap { gg ->
+                  h.flatMap { hh ->
+                    i.flatMap { ii ->
+                      j.flatMap { jj ->
+                        k.map { kk ->
+                          map(bb, cc, dd, ee, ff, gg, hh, ii, jj, kk)
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
   }
 
   /**

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -1838,9 +1838,6 @@ fun <A, B> Either<A, B>.combine(SGA: Semigroup<A>, SGB: Semigroup<B>, b: Either<
     }
   }
 
-fun <A, B> Either<A, B>.maybeCombine(SGA: Semigroup<A>, SGB: Semigroup<B>, b: Either<A, B>?): Either<A, B> =
-  b?.let { combine(SGA, SGB, it) } ?: this
-
 fun <A, B> Iterable<Either<A, B>>.combineAll(MA: Monoid<A>, MB: Monoid<B>): Either<A, B> =
   fold(Right(MB.empty()) as Either<A, B>) { acc, e ->
     acc.combine(MA, MB, e)
@@ -2018,7 +2015,7 @@ private open class EitherSemigroup<L, R>(
     combine(SGL, SGR, b)
 
   override fun Either<L, R>.maybeCombine(b: Either<L, R>?): Either<L, R> =
-    maybeCombine(SGL, SGR, b)
+    b?.let { combine(SGL, SGR, it) } ?: this
 }
 
 private class EitherMonoid<L, R>(

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -1429,4 +1429,3 @@ private class ValidatedOrder<L, R>(
   override fun Validated<L, R>.compare(b: Validated<L, R>): Ordering =
     compare(OL, OR, b)
 }
-

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -1070,12 +1070,6 @@ fun <E, B> Validated<E, B>.eqv(
 }
 
 /**
- * Replaces the [B] value inside [Validated] with [A] resulting in Validated<E, A>
- */
-fun <E, A, B> A.mapConst(fb: Validated<E, B>): Validated<E, A> =
-  fb.mapConst(this)
-
-/**
  * Given [A] is a sub type of [B], re-type this value from Validated<E, A> to Validated<E, B>
  *
  * ```kotlin:ank:playground:extension

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -1429,3 +1429,4 @@ private class ValidatedOrder<L, R>(
   override fun Validated<L, R>.compare(b: Validated<L, R>): Ordering =
     compare(OL, OR, b)
 }
+

--- a/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/EitherTest.kt
@@ -275,11 +275,11 @@ class EitherTest : UnitSpec() {
         runBlocking {
           val result =
             Either.resolve(
-              f = f,
+              f = { f() },
               success = { a -> handleWithPureFunction(a, returnObject) },
               error = { e -> handleWithPureFunction(e, returnObject) },
               throwable = { t -> handleWithPureFunction(t, returnObject) },
-              unrecoverableState = ::handleWithPureFunction
+              unrecoverableState = { handleWithPureFunction(it) }
             )
           result == returnObject
         }
@@ -295,11 +295,11 @@ class EitherTest : UnitSpec() {
         runBlocking {
           shouldThrow<Throwable> {
             Either.resolve(
-              f = f,
+              f = { f() },
               success = { a -> handleWithPureFunction(a, returnObject) },
               error = { e -> handleWithPureFunction(e, returnObject) },
               throwable = { t -> handleWithPureFunction(t, returnObject) },
-              unrecoverableState = ::handleWithPureFunction
+              unrecoverableState = { handleWithPureFunction(it) }
             )
           }
         }
@@ -316,11 +316,11 @@ class EitherTest : UnitSpec() {
         runBlocking {
           val result =
             Either.resolve(
-              f = f,
-              success = ::throwException,
+              f = { f() },
+              success = { throwException(it) },
               error = { e -> handleWithPureFunction(e, returnObject) },
               throwable = { t -> handleWithPureFunction(t, returnObject) },
-              unrecoverableState = ::handleWithPureFunction
+              unrecoverableState = { handleWithPureFunction(it) }
             )
           result == returnObject
         }
@@ -336,11 +336,11 @@ class EitherTest : UnitSpec() {
         runBlocking {
           val result =
             Either.resolve(
-              f = f,
+              f = { f() },
               success = { a -> handleWithPureFunction(a, returnObject) },
-              error = ::throwException,
+              error = { throwException(it) },
               throwable = { t -> handleWithPureFunction(t, returnObject) },
-              unrecoverableState = ::handleWithPureFunction
+              unrecoverableState = { handleWithPureFunction(it) }
             )
           result == returnObject
         }
@@ -355,11 +355,11 @@ class EitherTest : UnitSpec() {
         runBlocking {
           shouldThrow<Throwable> {
             Either.resolve(
-              f = f,
-              success = ::throwException,
-              error = ::throwException,
-              throwable = ::throwException,
-              unrecoverableState = ::handleWithPureFunction
+              f = { f() },
+              success = { throwException(it) },
+              error = { throwException(it) },
+              throwable = { throwException(it) },
+              unrecoverableState = { handleWithPureFunction(it) }
             )
           }
         }

--- a/arrow-core-data/src/test/kotlin/arrow/typeclasses/BifoldableTests.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/typeclasses/BifoldableTests.kt
@@ -2,9 +2,8 @@ package arrow.typeclasses
 
 import arrow.Kind2
 import arrow.core.Either
-import arrow.core.Eval
 import arrow.core.ForEither
-import arrow.core.fix
+import arrow.core.extensions.either.bifoldable.bifoldable
 import arrow.mtl.typeclasses.Nested
 import arrow.mtl.typeclasses.binest
 import arrow.mtl.typeclasses.compose
@@ -17,23 +16,7 @@ import io.kotlintest.properties.Gen
 
 class BifoldableTests : UnitSpec() {
   init {
-    val eitherBifoldable: Bifoldable<ForEither> = object : Bifoldable<ForEither> {
-      override fun <A, B, C> Kind2<ForEither, A, B>.bifoldLeft(c: C, f: (C, A) -> C, g: (C, B) -> C): C =
-        this.fix().run {
-          when (this) {
-            is Either.Left -> f(c, a)
-            is Either.Right -> g(c, b)
-          }
-        }
-
-      override fun <A, B, C> Kind2<ForEither, A, B>.bifoldRight(c: Eval<C>, f: (A, Eval<C>) -> Eval<C>, g: (B, Eval<C>) -> Eval<C>): Eval<C> =
-        when (this) {
-          is Either.Left -> f(a, c)
-          else -> g((this as Either.Right).b, c)
-        }
-    }
-
-    val eitherComposeEither = eitherBifoldable.compose(eitherBifoldable)
+    val eitherComposeEither = Either.bifoldable().compose(Either.bifoldable())
 
     val eitherGen = Gen.either(Gen.intSmall(), Gen.intSmall())
 

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either.kt
@@ -19,7 +19,6 @@ import arrow.core.extensions.either.monad.monad
 import arrow.core.fix
 import arrow.core.left
 import arrow.core.right
-import arrow.extension
 import arrow.typeclasses.Align
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.ApplicativeError
@@ -66,7 +65,6 @@ fun <L, R> Either<L, R>.combine(SGL: Semigroup<L>, SGR: Semigroup<R>, b: Either<
   }
 }
 
-@extension
 interface EitherSemigroup<L, R> : Semigroup<Either<L, R>> {
 
   fun SGL(): Semigroup<L>
@@ -75,7 +73,6 @@ interface EitherSemigroup<L, R> : Semigroup<Either<L, R>> {
   override fun Either<L, R>.combine(b: Either<L, R>): Either<L, R> = fix().combine(SGL(), SGR(), b)
 }
 
-@extension
 interface EitherMonoid<L, R> : Monoid<Either<L, R>>, EitherSemigroup<L, R> {
   fun MOL(): Monoid<L>
   fun MOR(): Monoid<R>
@@ -86,18 +83,15 @@ interface EitherMonoid<L, R> : Monoid<Either<L, R>>, EitherSemigroup<L, R> {
   override fun empty(): Either<L, R> = Right(MOR().empty())
 }
 
-@extension
 interface EitherFunctor<L> : Functor<EitherPartialOf<L>> {
   override fun <A, B> EitherOf<L, A>.map(f: (A) -> B): Either<L, B> = fix().map(f)
 }
 
-@extension
 interface EitherBifunctor : Bifunctor<ForEither> {
   override fun <A, B, C, D> EitherOf<A, B>.bimap(fl: (A) -> C, fr: (B) -> D): Either<C, D> =
     fix().bimap(fl, fr)
 }
 
-@extension
 interface EitherApply<L> : Apply<EitherPartialOf<L>>, EitherFunctor<L> {
 
   override fun <A, B> EitherOf<L, A>.map(f: (A) -> B): Either<L, B> = fix().map(f)
@@ -109,7 +103,6 @@ interface EitherApply<L> : Apply<EitherPartialOf<L>>, EitherFunctor<L> {
     fix().eitherAp(ff)
 }
 
-@extension
 interface EitherApplicative<L> : Applicative<EitherPartialOf<L>>, EitherApply<L> {
 
   override fun <A> just(a: A): Either<L, A> = Right(a)
@@ -117,7 +110,6 @@ interface EitherApplicative<L> : Applicative<EitherPartialOf<L>>, EitherApply<L>
   override fun <A, B> EitherOf<L, A>.map(f: (A) -> B): Either<L, B> = fix().map(f)
 }
 
-@extension
 interface EitherMonad<L> : Monad<EitherPartialOf<L>>, EitherApplicative<L> {
 
   override fun <A, B> EitherOf<L, A>.map(f: (A) -> B): Either<L, B> = fix().map(f)
@@ -142,7 +134,6 @@ internal object EitherMonadFx : MonadFx<EitherPartialOf<Any?>> {
     super.monad(c).fix()
 }
 
-@extension
 interface EitherApplicativeError<L> : ApplicativeError<EitherPartialOf<L>, L>, EitherApplicative<L> {
 
   override fun <A> raiseError(e: L): Either<L, A> = Left(e)
@@ -151,10 +142,8 @@ interface EitherApplicativeError<L> : ApplicativeError<EitherPartialOf<L>, L>, E
     fix().eitherHandleErrorWith(f)
 }
 
-@extension
 interface EitherMonadError<L> : MonadError<EitherPartialOf<L>, L>, EitherApplicativeError<L>, EitherMonad<L>
 
-@extension
 interface EitherFoldable<L> : Foldable<EitherPartialOf<L>> {
 
   override fun <A, B> EitherOf<L, A>.foldLeft(b: B, f: (B, A) -> B): B =
@@ -164,7 +153,6 @@ interface EitherFoldable<L> : Foldable<EitherPartialOf<L>> {
     fix().foldRight(lb, f)
 }
 
-@extension
 interface EitherBifoldable : Bifoldable<ForEither> {
   override fun <A, B, C> EitherOf<A, B>.bifoldLeft(c: C, f: (C, A) -> C, g: (C, B) -> C): C = fix().bifoldLeft(c, f, g)
 
@@ -175,27 +163,23 @@ interface EitherBifoldable : Bifoldable<ForEither> {
 fun <G, A, B, C> EitherOf<A, B>.traverse(GA: Applicative<G>, f: (B) -> Kind<G, C>): Kind<G, Either<A, C>> =
   fix().fold({ GA.just(Either.Left(it)) }, { GA.run { f(it).map { Either.Right(it) } } })
 
-@extension
 interface EitherTraverse<L> : Traverse<EitherPartialOf<L>>, EitherFoldable<L> {
 
   override fun <G, A, B> EitherOf<L, A>.traverse(AP: Applicative<G>, f: (A) -> Kind<G, B>): Kind<G, EitherOf<L, B>> =
     fix().eitherTraverse(AP, f)
 }
 
-@extension
 interface EitherBitraverse : Bitraverse<ForEither>, EitherBifoldable {
   override fun <G, A, B, C, D> EitherOf<A, B>.bitraverse(AP: Applicative<G>, f: (A) -> Kind<G, C>, g: (B) -> Kind<G, D>): Kind<G, EitherOf<C, D>> =
     fix().let { AP.run { it.fold({ f(it).map { Either.Left(it) } }, { g(it).map { Either.Right(it) } }) } }
 }
 
-@extension
 interface EitherSemigroupK<L> : SemigroupK<EitherPartialOf<L>> {
 
   override fun <A> EitherOf<L, A>.combineK(y: EitherOf<L, A>): Either<L, A> =
     fix().eitherCombineK(y)
 }
 
-@extension
 interface EitherEq<in L, in R> : Eq<Either<L, R>> {
 
   fun EQL(): Eq<L>
@@ -214,7 +198,6 @@ interface EitherEq<in L, in R> : Eq<Either<L, R>> {
   }
 }
 
-@extension
 interface EitherEqK<L> : EqK<EitherPartialOf<L>> {
   fun EQL(): Eq<L>
 
@@ -224,7 +207,6 @@ interface EitherEqK<L> : EqK<EitherPartialOf<L>> {
     }
 }
 
-@extension
 interface EitherEqK2 : EqK2<ForEither> {
   override fun <A, B> Kind2<ForEither, A, B>.eqK(other: Kind2<ForEither, A, B>, EQA: Eq<A>, EQB: Eq<B>): Boolean =
     (this.fix() to other.fix()).let {
@@ -234,14 +216,12 @@ interface EitherEqK2 : EqK2<ForEither> {
     }
 }
 
-@extension
 interface EitherShow<L, R> : Show<Either<L, R>> {
   fun SL(): Show<L>
   fun SR(): Show<R>
   override fun Either<L, R>.show(): String = show(SL(), SR())
 }
 
-@extension
 interface EitherHash<L, R> : Hash<Either<L, R>> {
 
   fun HL(): Hash<L>
@@ -260,7 +240,6 @@ interface EitherHash<L, R> : Hash<Either<L, R>> {
     )
 }
 
-@extension
 interface EitherOrder<L, R> : Order<Either<L, R>> {
   fun OL(): Order<L>
   fun OR(): Order<R>
@@ -276,7 +255,6 @@ interface EitherOrder<L, R> : Order<Either<L, R>> {
 fun <L, R> Either.Companion.fx(c: suspend MonadSyntax<EitherPartialOf<L>>.() -> R): Either<L, R> =
   Either.monad<L>().fx.monad(c).fix()
 
-@extension
 interface EitherBicrosswalk : Bicrosswalk<ForEither>, EitherBifunctor, EitherBifoldable {
   override fun <F, A, B, C, D> bicrosswalk(
     ALIGN: Align<F>,

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/applicative/EitherApplicative.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/applicative/EitherApplicative.kt
@@ -1,0 +1,87 @@
+package arrow.core.extensions.either.applicative
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.Either.Companion
+import arrow.core.ForEither
+import arrow.core.extensions.EitherApplicative
+import arrow.typeclasses.Monoid
+import kotlin.Any
+import kotlin.Function1
+import kotlin.Int
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.List
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val applicative_singleton: EitherApplicative<Any?> = object : EitherApplicative<Any?> {}
+
+@JvmName("just1")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> A.just(): Either<L, A> = arrow.core.Either.applicative<L>().run {
+  this@just.just<A>() as arrow.core.Either<L, A>
+}
+
+@JvmName("unit")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L> unit(): Either<L, Unit> = arrow.core.Either
+  .applicative<L>()
+  .unit() as arrow.core.Either<L, kotlin.Unit>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.map(arg1: Function1<A, B>): Either<L, B> =
+  arrow.core.Either.applicative<L>().run {
+    this@map.map<A, B>(arg1) as arrow.core.Either<L, B>
+  }
+
+@JvmName("replicate")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.replicate(arg1: Int): Either<L, List<A>> =
+  arrow.core.Either.applicative<L>().run {
+    this@replicate.replicate<A>(arg1) as arrow.core.Either<L, kotlin.collections.List<A>>
+  }
+
+@JvmName("replicate")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.replicate(arg1: Int, arg2: Monoid<A>): Either<L, A> =
+  arrow.core.Either.applicative<L>().run {
+    this@replicate.replicate<A>(arg1, arg2) as arrow.core.Either<L, A>
+  }
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+inline fun <L> Companion.applicative(): EitherApplicative<L> = applicative_singleton as
+  arrow.core.extensions.EitherApplicative<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/applicative/EitherApplicative.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/applicative/EitherApplicative.kt
@@ -2,9 +2,12 @@ package arrow.core.extensions.either.applicative
 
 import arrow.Kind
 import arrow.core.Either
+import arrow.core.replicate as _replicate
 import arrow.core.Either.Companion
 import arrow.core.ForEither
 import arrow.core.extensions.EitherApplicative
+import arrow.core.fix
+import arrow.core.right
 import arrow.typeclasses.Monoid
 import kotlin.Any
 import kotlin.Function1
@@ -28,9 +31,9 @@ internal val applicative_singleton: EitherApplicative<Any?> = object : EitherApp
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-fun <L, A> A.just(): Either<L, A> = arrow.core.Either.applicative<L>().run {
-  this@just.just<A>() as arrow.core.Either<L, A>
-}
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("this.right()", "arrow.core.right"))
+fun <L, A> A.just(): Either<L, A> =
+  right()
 
 @JvmName("unit")
 @Suppress(
@@ -39,9 +42,9 @@ fun <L, A> A.just(): Either<L, A> = arrow.core.Either.applicative<L>().run {
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-fun <L> unit(): Either<L, Unit> = arrow.core.Either
-  .applicative<L>()
-  .unit() as arrow.core.Either<L, kotlin.Unit>
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.unit()", "arrow.core.unit"))
+fun <L> unit(): Either<L, Unit> =
+  Either.unit()
 
 @JvmName("map")
 @Suppress(
@@ -50,10 +53,9 @@ fun <L> unit(): Either<L, Unit> = arrow.core.Either
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("map(arg1)"))
 fun <L, A, B> Kind<Kind<ForEither, L>, A>.map(arg1: Function1<A, B>): Either<L, B> =
-  arrow.core.Either.applicative<L>().run {
-    this@map.map<A, B>(arg1) as arrow.core.Either<L, B>
-  }
+  fix().map(arg1)
 
 @JvmName("replicate")
 @Suppress(
@@ -62,10 +64,9 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.map(arg1: Function1<A, B>): Either<L, 
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("replicate(arg1)"))
 fun <L, A> Kind<Kind<ForEither, L>, A>.replicate(arg1: Int): Either<L, List<A>> =
-  arrow.core.Either.applicative<L>().run {
-    this@replicate.replicate<A>(arg1) as arrow.core.Either<L, kotlin.collections.List<A>>
-  }
+  fix().replicate(arg1)
 
 @JvmName("replicate")
 @Suppress(
@@ -74,14 +75,14 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.replicate(arg1: Int): Either<L, List<A>> 
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("replicate(arg1, arg2)", "arrow.core.replicate"))
 fun <L, A> Kind<Kind<ForEither, L>, A>.replicate(arg1: Int, arg2: Monoid<A>): Either<L, A> =
-  arrow.core.Either.applicative<L>().run {
-    this@replicate.replicate<A>(arg1, arg2) as arrow.core.Either<L, A>
-  }
+  fix()._replicate(arg1, arg2)
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("Applicative typeclasses is deprecated. Use concrete methods on Validated")
 inline fun <L> Companion.applicative(): EitherApplicative<L> = applicative_singleton as
   arrow.core.extensions.EitherApplicative<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/applicative/EitherApplicative.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/applicative/EitherApplicative.kt
@@ -83,6 +83,6 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.replicate(arg1: Int, arg2: Monoid<A>): Ei
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("Applicative typeclasses is deprecated. Use concrete methods on Validated")
+@Deprecated("Applicative typeclasses is deprecated. Use concrete methods on Either")
 inline fun <L> Companion.applicative(): EitherApplicative<L> = applicative_singleton as
   arrow.core.extensions.EitherApplicative<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/applicativeError/EitherApplicativeError.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/applicativeError/EitherApplicativeError.kt
@@ -2,10 +2,18 @@ package arrow.core.extensions.either.applicativeError
 
 import arrow.Kind
 import arrow.core.Either
+import arrow.core.handleErrorWith as _handleErrorWith
+import arrow.core.handleError as _handleError
+import arrow.core.redeem as _redeem
 import arrow.core.Either.Companion
 import arrow.core.ForEither
 import arrow.core.ForOption
+import arrow.core.Left
+import arrow.core.Right
 import arrow.core.extensions.EitherApplicativeError
+import arrow.core.fix
+import arrow.core.left
+import arrow.core.right
 import arrow.typeclasses.ApplicativeError
 import kotlin.Any
 import kotlin.Function0
@@ -29,12 +37,12 @@ internal val applicativeError_singleton: EitherApplicativeError<Any?> = object :
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("handleErrorWith(arg1)", "arrow.core.handleErrorWith"))
 fun <L, A> Kind<Kind<ForEither, L>, A>.handleErrorWith(
   arg1: Function1<L, Kind<Kind<ForEither, L>,
     A>>
-): Either<L, A> = arrow.core.Either.applicativeError<L>().run {
-  this@handleErrorWith.handleErrorWith<A>(arg1) as arrow.core.Either<L, A>
-}
+): Either<L, A> =
+  fix()._handleErrorWith(arg1)
 
 @JvmName("raiseError1")
 @Suppress(
@@ -43,9 +51,9 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.handleErrorWith(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-fun <L, A> L.raiseError(): Either<L, A> = arrow.core.Either.applicativeError<L>().run {
-  this@raiseError.raiseError<A>() as arrow.core.Either<L, A>
-}
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("this.left()", "arrow.core.left"))
+fun <L, A> L.raiseError(): Either<L, A> =
+  left()
 
 @JvmName("fromOption")
 @Suppress(
@@ -54,10 +62,9 @@ fun <L, A> L.raiseError(): Either<L, A> = arrow.core.Either.applicativeError<L>(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.fromNullable(fix().orNull()).mapLeft { arg1.invoke() }", "arrow.core.fromNullable"))
 fun <L, A> Kind<ForOption, A>.fromOption(arg1: Function0<L>): Either<L, A> =
-  arrow.core.Either.applicativeError<L>().run {
-    this@fromOption.fromOption<A>(arg1) as arrow.core.Either<L, A>
-  }
+  Either.fromNullable(fix().orNull()).mapLeft { arg1.invoke() }
 
 @JvmName("fromEither")
 @Suppress(
@@ -66,10 +73,9 @@ fun <L, A> Kind<ForOption, A>.fromOption(arg1: Function0<L>): Either<L, A> =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("mapLeft(arg1)"))
 fun <L, A, EE> Either<EE, A>.fromEither(arg1: Function1<EE, L>): Either<L, A> =
-  arrow.core.Either.applicativeError<L>().run {
-    this@fromEither.fromEither<A, EE>(arg1) as arrow.core.Either<L, A>
-  }
+  mapLeft(arg1)
 
 @JvmName("handleError")
 @Suppress(
@@ -78,10 +84,9 @@ fun <L, A, EE> Either<EE, A>.fromEither(arg1: Function1<EE, L>): Either<L, A> =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("handleError(arg1)"))
 fun <L, A> Kind<Kind<ForEither, L>, A>.handleError(arg1: Function1<L, A>): Either<L, A> =
-  arrow.core.Either.applicativeError<L>().run {
-    this@handleError.handleError<A>(arg1) as arrow.core.Either<L, A>
-  }
+  fix()._handleError(arg1)
 
 @JvmName("redeem")
 @Suppress(
@@ -90,10 +95,9 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.handleError(arg1: Function1<L, A>): Eithe
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-fun <L, A, B> Kind<Kind<ForEither, L>, A>.redeem(arg1: Function1<L, B>, arg2: Function1<A, B>):
-  Either<L, B> = arrow.core.Either.applicativeError<L>().run {
-  this@redeem.redeem<A, B>(arg1, arg2) as arrow.core.Either<L, B>
-}
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("redeem(arg1, arg2)"))
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.redeem(arg1: Function1<L, B>, arg2: Function1<A, B>): Either<L, B> =
+  fix()._redeem(arg1, arg2)
 
 @JvmName("attempt")
 @Suppress(
@@ -102,10 +106,9 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.redeem(arg1: Function1<L, B>, arg2: Fu
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("map { it.right() }.handleErrorWith { it.left().right() }", "arrow.core.right", "arrow.core.left", "arrow.core.handleErrorWith"))
 fun <L, A> Kind<Kind<ForEither, L>, A>.attempt(): Either<L, Either<L, A>> =
-  arrow.core.Either.applicativeError<L>().run {
-    this@attempt.attempt<A>() as arrow.core.Either<L, arrow.core.Either<L, A>>
-  }
+  fix().map { Right(it) }.handleErrorWith { Left(it).right() }
 
 @JvmName("catch")
 @Suppress(
@@ -114,10 +117,9 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.attempt(): Either<L, Either<L, A>> =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.catch(arg0, arg1)", "arrow.core.catch"))
 fun <L, A> catch(arg0: Function1<Throwable, L>, arg1: Function0<A>): Either<L, A> =
-  arrow.core.Either
-    .applicativeError<L>()
-    .effectCatch(arg0, arg1) as arrow.core.Either<L, A>
+  Either.catch(arg0, arg1)
 
 @JvmName("catch")
 @Suppress(
@@ -126,9 +128,10 @@ fun <L, A> catch(arg0: Function1<Throwable, L>, arg1: Function0<A>): Either<L, A
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("This methods is invalid for Validated. ApplicativeError<F, Throwable> is inconsistent in `F`")
 fun <L, A> ApplicativeError<Kind<ForEither, L>, Throwable>.catch(arg1: Function0<A>): Either<L, A> =
   arrow.core.Either.applicativeError<L>().run {
-    effectCatch(arg1) as arrow.core.Either<L, A>
+    catch(arg1) as arrow.core.Either<L, A>
   }
 
 @JvmName("effectCatch")
@@ -138,10 +141,9 @@ fun <L, A> ApplicativeError<Kind<ForEither, L>, Throwable>.catch(arg1: Function0
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith(" Either.catch(arg0) { arg1() }", "arrow.core.catch"))
 suspend fun <L, A> effectCatch(arg0: Function1<Throwable, L>, arg1: suspend () -> A): Either<L, A> =
-  arrow.core.Either
-    .applicativeError<L>()
-    .effectCatch<A>(arg0, arg1) as arrow.core.Either<L, A>
+  Either.catch(arg0) { arg1() }
 
 @JvmName("effectCatch")
 @Suppress(
@@ -150,6 +152,7 @@ suspend fun <L, A> effectCatch(arg0: Function1<Throwable, L>, arg1: suspend () -
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("This methods is invalid for Validated. ApplicativeError<F, Throwable> is inconsistent in `F`")
 suspend fun <L, F, A> ApplicativeError<F, Throwable>.effectCatch(arg1: suspend () -> A): Kind<F, A> =
   arrow.core.Either.applicativeError<L>().run {
     this@effectCatch.effectCatch<F, A>(arg1) as arrow.Kind<F, A>
@@ -159,5 +162,6 @@ suspend fun <L, F, A> ApplicativeError<F, Throwable>.effectCatch(arg1: suspend (
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("ApplicativeErrpr typeclasses is deprecated. Use concrete methods on Validated")
 inline fun <L> Companion.applicativeError(): EitherApplicativeError<L> = applicativeError_singleton
   as arrow.core.extensions.EitherApplicativeError<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/applicativeError/EitherApplicativeError.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/applicativeError/EitherApplicativeError.kt
@@ -1,0 +1,163 @@
+package arrow.core.extensions.either.applicativeError
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.Either.Companion
+import arrow.core.ForEither
+import arrow.core.ForOption
+import arrow.core.extensions.EitherApplicativeError
+import arrow.typeclasses.ApplicativeError
+import kotlin.Any
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val applicativeError_singleton: EitherApplicativeError<Any?> = object :
+  EitherApplicativeError<Any?> {}
+
+@JvmName("handleErrorWith")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.handleErrorWith(
+  arg1: Function1<L, Kind<Kind<ForEither, L>,
+    A>>
+): Either<L, A> = arrow.core.Either.applicativeError<L>().run {
+  this@handleErrorWith.handleErrorWith<A>(arg1) as arrow.core.Either<L, A>
+}
+
+@JvmName("raiseError1")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> L.raiseError(): Either<L, A> = arrow.core.Either.applicativeError<L>().run {
+  this@raiseError.raiseError<A>() as arrow.core.Either<L, A>
+}
+
+@JvmName("fromOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<ForOption, A>.fromOption(arg1: Function0<L>): Either<L, A> =
+  arrow.core.Either.applicativeError<L>().run {
+    this@fromOption.fromOption<A>(arg1) as arrow.core.Either<L, A>
+  }
+
+@JvmName("fromEither")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, EE> Either<EE, A>.fromEither(arg1: Function1<EE, L>): Either<L, A> =
+  arrow.core.Either.applicativeError<L>().run {
+    this@fromEither.fromEither<A, EE>(arg1) as arrow.core.Either<L, A>
+  }
+
+@JvmName("handleError")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.handleError(arg1: Function1<L, A>): Either<L, A> =
+  arrow.core.Either.applicativeError<L>().run {
+    this@handleError.handleError<A>(arg1) as arrow.core.Either<L, A>
+  }
+
+@JvmName("redeem")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.redeem(arg1: Function1<L, B>, arg2: Function1<A, B>):
+  Either<L, B> = arrow.core.Either.applicativeError<L>().run {
+  this@redeem.redeem<A, B>(arg1, arg2) as arrow.core.Either<L, B>
+}
+
+@JvmName("attempt")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.attempt(): Either<L, Either<L, A>> =
+  arrow.core.Either.applicativeError<L>().run {
+    this@attempt.attempt<A>() as arrow.core.Either<L, arrow.core.Either<L, A>>
+  }
+
+@JvmName("catch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> catch(arg0: Function1<Throwable, L>, arg1: Function0<A>): Either<L, A> =
+  arrow.core.Either
+    .applicativeError<L>()
+    .effectCatch(arg0, arg1) as arrow.core.Either<L, A>
+
+@JvmName("catch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> ApplicativeError<Kind<ForEither, L>, Throwable>.catch(arg1: Function0<A>): Either<L, A> =
+  arrow.core.Either.applicativeError<L>().run {
+    effectCatch(arg1) as arrow.core.Either<L, A>
+  }
+
+@JvmName("effectCatch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+suspend fun <L, A> effectCatch(arg0: Function1<Throwable, L>, arg1: suspend () -> A): Either<L, A> =
+  arrow.core.Either
+    .applicativeError<L>()
+    .effectCatch<A>(arg0, arg1) as arrow.core.Either<L, A>
+
+@JvmName("effectCatch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+suspend fun <L, F, A> ApplicativeError<F, Throwable>.effectCatch(arg1: suspend () -> A): Kind<F, A> =
+  arrow.core.Either.applicativeError<L>().run {
+    this@effectCatch.effectCatch<F, A>(arg1) as arrow.Kind<F, A>
+  }
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+inline fun <L> Companion.applicativeError(): EitherApplicativeError<L> = applicativeError_singleton
+  as arrow.core.extensions.EitherApplicativeError<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/applicativeError/EitherApplicativeError.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/applicativeError/EitherApplicativeError.kt
@@ -141,7 +141,7 @@ fun <L, A> ApplicativeError<Kind<ForEither, L>, Throwable>.catch(arg1: Function0
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith(" Either.catch(arg0) { arg1() }", "arrow.core.catch"))
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.catch(arg0) { arg1() }", "arrow.core.catch"))
 suspend fun <L, A> effectCatch(arg0: Function1<Throwable, L>, arg1: suspend () -> A): Either<L, A> =
   Either.catch(arg0) { arg1() }
 
@@ -162,6 +162,6 @@ suspend fun <L, F, A> ApplicativeError<F, Throwable>.effectCatch(arg1: suspend (
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("ApplicativeErrpr typeclasses is deprecated. Use concrete methods on Validated")
+@Deprecated("ApplicativeError typeclasses is deprecated. Use concrete methods on Either")
 inline fun <L> Companion.applicativeError(): EitherApplicativeError<L> = applicativeError_singleton
   as arrow.core.extensions.EitherApplicativeError<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/apply/EitherApply.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/apply/EitherApply.kt
@@ -1,0 +1,922 @@
+package arrow.core.extensions.either.apply
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.Either.Companion
+import arrow.core.Eval
+import arrow.core.ForEither
+import arrow.core.Tuple10
+import arrow.core.Tuple2
+import arrow.core.Tuple3
+import arrow.core.Tuple4
+import arrow.core.Tuple5
+import arrow.core.Tuple6
+import arrow.core.Tuple7
+import arrow.core.Tuple8
+import arrow.core.Tuple9
+import arrow.core.extensions.EitherApply
+import kotlin.Any
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val apply_singleton: EitherApply<Any?> = object : EitherApply<Any?> {}
+
+@JvmName("ap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.ap(arg1: Kind<Kind<ForEither, L>, Function1<A, B>>):
+  Either<L, B> = arrow.core.Either.apply<L>().run {
+  this@EitherApply.mapN<A, (A) -> B, B>(this@ap, arg1) { (a, f) -> f(a) } as arrow.core.Either<L, B>
+}
+
+@JvmName("apEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.apEval(
+  arg1: Eval<Kind<Kind<ForEither, L>, Function1<A,
+    B>>>
+): Eval<Kind<Kind<ForEither, L>, B>> = arrow.core.Either.apply<L>().run {
+  this@apEval.map2Eval(arg1) { (a, f) -> f(a) } as arrow.core.Eval<arrow.Kind<arrow.Kind<arrow.core.ForEither, L>,
+    B>>
+}
+
+@JvmName("map2Eval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, Z> Kind<Kind<ForEither, L>, A>.map2Eval(
+  arg1: Eval<Kind<Kind<ForEither, L>, B>>,
+  arg2: Function1<Tuple2<A, B>, Z>
+): Eval<Kind<Kind<ForEither, L>, Z>> =
+  arrow.core.Either.apply<L>().run {
+    this@map2Eval.map2Eval<A, B, Z>(arg1, arg2) as
+      arrow.core.Eval<arrow.Kind<arrow.Kind<arrow.core.ForEither, L>, Z>>
+  }
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, Z> map(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Function1<Tuple2<A, B>, Z>
+): Either<L, Z> = arrow.core.Either
+  .apply<L>()
+  .mapN(arg0, arg1, arg2) as arrow.core.Either<L, Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, Z> mapN(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Function1<Tuple2<A, B>, Z>
+): Either<L, Z> = arrow.core.Either
+  .apply<L>()
+  .mapN<A, B, Z>(arg0, arg1, arg2) as arrow.core.Either<L, Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, Z> map(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Function1<Tuple3<A, B, C>, Z>
+): Either<L, Z> = arrow.core.Either
+  .apply<L>()
+  .mapN(arg0, arg1, arg2, arg3) as arrow.core.Either<L, Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, Z> mapN(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Function1<Tuple3<A, B, C>, Z>
+): Either<L, Z> = arrow.core.Either
+  .apply<L>()
+  .mapN<A, B, C, Z>(arg0, arg1, arg2, arg3) as arrow.core.Either<L, Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, Z> map(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Function1<Tuple4<A, B, C, D>, Z>
+): Either<L, Z> = arrow.core.Either
+  .apply<L>()
+  .mapN(arg0, arg1, arg2, arg3, arg4) as arrow.core.Either<L, Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, Z> mapN(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Function1<Tuple4<A, B, C, D>, Z>
+): Either<L, Z> = arrow.core.Either
+  .apply<L>()
+  .mapN<A, B, C, D, Z>(arg0, arg1, arg2, arg3, arg4) as arrow.core.Either<L, Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, Z> map(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Kind<Kind<ForEither, L>, E>,
+  arg5: Function1<Tuple5<A, B, C, D, E>, Z>
+): Either<L, Z> = arrow.core.Either
+  .apply<L>()
+  .mapN(arg0, arg1, arg2, arg3, arg4, arg5) as arrow.core.Either<L, Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, Z> mapN(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Kind<Kind<ForEither, L>, E>,
+  arg5: Function1<Tuple5<A, B, C, D, E>, Z>
+): Either<L, Z> = arrow.core.Either
+  .apply<L>()
+  .mapN<A, B, C, D, E, Z>(arg0, arg1, arg2, arg3, arg4, arg5) as arrow.core.Either<L, Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, FF, Z> map(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Kind<Kind<ForEither, L>, E>,
+  arg5: Kind<Kind<ForEither, L>, FF>,
+  arg6: Function1<Tuple6<A, B, C, D, E, FF>, Z>
+): Either<L, Z> = arrow.core.Either
+  .apply<L>()
+  .mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as arrow.core.Either<L, Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, FF, Z> mapN(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Kind<Kind<ForEither, L>, E>,
+  arg5: Kind<Kind<ForEither, L>, FF>,
+  arg6: Function1<Tuple6<A, B, C, D, E, FF>, Z>
+): Either<L, Z> = arrow.core.Either
+  .apply<L>()
+  .mapN<A, B, C, D, E, FF, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as arrow.core.Either<L, Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, FF, G, Z> map(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Kind<Kind<ForEither, L>, E>,
+  arg5: Kind<Kind<ForEither, L>, FF>,
+  arg6: Kind<Kind<ForEither, L>, G>,
+  arg7: Function1<Tuple7<A, B, C, D, E, FF, G>, Z>
+): Either<L, Z> = arrow.core.Either
+  .apply<L>()
+  .mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as
+  arrow.core.Either<L, Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, FF, G, Z> mapN(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Kind<Kind<ForEither, L>, E>,
+  arg5: Kind<Kind<ForEither, L>, FF>,
+  arg6: Kind<Kind<ForEither, L>, G>,
+  arg7: Function1<Tuple7<A, B, C, D, E, FF, G>, Z>
+): Either<L, Z> = arrow.core.Either
+  .apply<L>()
+  .mapN<A, B, C, D, E, FF, G, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as
+  arrow.core.Either<L, Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, FF, G, H, Z> map(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Kind<Kind<ForEither, L>, E>,
+  arg5: Kind<Kind<ForEither, L>, FF>,
+  arg6: Kind<Kind<ForEither, L>, G>,
+  arg7: Kind<Kind<ForEither, L>, H>,
+  arg8: Function1<Tuple8<A, B, C, D, E, FF, G, H>, Z>
+): Either<L, Z> = arrow.core.Either
+  .apply<L>()
+  .mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
+  arrow.core.Either<L, Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, FF, G, H, Z> mapN(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Kind<Kind<ForEither, L>, E>,
+  arg5: Kind<Kind<ForEither, L>, FF>,
+  arg6: Kind<Kind<ForEither, L>, G>,
+  arg7: Kind<Kind<ForEither, L>, H>,
+  arg8: Function1<Tuple8<A, B, C, D, E, FF, G, H>, Z>
+): Either<L, Z> = arrow.core.Either
+  .apply<L>()
+  .mapN<A, B, C, D, E, FF, G, H, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
+  arrow.core.Either<L, Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, FF, G, H, I, Z> map(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Kind<Kind<ForEither, L>, E>,
+  arg5: Kind<Kind<ForEither, L>, FF>,
+  arg6: Kind<Kind<ForEither, L>, G>,
+  arg7: Kind<Kind<ForEither, L>, H>,
+  arg8: Kind<Kind<ForEither, L>, I>,
+  arg9: Function1<Tuple9<A, B, C, D, E, FF, G, H, I>, Z>
+): Either<L, Z> = arrow.core.Either
+  .apply<L>()
+  .mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+  as arrow.core.Either<L, Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, FF, G, H, I, Z> mapN(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Kind<Kind<ForEither, L>, E>,
+  arg5: Kind<Kind<ForEither, L>, FF>,
+  arg6: Kind<Kind<ForEither, L>, G>,
+  arg7: Kind<Kind<ForEither, L>, H>,
+  arg8: Kind<Kind<ForEither, L>, I>,
+  arg9: Function1<Tuple9<A, B, C, D, E, FF, G, H, I>, Z>
+): Either<L, Z> = arrow.core.Either
+  .apply<L>()
+  .mapN<A, B, C, D, E, FF, G, H, I, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+  as arrow.core.Either<L, Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, FF, G, H, I, J, Z> map(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Kind<Kind<ForEither, L>, E>,
+  arg5: Kind<Kind<ForEither, L>, FF>,
+  arg6: Kind<Kind<ForEither, L>, G>,
+  arg7: Kind<Kind<ForEither, L>, H>,
+  arg8: Kind<Kind<ForEither, L>, I>,
+  arg9: Kind<Kind<ForEither, L>, J>,
+  arg10: Function1<Tuple10<A, B, C, D, E, FF, G, H, I, J>, Z>
+): Either<L, Z> = arrow.core.Either
+  .apply<L>()
+  .mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) as arrow.core.Either<L, Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, FF, G, H, I, J, Z> mapN(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Kind<Kind<ForEither, L>, E>,
+  arg5: Kind<Kind<ForEither, L>, FF>,
+  arg6: Kind<Kind<ForEither, L>, G>,
+  arg7: Kind<Kind<ForEither, L>, H>,
+  arg8: Kind<Kind<ForEither, L>, I>,
+  arg9: Kind<Kind<ForEither, L>, J>,
+  arg10: Function1<Tuple10<A, B, C, D, E, FF, G, H, I, J>, Z>
+): Either<L, Z> = arrow.core.Either
+  .apply<L>()
+  .mapN<A, B, C, D, E, FF, G, H, I, J,
+    Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) as arrow.core.Either<L, Z>
+
+@JvmName("map2")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, Z> Kind<Kind<ForEither, L>, A>.map2(
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Function1<Tuple2<A, B>, Z>
+): Either<L, Z> = arrow.core.Either.apply<L>().run {
+  this@map2.map2<A, B, Z>(arg1, arg2) as arrow.core.Either<L, Z>
+}
+
+@JvmName("product")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.product(arg1: Kind<Kind<ForEither, L>, B>): Either<L,
+  Tuple2<A, B>> = arrow.core.Either.apply<L>().run {
+  this@product.product<A, B>(arg1) as arrow.core.Either<L, arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("product1")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, Z> Kind<Kind<ForEither, L>, Tuple2<A, B>>.product(arg1: Kind<Kind<ForEither, L>, Z>):
+  Either<L, Tuple3<A, B, Z>> = arrow.core.Either.apply<L>().run {
+  this@product.product<A, B, Z>(arg1) as arrow.core.Either<L, arrow.core.Tuple3<A, B, Z>>
+}
+
+@JvmName("product2")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, Z> Kind<Kind<ForEither, L>, Tuple3<A, B, C>>.product(
+  arg1: Kind<Kind<ForEither, L>,
+    Z>
+): Either<L, Tuple4<A, B, C, Z>> = arrow.core.Either.apply<L>().run {
+  this@product.product<A, B, C, Z>(arg1) as arrow.core.Either<L, arrow.core.Tuple4<A, B, C, Z>>
+}
+
+@JvmName("product3")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, Z> Kind<Kind<ForEither, L>, Tuple4<A, B, C,
+  D>>.product(arg1: Kind<Kind<ForEither, L>, Z>): Either<L, Tuple5<A, B, C, D, Z>> =
+  arrow.core.Either.apply<L>().run {
+    this@product.product<A, B, C, D, Z>(arg1) as arrow.core.Either<L, arrow.core.Tuple5<A, B, C, D,
+      Z>>
+  }
+
+@JvmName("product4")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, Z> Kind<Kind<ForEither, L>, Tuple5<A, B, C, D,
+  E>>.product(arg1: Kind<Kind<ForEither, L>, Z>): Either<L, Tuple6<A, B, C, D, E, Z>> =
+  arrow.core.Either.apply<L>().run {
+    this@product.product<A, B, C, D, E, Z>(arg1) as arrow.core.Either<L, arrow.core.Tuple6<A, B, C, D,
+      E, Z>>
+  }
+
+@JvmName("product5")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, FF, Z> Kind<Kind<ForEither, L>, Tuple6<A, B, C, D, E,
+  FF>>.product(arg1: Kind<Kind<ForEither, L>, Z>): Either<L, Tuple7<A, B, C, D, E, FF, Z>> =
+  arrow.core.Either.apply<L>().run {
+    this@product.product<A, B, C, D, E, FF, Z>(arg1) as arrow.core.Either<L, arrow.core.Tuple7<A, B,
+      C, D, E, FF, Z>>
+  }
+
+@JvmName("product6")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, FF, G, Z> Kind<Kind<ForEither, L>, Tuple7<A, B, C, D, E, FF,
+  G>>.product(arg1: Kind<Kind<ForEither, L>, Z>): Either<L, Tuple8<A, B, C, D, E, FF, G, Z>> =
+  arrow.core.Either.apply<L>().run {
+    this@product.product<A, B, C, D, E, FF, G, Z>(arg1) as arrow.core.Either<L, arrow.core.Tuple8<A,
+      B, C, D, E, FF, G, Z>>
+  }
+
+@JvmName("product7")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, FF, G, H, Z> Kind<Kind<ForEither, L>, Tuple8<A, B, C, D, E, FF, G,
+  H>>.product(arg1: Kind<Kind<ForEither, L>, Z>): Either<L, Tuple9<A, B, C, D, E, FF, G, H, Z>> =
+  arrow.core.Either.apply<L>().run {
+    this@product.product<A, B, C, D, E, FF, G, H, Z>(arg1) as arrow.core.Either<L,
+      arrow.core.Tuple9<A, B, C, D, E, FF, G, H, Z>>
+  }
+
+@JvmName("product8")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, FF, G, H, I, Z> Kind<Kind<ForEither, L>, Tuple9<A, B, C, D, E, FF, G, H,
+  I>>.product(arg1: Kind<Kind<ForEither, L>, Z>): Either<L, Tuple10<A, B, C, D, E, FF, G, H, I,
+  Z>> = arrow.core.Either.apply<L>().run {
+  this@product.product<A, B, C, D, E, FF, G, H, I, Z>(arg1) as arrow.core.Either<L,
+    arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, Z>>
+}
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> tupled(arg0: Kind<Kind<ForEither, L>, A>, arg1: Kind<Kind<ForEither, L>, B>):
+  Either<L, Tuple2<A, B>> = arrow.core.Either
+  .apply<L>()
+  .tupledN(arg0, arg1) as arrow.core.Either<L, arrow.core.Tuple2<A, B>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> tupledN(arg0: Kind<Kind<ForEither, L>, A>, arg1: Kind<Kind<ForEither, L>, B>):
+  Either<L, Tuple2<A, B>> = arrow.core.Either
+  .apply<L>()
+  .tupledN<A, B>(arg0, arg1) as arrow.core.Either<L, arrow.core.Tuple2<A, B>>
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C> tupled(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>
+): Either<L, Tuple3<A, B, C>> = arrow.core.Either
+  .apply<L>()
+  .tupledN(arg0, arg1, arg2) as arrow.core.Either<L, arrow.core.Tuple3<A, B, C>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C> tupledN(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>
+): Either<L, Tuple3<A, B, C>> = arrow.core.Either
+  .apply<L>()
+  .tupledN<A, B, C>(arg0, arg1, arg2) as arrow.core.Either<L, arrow.core.Tuple3<A, B, C>>
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D> tupled(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>
+): Either<L, Tuple4<A, B, C, D>> = arrow.core.Either
+  .apply<L>()
+  .tupledN(arg0, arg1, arg2, arg3) as arrow.core.Either<L, arrow.core.Tuple4<A, B, C,
+  D>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D> tupledN(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>
+): Either<L, Tuple4<A, B, C, D>> = arrow.core.Either
+  .apply<L>()
+  .tupledN<A, B, C, D>(arg0, arg1, arg2, arg3) as arrow.core.Either<L, arrow.core.Tuple4<A, B, C,
+  D>>
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E> tupled(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Kind<Kind<ForEither, L>, E>
+): Either<L, Tuple5<A, B, C, D, E>> = arrow.core.Either
+  .apply<L>()
+  .tupledN(arg0, arg1, arg2, arg3, arg4) as arrow.core.Either<L, arrow.core.Tuple5<A,
+  B, C, D, E>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E> tupledN(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Kind<Kind<ForEither, L>, E>
+): Either<L, Tuple5<A, B, C, D, E>> = arrow.core.Either
+  .apply<L>()
+  .tupledN<A, B, C, D, E>(arg0, arg1, arg2, arg3, arg4) as arrow.core.Either<L,
+  arrow.core.Tuple5<A, B, C, D, E>>
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, FF> tupled(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Kind<Kind<ForEither, L>, E>,
+  arg5: Kind<Kind<ForEither, L>, FF>
+): Either<L, Tuple6<A, B, C, D, E, FF>> = arrow.core.Either
+  .apply<L>()
+  .tupledN(arg0, arg1, arg2, arg3, arg4, arg5) as arrow.core.Either<L,
+  arrow.core.Tuple6<A, B, C, D, E, FF>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, FF> tupledN(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Kind<Kind<ForEither, L>, E>,
+  arg5: Kind<Kind<ForEither, L>, FF>
+): Either<L, Tuple6<A, B, C, D, E, FF>> = arrow.core.Either
+  .apply<L>()
+  .tupledN<A, B, C, D, E, FF>(arg0, arg1, arg2, arg3, arg4, arg5) as arrow.core.Either<L,
+  arrow.core.Tuple6<A, B, C, D, E, FF>>
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, FF, G> tupled(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Kind<Kind<ForEither, L>, E>,
+  arg5: Kind<Kind<ForEither, L>, FF>,
+  arg6: Kind<Kind<ForEither, L>, G>
+): Either<L, Tuple7<A, B, C, D, E, FF, G>> = arrow.core.Either
+  .apply<L>()
+  .tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as arrow.core.Either<L,
+  arrow.core.Tuple7<A, B, C, D, E, FF, G>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, FF, G> tupledN(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Kind<Kind<ForEither, L>, E>,
+  arg5: Kind<Kind<ForEither, L>, FF>,
+  arg6: Kind<Kind<ForEither, L>, G>
+): Either<L, Tuple7<A, B, C, D, E, FF, G>> = arrow.core.Either
+  .apply<L>()
+  .tupledN<A, B, C, D, E, FF, G>(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as arrow.core.Either<L,
+  arrow.core.Tuple7<A, B, C, D, E, FF, G>>
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, FF, G, H> tupled(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Kind<Kind<ForEither, L>, E>,
+  arg5: Kind<Kind<ForEither, L>, FF>,
+  arg6: Kind<Kind<ForEither, L>, G>,
+  arg7: Kind<Kind<ForEither, L>, H>
+): Either<L, Tuple8<A, B, C, D, E, FF, G, H>> = arrow.core.Either
+  .apply<L>()
+  .tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as
+  arrow.core.Either<L, arrow.core.Tuple8<A, B, C, D, E, FF, G, H>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, FF, G, H> tupledN(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Kind<Kind<ForEither, L>, E>,
+  arg5: Kind<Kind<ForEither, L>, FF>,
+  arg6: Kind<Kind<ForEither, L>, G>,
+  arg7: Kind<Kind<ForEither, L>, H>
+): Either<L, Tuple8<A, B, C, D, E, FF, G, H>> = arrow.core.Either
+  .apply<L>()
+  .tupledN<A, B, C, D, E, FF, G, H>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as
+  arrow.core.Either<L, arrow.core.Tuple8<A, B, C, D, E, FF, G, H>>
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, FF, G, H, I> tupled(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Kind<Kind<ForEither, L>, E>,
+  arg5: Kind<Kind<ForEither, L>, FF>,
+  arg6: Kind<Kind<ForEither, L>, G>,
+  arg7: Kind<Kind<ForEither, L>, H>,
+  arg8: Kind<Kind<ForEither, L>, I>
+): Either<L, Tuple9<A, B, C, D, E, FF, G, H, I>> = arrow.core.Either
+  .apply<L>()
+  .tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
+  arrow.core.Either<L, arrow.core.Tuple9<A, B, C, D, E, FF, G, H, I>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, FF, G, H, I> tupledN(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Kind<Kind<ForEither, L>, E>,
+  arg5: Kind<Kind<ForEither, L>, FF>,
+  arg6: Kind<Kind<ForEither, L>, G>,
+  arg7: Kind<Kind<ForEither, L>, H>,
+  arg8: Kind<Kind<ForEither, L>, I>
+): Either<L, Tuple9<A, B, C, D, E, FF, G, H, I>> = arrow.core.Either
+  .apply<L>()
+  .tupledN<A, B, C, D, E, FF, G, H, I>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
+  arrow.core.Either<L, arrow.core.Tuple9<A, B, C, D, E, FF, G, H, I>>
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, FF, G, H, I, J> tupled(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Kind<Kind<ForEither, L>, E>,
+  arg5: Kind<Kind<ForEither, L>, FF>,
+  arg6: Kind<Kind<ForEither, L>, G>,
+  arg7: Kind<Kind<ForEither, L>, H>,
+  arg8: Kind<Kind<ForEither, L>, I>,
+  arg9: Kind<Kind<ForEither, L>, J>
+): Either<L, Tuple10<A, B, C, D, E, FF, G, H, I, J>> = arrow.core.Either
+  .apply<L>()
+  .tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) as arrow.core.Either<L,
+  arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, J>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B, C, D, E, FF, G, H, I, J> tupledN(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Kind<Kind<ForEither, L>, E>,
+  arg5: Kind<Kind<ForEither, L>, FF>,
+  arg6: Kind<Kind<ForEither, L>, G>,
+  arg7: Kind<Kind<ForEither, L>, H>,
+  arg8: Kind<Kind<ForEither, L>, I>,
+  arg9: Kind<Kind<ForEither, L>, J>
+): Either<L, Tuple10<A, B, C, D, E, FF, G, H, I, J>> = arrow.core.Either
+  .apply<L>()
+  .tupledN<A, B, C, D, E, FF, G, H, I,
+    J>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) as arrow.core.Either<L,
+  arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, J>>
+
+@JvmName("followedBy")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.followedBy(arg1: Kind<Kind<ForEither, L>, B>): Either<L,
+  B> = arrow.core.Either.apply<L>().run {
+  this@followedBy.followedBy<A, B>(arg1) as arrow.core.Either<L, B>
+}
+
+@JvmName("apTap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.apTap(arg1: Kind<Kind<ForEither, L>, B>): Either<L, A> =
+  arrow.core.Either.apply<L>().run {
+    this@apTap.apTap<A, B>(arg1) as arrow.core.Either<L, A>
+  }
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+inline fun <L> Companion.apply(): EitherApply<L> = apply_singleton as
+  arrow.core.extensions.EitherApply<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/apply/EitherApply.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/apply/EitherApply.kt
@@ -847,6 +847,6 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.apTap(arg1: Kind<Kind<ForEither, L>, B
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("Apply typeclasses is deprecated. Use concrete methods on Validated")
+@Deprecated("Apply typeclasses is deprecated. Use concrete methods on Either")
 inline fun <L> Companion.apply(): EitherApply<L> = apply_singleton as
   arrow.core.extensions.EitherApply<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/apply/EitherApply.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/apply/EitherApply.kt
@@ -2,6 +2,11 @@ package arrow.core.extensions.either.apply
 
 import arrow.Kind
 import arrow.core.Either
+import arrow.core.ap as _ap
+import arrow.core.apEval as _apEval
+import arrow.core.map2 as _map2
+import arrow.core.product as _product
+import arrow.core.flatMap as _flatMap
 import arrow.core.Either.Companion
 import arrow.core.Eval
 import arrow.core.ForEither
@@ -15,6 +20,7 @@ import arrow.core.Tuple7
 import arrow.core.Tuple8
 import arrow.core.Tuple9
 import arrow.core.extensions.EitherApply
+import arrow.core.fix
 import kotlin.Any
 import kotlin.Function1
 import kotlin.PublishedApi
@@ -34,10 +40,9 @@ internal val apply_singleton: EitherApply<Any?> = object : EitherApply<Any?> {}
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("ap(arg1)", "arrow.core.ap"))
 fun <L, A, B> Kind<Kind<ForEither, L>, A>.ap(arg1: Kind<Kind<ForEither, L>, Function1<A, B>>):
-  Either<L, B> = arrow.core.Either.apply<L>().run {
-  this@EitherApply.mapN<A, (A) -> B, B>(this@ap, arg1) { (a, f) -> f(a) } as arrow.core.Either<L, B>
-}
+  Either<L, B> = _ap(arg1)
 
 @JvmName("apEval")
 @Suppress(
@@ -46,13 +51,12 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.ap(arg1: Kind<Kind<ForEither, L>, Func
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("apEval(arg1)", "arrow.core.apEval"))
 fun <L, A, B> Kind<Kind<ForEither, L>, A>.apEval(
   arg1: Eval<Kind<Kind<ForEither, L>, Function1<A,
     B>>>
-): Eval<Kind<Kind<ForEither, L>, B>> = arrow.core.Either.apply<L>().run {
-  this@apEval.map2Eval(arg1) { (a, f) -> f(a) } as arrow.core.Eval<arrow.Kind<arrow.Kind<arrow.core.ForEither, L>,
-    B>>
-}
+): Eval<Kind<Kind<ForEither, L>, B>> =
+  fix()._apEval(arg1.map { it.fix() })
 
 @JvmName("map2Eval")
 @Suppress(
@@ -61,6 +65,7 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.apEval(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("map2Eval(arg1, arg2)", "arrow.core.map2Eval"))
 fun <L, A, B, Z> Kind<Kind<ForEither, L>, A>.map2Eval(
   arg1: Eval<Kind<Kind<ForEither, L>, B>>,
   arg2: Function1<Tuple2<A, B>, Z>
@@ -77,13 +82,12 @@ fun <L, A, B, Z> Kind<Kind<ForEither, L>, A>.map2Eval(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.mapN(arg0, arg1) { a, b -> arg2(Tuple2(a, b)) }", "arrow.core.mapN", "arrow.core.Tuple2"))
 fun <L, A, B, Z> map(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
   arg2: Function1<Tuple2<A, B>, Z>
-): Either<L, Z> = arrow.core.Either
-  .apply<L>()
-  .mapN(arg0, arg1, arg2) as arrow.core.Either<L, Z>
+): Either<L, Z> = Either.mapN(arg0.fix(), arg1.fix()) { a, b -> arg2(Tuple2(a, b)) }
 
 @JvmName("mapN")
 @Suppress(
@@ -92,13 +96,12 @@ fun <L, A, B, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.mapN(arg0, arg1) { a, b -> arg2(Tuple2(a, b)) }", "arrow.core.mapN", "arrow.core.Tuple2"))
 fun <L, A, B, Z> mapN(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
   arg2: Function1<Tuple2<A, B>, Z>
-): Either<L, Z> = arrow.core.Either
-  .apply<L>()
-  .mapN<A, B, Z>(arg0, arg1, arg2) as arrow.core.Either<L, Z>
+): Either<L, Z> = Either.mapN(arg0.fix(), arg1.fix()) { a, b -> arg2(Tuple2(a, b)) }
 
 @JvmName("map")
 @Suppress(
@@ -107,14 +110,13 @@ fun <L, A, B, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.mapN(arg0, arg1, arg2) { a, b, c -> arg3(Tuple3(a, b, c)) }", "arrow.core.mapN", "arrow.core.Tuple3"))
 fun <L, A, B, C, Z> map(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
   arg2: Kind<Kind<ForEither, L>, C>,
   arg3: Function1<Tuple3<A, B, C>, Z>
-): Either<L, Z> = arrow.core.Either
-  .apply<L>()
-  .mapN(arg0, arg1, arg2, arg3) as arrow.core.Either<L, Z>
+): Either<L, Z> = Either.mapN(arg0.fix(), arg1.fix(), arg2.fix()) { a, b, c -> arg3(Tuple3(a, b, c)) }
 
 @JvmName("mapN")
 @Suppress(
@@ -123,31 +125,13 @@ fun <L, A, B, C, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.mapN(arg0, arg1, arg2) { a, b, c -> arg3(Tuple3(a, b, c)) }", "arrow.core.mapN", "arrow.core.Tuple3"))
 fun <L, A, B, C, Z> mapN(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
   arg2: Kind<Kind<ForEither, L>, C>,
   arg3: Function1<Tuple3<A, B, C>, Z>
-): Either<L, Z> = arrow.core.Either
-  .apply<L>()
-  .mapN<A, B, C, Z>(arg0, arg1, arg2, arg3) as arrow.core.Either<L, Z>
-
-@JvmName("map")
-@Suppress(
-  "UNCHECKED_CAST",
-  "USELESS_CAST",
-  "EXTENSION_SHADOWED_BY_MEMBER",
-  "UNUSED_PARAMETER"
-)
-fun <L, A, B, C, D, Z> map(
-  arg0: Kind<Kind<ForEither, L>, A>,
-  arg1: Kind<Kind<ForEither, L>, B>,
-  arg2: Kind<Kind<ForEither, L>, C>,
-  arg3: Kind<Kind<ForEither, L>, D>,
-  arg4: Function1<Tuple4<A, B, C, D>, Z>
-): Either<L, Z> = arrow.core.Either
-  .apply<L>()
-  .mapN(arg0, arg1, arg2, arg3, arg4) as arrow.core.Either<L, Z>
+): Either<L, Z> = Either.mapN(arg0.fix(), arg1.fix(), arg2.fix()) { a, b, c -> arg3(Tuple3(a, b, c)) }
 
 @JvmName("mapN")
 @Suppress(
@@ -156,15 +140,14 @@ fun <L, A, B, C, D, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.mapN(arg0, arg1, arg2, arg3) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }", "arrow.core.mapN", "arrow.core.Tuple4"))
 fun <L, A, B, C, D, Z> mapN(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
   arg2: Kind<Kind<ForEither, L>, C>,
   arg3: Kind<Kind<ForEither, L>, D>,
   arg4: Function1<Tuple4<A, B, C, D>, Z>
-): Either<L, Z> = arrow.core.Either
-  .apply<L>()
-  .mapN<A, B, C, D, Z>(arg0, arg1, arg2, arg3, arg4) as arrow.core.Either<L, Z>
+): Either<L, Z> = Either.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix()) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }
 
 @JvmName("map")
 @Suppress(
@@ -173,6 +156,23 @@ fun <L, A, B, C, D, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.mapN(arg0, arg1, arg2, arg3) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }", "arrow.core.mapN", "arrow.core.Tuple4"))
+fun <L, A, B, C, D, Z> map(
+  arg0: Kind<Kind<ForEither, L>, A>,
+  arg1: Kind<Kind<ForEither, L>, B>,
+  arg2: Kind<Kind<ForEither, L>, C>,
+  arg3: Kind<Kind<ForEither, L>, D>,
+  arg4: Function1<Tuple4<A, B, C, D>, Z>
+): Either<L, Z> = Either.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix()) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.mapN(arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }", "arrow.core.mapN", "arrow.core.Tuple5"))
 fun <L, A, B, C, D, E, Z> map(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
@@ -180,9 +180,7 @@ fun <L, A, B, C, D, E, Z> map(
   arg3: Kind<Kind<ForEither, L>, D>,
   arg4: Kind<Kind<ForEither, L>, E>,
   arg5: Function1<Tuple5<A, B, C, D, E>, Z>
-): Either<L, Z> = arrow.core.Either
-  .apply<L>()
-  .mapN(arg0, arg1, arg2, arg3, arg4, arg5) as arrow.core.Either<L, Z>
+): Either<L, Z> = Either.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix()) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }
 
 @JvmName("mapN")
 @Suppress(
@@ -191,6 +189,7 @@ fun <L, A, B, C, D, E, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.mapN(arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }", "arrow.core.mapN", "arrow.core.Tuple5"))
 fun <L, A, B, C, D, E, Z> mapN(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
@@ -198,9 +197,7 @@ fun <L, A, B, C, D, E, Z> mapN(
   arg3: Kind<Kind<ForEither, L>, D>,
   arg4: Kind<Kind<ForEither, L>, E>,
   arg5: Function1<Tuple5<A, B, C, D, E>, Z>
-): Either<L, Z> = arrow.core.Either
-  .apply<L>()
-  .mapN<A, B, C, D, E, Z>(arg0, arg1, arg2, arg3, arg4, arg5) as arrow.core.Either<L, Z>
+): Either<L, Z> = Either.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix()) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }
 
 @JvmName("map")
 @Suppress(
@@ -209,6 +206,7 @@ fun <L, A, B, C, D, E, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.mapN(arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> arg6(Tuple6(a, b, c, d, e, f)) }", "arrow.core.mapN", "arrow.core.Tuple6"))
 fun <L, A, B, C, D, E, FF, Z> map(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
@@ -217,9 +215,7 @@ fun <L, A, B, C, D, E, FF, Z> map(
   arg4: Kind<Kind<ForEither, L>, E>,
   arg5: Kind<Kind<ForEither, L>, FF>,
   arg6: Function1<Tuple6<A, B, C, D, E, FF>, Z>
-): Either<L, Z> = arrow.core.Either
-  .apply<L>()
-  .mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as arrow.core.Either<L, Z>
+): Either<L, Z> = Either.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix()) { a, b, c, d, e, f -> arg6(Tuple6(a, b, c, d, e, f)) }
 
 @JvmName("mapN")
 @Suppress(
@@ -228,6 +224,7 @@ fun <L, A, B, C, D, E, FF, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.mapN(arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> arg6(Tuple6(a, b, c, d, e, f)) }", "arrow.core.mapN", "arrow.core.Tuple6"))
 fun <L, A, B, C, D, E, FF, Z> mapN(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
@@ -236,9 +233,7 @@ fun <L, A, B, C, D, E, FF, Z> mapN(
   arg4: Kind<Kind<ForEither, L>, E>,
   arg5: Kind<Kind<ForEither, L>, FF>,
   arg6: Function1<Tuple6<A, B, C, D, E, FF>, Z>
-): Either<L, Z> = arrow.core.Either
-  .apply<L>()
-  .mapN<A, B, C, D, E, FF, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as arrow.core.Either<L, Z>
+): Either<L, Z> = Either.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix()) { a, b, c, d, e, f -> arg6(Tuple6(a, b, c, d, e, f)) }
 
 @JvmName("map")
 @Suppress(
@@ -247,6 +242,7 @@ fun <L, A, B, C, D, E, FF, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> arg7(Tuple7(a, b, c, d, e, f, g)) }", "arrow.core.mapN", "arrow.core.Tuple7"))
 fun <L, A, B, C, D, E, FF, G, Z> map(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
@@ -256,10 +252,7 @@ fun <L, A, B, C, D, E, FF, G, Z> map(
   arg5: Kind<Kind<ForEither, L>, FF>,
   arg6: Kind<Kind<ForEither, L>, G>,
   arg7: Function1<Tuple7<A, B, C, D, E, FF, G>, Z>
-): Either<L, Z> = arrow.core.Either
-  .apply<L>()
-  .mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as
-  arrow.core.Either<L, Z>
+): Either<L, Z> = Either.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix()) { a, b, c, d, e, f, g -> arg7(Tuple7(a, b, c, d, e, f, g)) }
 
 @JvmName("mapN")
 @Suppress(
@@ -268,6 +261,7 @@ fun <L, A, B, C, D, E, FF, G, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> arg7(Tuple7(a, b, c, d, e, f, g)) }", "arrow.core.mapN", "arrow.core.Tuple7"))
 fun <L, A, B, C, D, E, FF, G, Z> mapN(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
@@ -277,10 +271,7 @@ fun <L, A, B, C, D, E, FF, G, Z> mapN(
   arg5: Kind<Kind<ForEither, L>, FF>,
   arg6: Kind<Kind<ForEither, L>, G>,
   arg7: Function1<Tuple7<A, B, C, D, E, FF, G>, Z>
-): Either<L, Z> = arrow.core.Either
-  .apply<L>()
-  .mapN<A, B, C, D, E, FF, G, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as
-  arrow.core.Either<L, Z>
+): Either<L, Z> = Either.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix()) { a, b, c, d, e, f, g -> arg7(Tuple7(a, b, c, d, e, f, g)) }
 
 @JvmName("map")
 @Suppress(
@@ -289,6 +280,7 @@ fun <L, A, B, C, D, E, FF, G, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> arg8(Tuple8(a, b, c, d, e, f, g, h)) }", "arrow.core.mapN", "arrow.core.Tuple8"))
 fun <L, A, B, C, D, E, FF, G, H, Z> map(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
@@ -299,10 +291,7 @@ fun <L, A, B, C, D, E, FF, G, H, Z> map(
   arg6: Kind<Kind<ForEither, L>, G>,
   arg7: Kind<Kind<ForEither, L>, H>,
   arg8: Function1<Tuple8<A, B, C, D, E, FF, G, H>, Z>
-): Either<L, Z> = arrow.core.Either
-  .apply<L>()
-  .mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
-  arrow.core.Either<L, Z>
+): Either<L, Z> = Either.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix()) { a, b, c, d, e, f, g, h -> arg8(Tuple8(a, b, c, d, e, f, g, h)) }
 
 @JvmName("mapN")
 @Suppress(
@@ -311,6 +300,7 @@ fun <L, A, B, C, D, E, FF, G, H, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> arg8(Tuple8(a, b, c, d, e, f, g, h)) }", "arrow.core.mapN", "arrow.core.Tuple8"))
 fun <L, A, B, C, D, E, FF, G, H, Z> mapN(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
@@ -321,10 +311,7 @@ fun <L, A, B, C, D, E, FF, G, H, Z> mapN(
   arg6: Kind<Kind<ForEither, L>, G>,
   arg7: Kind<Kind<ForEither, L>, H>,
   arg8: Function1<Tuple8<A, B, C, D, E, FF, G, H>, Z>
-): Either<L, Z> = arrow.core.Either
-  .apply<L>()
-  .mapN<A, B, C, D, E, FF, G, H, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
-  arrow.core.Either<L, Z>
+): Either<L, Z> = Either.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix()) { a, b, c, d, e, f, g, h -> arg8(Tuple8(a, b, c, d, e, f, g, h)) }
 
 @JvmName("map")
 @Suppress(
@@ -333,6 +320,7 @@ fun <L, A, B, C, D, E, FF, G, H, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, f, g, h, i -> arg9(Tuple9(a, b, c, d, e, f, g, h, i)) }", "arrow.core.mapN", "arrow.core.Tuple9"))
 fun <L, A, B, C, D, E, FF, G, H, I, Z> map(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
@@ -344,10 +332,7 @@ fun <L, A, B, C, D, E, FF, G, H, I, Z> map(
   arg7: Kind<Kind<ForEither, L>, H>,
   arg8: Kind<Kind<ForEither, L>, I>,
   arg9: Function1<Tuple9<A, B, C, D, E, FF, G, H, I>, Z>
-): Either<L, Z> = arrow.core.Either
-  .apply<L>()
-  .mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
-  as arrow.core.Either<L, Z>
+): Either<L, Z> = Either.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix()) { a, b, c, d, e, f, g, h, i -> arg9(Tuple9(a, b, c, d, e, f, g, h, i)) }
 
 @JvmName("mapN")
 @Suppress(
@@ -356,6 +341,7 @@ fun <L, A, B, C, D, E, FF, G, H, I, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, f, g, h, i -> arg9(Tuple9(a, b, c, d, e, f, g, h, i)) }", "arrow.core.mapN", "arrow.core.Tuple9"))
 fun <L, A, B, C, D, E, FF, G, H, I, Z> mapN(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
@@ -367,10 +353,7 @@ fun <L, A, B, C, D, E, FF, G, H, I, Z> mapN(
   arg7: Kind<Kind<ForEither, L>, H>,
   arg8: Kind<Kind<ForEither, L>, I>,
   arg9: Function1<Tuple9<A, B, C, D, E, FF, G, H, I>, Z>
-): Either<L, Z> = arrow.core.Either
-  .apply<L>()
-  .mapN<A, B, C, D, E, FF, G, H, I, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
-  as arrow.core.Either<L, Z>
+): Either<L, Z> = Either.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix()) { a, b, c, d, e, f, g, h, i -> arg9(Tuple9(a, b, c, d, e, f, g, h, i)) }
 
 @JvmName("map")
 @Suppress(
@@ -379,6 +362,7 @@ fun <L, A, B, C, D, E, FF, G, H, I, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, f, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, f, g, h, i, j)) }", "arrow.core.mapN", "arrow.core.Tuple10"))
 fun <L, A, B, C, D, E, FF, G, H, I, J, Z> map(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
@@ -391,9 +375,7 @@ fun <L, A, B, C, D, E, FF, G, H, I, J, Z> map(
   arg8: Kind<Kind<ForEither, L>, I>,
   arg9: Kind<Kind<ForEither, L>, J>,
   arg10: Function1<Tuple10<A, B, C, D, E, FF, G, H, I, J>, Z>
-): Either<L, Z> = arrow.core.Either
-  .apply<L>()
-  .mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) as arrow.core.Either<L, Z>
+): Either<L, Z> = Either.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix(), arg9.fix()) { a, b, c, d, e, f, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, f, g, h, i, j)) }
 
 @JvmName("mapN")
 @Suppress(
@@ -402,6 +384,7 @@ fun <L, A, B, C, D, E, FF, G, H, I, J, Z> map(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, f, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, f, g, h, i, j)) }", "arrow.core.mapN", "arrow.core.Tuple10"))
 fun <L, A, B, C, D, E, FF, G, H, I, J, Z> mapN(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
@@ -414,10 +397,7 @@ fun <L, A, B, C, D, E, FF, G, H, I, J, Z> mapN(
   arg8: Kind<Kind<ForEither, L>, I>,
   arg9: Kind<Kind<ForEither, L>, J>,
   arg10: Function1<Tuple10<A, B, C, D, E, FF, G, H, I, J>, Z>
-): Either<L, Z> = arrow.core.Either
-  .apply<L>()
-  .mapN<A, B, C, D, E, FF, G, H, I, J,
-    Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) as arrow.core.Either<L, Z>
+): Either<L, Z> = Either.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix(), arg9.fix()) { a, b, c, d, e, f, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, f, g, h, i, j)) }
 
 @JvmName("map2")
 @Suppress(
@@ -426,12 +406,11 @@ fun <L, A, B, C, D, E, FF, G, H, I, J, Z> mapN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("map2(arg1, arg2)", "arrow.core.map2"))
 fun <L, A, B, Z> Kind<Kind<ForEither, L>, A>.map2(
   arg1: Kind<Kind<ForEither, L>, B>,
   arg2: Function1<Tuple2<A, B>, Z>
-): Either<L, Z> = arrow.core.Either.apply<L>().run {
-  this@map2.map2<A, B, Z>(arg1, arg2) as arrow.core.Either<L, Z>
-}
+): Either<L, Z> = fix()._map2(arg1.fix(), arg2)
 
 @JvmName("product")
 @Suppress(
@@ -440,10 +419,9 @@ fun <L, A, B, Z> Kind<Kind<ForEither, L>, A>.map2(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("product(arg1)", "arrow.core.product"))
 fun <L, A, B> Kind<Kind<ForEither, L>, A>.product(arg1: Kind<Kind<ForEither, L>, B>): Either<L,
-  Tuple2<A, B>> = arrow.core.Either.apply<L>().run {
-  this@product.product<A, B>(arg1) as arrow.core.Either<L, arrow.core.Tuple2<A, B>>
-}
+  Tuple2<A, B>> = fix()._product(arg1.fix())
 
 @JvmName("product1")
 @Suppress(
@@ -452,10 +430,9 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.product(arg1: Kind<Kind<ForEither, L>,
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("product(arg1)", "arrow.core.product"))
 fun <L, A, B, Z> Kind<Kind<ForEither, L>, Tuple2<A, B>>.product(arg1: Kind<Kind<ForEither, L>, Z>):
-  Either<L, Tuple3<A, B, Z>> = arrow.core.Either.apply<L>().run {
-  this@product.product<A, B, Z>(arg1) as arrow.core.Either<L, arrow.core.Tuple3<A, B, Z>>
-}
+  Either<L, Tuple3<A, B, Z>> = fix()._product(arg1.fix())
 
 @JvmName("product2")
 @Suppress(
@@ -464,12 +441,11 @@ fun <L, A, B, Z> Kind<Kind<ForEither, L>, Tuple2<A, B>>.product(arg1: Kind<Kind<
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("product(arg1)", "arrow.core.product"))
 fun <L, A, B, C, Z> Kind<Kind<ForEither, L>, Tuple3<A, B, C>>.product(
   arg1: Kind<Kind<ForEither, L>,
     Z>
-): Either<L, Tuple4<A, B, C, Z>> = arrow.core.Either.apply<L>().run {
-  this@product.product<A, B, C, Z>(arg1) as arrow.core.Either<L, arrow.core.Tuple4<A, B, C, Z>>
-}
+): Either<L, Tuple4<A, B, C, Z>> = fix()._product(arg1.fix())
 
 @JvmName("product3")
 @Suppress(
@@ -478,12 +454,10 @@ fun <L, A, B, C, Z> Kind<Kind<ForEither, L>, Tuple3<A, B, C>>.product(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("product(arg1)", "arrow.core.product"))
 fun <L, A, B, C, D, Z> Kind<Kind<ForEither, L>, Tuple4<A, B, C,
   D>>.product(arg1: Kind<Kind<ForEither, L>, Z>): Either<L, Tuple5<A, B, C, D, Z>> =
-  arrow.core.Either.apply<L>().run {
-    this@product.product<A, B, C, D, Z>(arg1) as arrow.core.Either<L, arrow.core.Tuple5<A, B, C, D,
-      Z>>
-  }
+  fix()._product(arg1.fix())
 
 @JvmName("product4")
 @Suppress(
@@ -492,12 +466,10 @@ fun <L, A, B, C, D, Z> Kind<Kind<ForEither, L>, Tuple4<A, B, C,
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("product(arg1)", "arrow.core.product"))
 fun <L, A, B, C, D, E, Z> Kind<Kind<ForEither, L>, Tuple5<A, B, C, D,
   E>>.product(arg1: Kind<Kind<ForEither, L>, Z>): Either<L, Tuple6<A, B, C, D, E, Z>> =
-  arrow.core.Either.apply<L>().run {
-    this@product.product<A, B, C, D, E, Z>(arg1) as arrow.core.Either<L, arrow.core.Tuple6<A, B, C, D,
-      E, Z>>
-  }
+  fix()._product(arg1.fix())
 
 @JvmName("product5")
 @Suppress(
@@ -506,12 +478,10 @@ fun <L, A, B, C, D, E, Z> Kind<Kind<ForEither, L>, Tuple5<A, B, C, D,
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("product(arg1)", "arrow.core.product"))
 fun <L, A, B, C, D, E, FF, Z> Kind<Kind<ForEither, L>, Tuple6<A, B, C, D, E,
   FF>>.product(arg1: Kind<Kind<ForEither, L>, Z>): Either<L, Tuple7<A, B, C, D, E, FF, Z>> =
-  arrow.core.Either.apply<L>().run {
-    this@product.product<A, B, C, D, E, FF, Z>(arg1) as arrow.core.Either<L, arrow.core.Tuple7<A, B,
-      C, D, E, FF, Z>>
-  }
+  fix()._product(arg1.fix())
 
 @JvmName("product6")
 @Suppress(
@@ -520,12 +490,10 @@ fun <L, A, B, C, D, E, FF, Z> Kind<Kind<ForEither, L>, Tuple6<A, B, C, D, E,
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("product(arg1)", "arrow.core.product"))
 fun <L, A, B, C, D, E, FF, G, Z> Kind<Kind<ForEither, L>, Tuple7<A, B, C, D, E, FF,
   G>>.product(arg1: Kind<Kind<ForEither, L>, Z>): Either<L, Tuple8<A, B, C, D, E, FF, G, Z>> =
-  arrow.core.Either.apply<L>().run {
-    this@product.product<A, B, C, D, E, FF, G, Z>(arg1) as arrow.core.Either<L, arrow.core.Tuple8<A,
-      B, C, D, E, FF, G, Z>>
-  }
+  fix()._product(arg1.fix())
 
 @JvmName("product7")
 @Suppress(
@@ -534,12 +502,10 @@ fun <L, A, B, C, D, E, FF, G, Z> Kind<Kind<ForEither, L>, Tuple7<A, B, C, D, E, 
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("product(arg1)", "arrow.core.product"))
 fun <L, A, B, C, D, E, FF, G, H, Z> Kind<Kind<ForEither, L>, Tuple8<A, B, C, D, E, FF, G,
   H>>.product(arg1: Kind<Kind<ForEither, L>, Z>): Either<L, Tuple9<A, B, C, D, E, FF, G, H, Z>> =
-  arrow.core.Either.apply<L>().run {
-    this@product.product<A, B, C, D, E, FF, G, H, Z>(arg1) as arrow.core.Either<L,
-      arrow.core.Tuple9<A, B, C, D, E, FF, G, H, Z>>
-  }
+  fix()._product(arg1.fix())
 
 @JvmName("product8")
 @Suppress(
@@ -548,12 +514,10 @@ fun <L, A, B, C, D, E, FF, G, H, Z> Kind<Kind<ForEither, L>, Tuple8<A, B, C, D, 
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("product(arg1)", "arrow.core.product"))
 fun <L, A, B, C, D, E, FF, G, H, I, Z> Kind<Kind<ForEither, L>, Tuple9<A, B, C, D, E, FF, G, H,
   I>>.product(arg1: Kind<Kind<ForEither, L>, Z>): Either<L, Tuple10<A, B, C, D, E, FF, G, H, I,
-  Z>> = arrow.core.Either.apply<L>().run {
-  this@product.product<A, B, C, D, E, FF, G, H, I, Z>(arg1) as arrow.core.Either<L,
-    arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, Z>>
-}
+  Z>> = fix()._product(arg1.fix())
 
 @JvmName("tupled")
 @Suppress(
@@ -562,10 +526,9 @@ fun <L, A, B, C, D, E, FF, G, H, I, Z> Kind<Kind<ForEither, L>, Tuple9<A, B, C, 
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.tupledN(arg0, arg1)", "arrow.core.tupledN"))
 fun <L, A, B> tupled(arg0: Kind<Kind<ForEither, L>, A>, arg1: Kind<Kind<ForEither, L>, B>):
-  Either<L, Tuple2<A, B>> = arrow.core.Either
-  .apply<L>()
-  .tupledN(arg0, arg1) as arrow.core.Either<L, arrow.core.Tuple2<A, B>>
+  Either<L, Tuple2<A, B>> = Either.tupledN(arg0.fix(), arg1.fix())
 
 @JvmName("tupledN")
 @Suppress(
@@ -574,10 +537,9 @@ fun <L, A, B> tupled(arg0: Kind<Kind<ForEither, L>, A>, arg1: Kind<Kind<ForEithe
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.tupledN(arg0, arg1)", "arrow.core.tupledN"))
 fun <L, A, B> tupledN(arg0: Kind<Kind<ForEither, L>, A>, arg1: Kind<Kind<ForEither, L>, B>):
-  Either<L, Tuple2<A, B>> = arrow.core.Either
-  .apply<L>()
-  .tupledN<A, B>(arg0, arg1) as arrow.core.Either<L, arrow.core.Tuple2<A, B>>
+  Either<L, Tuple2<A, B>> = Either.tupledN(arg0.fix(), arg1.fix())
 
 @JvmName("tupled")
 @Suppress(
@@ -586,13 +548,12 @@ fun <L, A, B> tupledN(arg0: Kind<Kind<ForEither, L>, A>, arg1: Kind<Kind<ForEith
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.tupledN(arg0, arg1, arg2)", "arrow.core.tupledN"))
 fun <L, A, B, C> tupled(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
   arg2: Kind<Kind<ForEither, L>, C>
-): Either<L, Tuple3<A, B, C>> = arrow.core.Either
-  .apply<L>()
-  .tupledN(arg0, arg1, arg2) as arrow.core.Either<L, arrow.core.Tuple3<A, B, C>>
+): Either<L, Tuple3<A, B, C>> = Either.tupledN(arg0.fix(), arg1.fix(), arg2.fix())
 
 @JvmName("tupledN")
 @Suppress(
@@ -601,13 +562,12 @@ fun <L, A, B, C> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.tupledN(arg0, arg1, arg2)", "arrow.core.tupledN"))
 fun <L, A, B, C> tupledN(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
   arg2: Kind<Kind<ForEither, L>, C>
-): Either<L, Tuple3<A, B, C>> = arrow.core.Either
-  .apply<L>()
-  .tupledN<A, B, C>(arg0, arg1, arg2) as arrow.core.Either<L, arrow.core.Tuple3<A, B, C>>
+): Either<L, Tuple3<A, B, C>> = Either.tupledN(arg0.fix(), arg1.fix(), arg2.fix())
 
 @JvmName("tupled")
 @Suppress(
@@ -616,15 +576,13 @@ fun <L, A, B, C> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.tupledN(arg0, arg1, arg2, arg3)", "arrow.core.tupledN"))
 fun <L, A, B, C, D> tupled(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
   arg2: Kind<Kind<ForEither, L>, C>,
   arg3: Kind<Kind<ForEither, L>, D>
-): Either<L, Tuple4<A, B, C, D>> = arrow.core.Either
-  .apply<L>()
-  .tupledN(arg0, arg1, arg2, arg3) as arrow.core.Either<L, arrow.core.Tuple4<A, B, C,
-  D>>
+): Either<L, Tuple4<A, B, C, D>> = Either.tupledN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix())
 
 @JvmName("tupledN")
 @Suppress(
@@ -633,15 +591,13 @@ fun <L, A, B, C, D> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.tupledN(arg0, arg1, arg2, arg3)", "arrow.core.tupledN"))
 fun <L, A, B, C, D> tupledN(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
   arg2: Kind<Kind<ForEither, L>, C>,
   arg3: Kind<Kind<ForEither, L>, D>
-): Either<L, Tuple4<A, B, C, D>> = arrow.core.Either
-  .apply<L>()
-  .tupledN<A, B, C, D>(arg0, arg1, arg2, arg3) as arrow.core.Either<L, arrow.core.Tuple4<A, B, C,
-  D>>
+): Either<L, Tuple4<A, B, C, D>> = Either.tupledN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix())
 
 @JvmName("tupled")
 @Suppress(
@@ -650,16 +606,14 @@ fun <L, A, B, C, D> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.tupledN(arg0, arg1, arg2, arg3, arg4)", "arrow.core.tupledN"))
 fun <L, A, B, C, D, E> tupled(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
   arg2: Kind<Kind<ForEither, L>, C>,
   arg3: Kind<Kind<ForEither, L>, D>,
   arg4: Kind<Kind<ForEither, L>, E>
-): Either<L, Tuple5<A, B, C, D, E>> = arrow.core.Either
-  .apply<L>()
-  .tupledN(arg0, arg1, arg2, arg3, arg4) as arrow.core.Either<L, arrow.core.Tuple5<A,
-  B, C, D, E>>
+): Either<L, Tuple5<A, B, C, D, E>> = Either.tupledN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix())
 
 @JvmName("tupledN")
 @Suppress(
@@ -668,16 +622,14 @@ fun <L, A, B, C, D, E> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.tupledN(arg0, arg1, arg2, arg3, arg4)", "arrow.core.tupledN"))
 fun <L, A, B, C, D, E> tupledN(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
   arg2: Kind<Kind<ForEither, L>, C>,
   arg3: Kind<Kind<ForEither, L>, D>,
   arg4: Kind<Kind<ForEither, L>, E>
-): Either<L, Tuple5<A, B, C, D, E>> = arrow.core.Either
-  .apply<L>()
-  .tupledN<A, B, C, D, E>(arg0, arg1, arg2, arg3, arg4) as arrow.core.Either<L,
-  arrow.core.Tuple5<A, B, C, D, E>>
+): Either<L, Tuple5<A, B, C, D, E>> = Either.tupledN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix())
 
 @JvmName("tupled")
 @Suppress(
@@ -686,6 +638,7 @@ fun <L, A, B, C, D, E> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.tupledN(arg0, arg1, arg2, arg3, arg5)", "arrow.core.tupledN"))
 fun <L, A, B, C, D, E, FF> tupled(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
@@ -693,10 +646,7 @@ fun <L, A, B, C, D, E, FF> tupled(
   arg3: Kind<Kind<ForEither, L>, D>,
   arg4: Kind<Kind<ForEither, L>, E>,
   arg5: Kind<Kind<ForEither, L>, FF>
-): Either<L, Tuple6<A, B, C, D, E, FF>> = arrow.core.Either
-  .apply<L>()
-  .tupledN(arg0, arg1, arg2, arg3, arg4, arg5) as arrow.core.Either<L,
-  arrow.core.Tuple6<A, B, C, D, E, FF>>
+): Either<L, Tuple6<A, B, C, D, E, FF>> = Either.tupledN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix())
 
 @JvmName("tupledN")
 @Suppress(
@@ -705,6 +655,7 @@ fun <L, A, B, C, D, E, FF> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.tupledN(arg0, arg1, arg2, arg3, arg5)", "arrow.core.tupledN"))
 fun <L, A, B, C, D, E, FF> tupledN(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
@@ -712,10 +663,7 @@ fun <L, A, B, C, D, E, FF> tupledN(
   arg3: Kind<Kind<ForEither, L>, D>,
   arg4: Kind<Kind<ForEither, L>, E>,
   arg5: Kind<Kind<ForEither, L>, FF>
-): Either<L, Tuple6<A, B, C, D, E, FF>> = arrow.core.Either
-  .apply<L>()
-  .tupledN<A, B, C, D, E, FF>(arg0, arg1, arg2, arg3, arg4, arg5) as arrow.core.Either<L,
-  arrow.core.Tuple6<A, B, C, D, E, FF>>
+): Either<L, Tuple6<A, B, C, D, E, FF>> = Either.tupledN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix())
 
 @JvmName("tupled")
 @Suppress(
@@ -724,6 +672,7 @@ fun <L, A, B, C, D, E, FF> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.tupledN(arg0, arg1, arg2, arg3, arg5, arg6)", "arrow.core.tupledN"))
 fun <L, A, B, C, D, E, FF, G> tupled(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
@@ -732,10 +681,7 @@ fun <L, A, B, C, D, E, FF, G> tupled(
   arg4: Kind<Kind<ForEither, L>, E>,
   arg5: Kind<Kind<ForEither, L>, FF>,
   arg6: Kind<Kind<ForEither, L>, G>
-): Either<L, Tuple7<A, B, C, D, E, FF, G>> = arrow.core.Either
-  .apply<L>()
-  .tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as arrow.core.Either<L,
-  arrow.core.Tuple7<A, B, C, D, E, FF, G>>
+): Either<L, Tuple7<A, B, C, D, E, FF, G>> = Either.tupledN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix())
 
 @JvmName("tupledN")
 @Suppress(
@@ -744,6 +690,7 @@ fun <L, A, B, C, D, E, FF, G> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.tupledN(arg0, arg1, arg2, arg3, arg5, arg6)", "arrow.core.tupledN"))
 fun <L, A, B, C, D, E, FF, G> tupledN(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
@@ -752,10 +699,7 @@ fun <L, A, B, C, D, E, FF, G> tupledN(
   arg4: Kind<Kind<ForEither, L>, E>,
   arg5: Kind<Kind<ForEither, L>, FF>,
   arg6: Kind<Kind<ForEither, L>, G>
-): Either<L, Tuple7<A, B, C, D, E, FF, G>> = arrow.core.Either
-  .apply<L>()
-  .tupledN<A, B, C, D, E, FF, G>(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as arrow.core.Either<L,
-  arrow.core.Tuple7<A, B, C, D, E, FF, G>>
+): Either<L, Tuple7<A, B, C, D, E, FF, G>> = Either.tupledN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix())
 
 @JvmName("tupled")
 @Suppress(
@@ -764,6 +708,7 @@ fun <L, A, B, C, D, E, FF, G> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.tupledN(arg0, arg1, arg2, arg3, arg5, arg6, arg7)", "arrow.core.tupledN"))
 fun <L, A, B, C, D, E, FF, G, H> tupled(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
@@ -773,10 +718,7 @@ fun <L, A, B, C, D, E, FF, G, H> tupled(
   arg5: Kind<Kind<ForEither, L>, FF>,
   arg6: Kind<Kind<ForEither, L>, G>,
   arg7: Kind<Kind<ForEither, L>, H>
-): Either<L, Tuple8<A, B, C, D, E, FF, G, H>> = arrow.core.Either
-  .apply<L>()
-  .tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as
-  arrow.core.Either<L, arrow.core.Tuple8<A, B, C, D, E, FF, G, H>>
+): Either<L, Tuple8<A, B, C, D, E, FF, G, H>> = Either.tupledN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix())
 
 @JvmName("tupledN")
 @Suppress(
@@ -785,6 +727,7 @@ fun <L, A, B, C, D, E, FF, G, H> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.tupledN(arg0, arg1, arg2, arg3, arg5, arg6, arg7)", "arrow.core.tupledN"))
 fun <L, A, B, C, D, E, FF, G, H> tupledN(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
@@ -794,10 +737,7 @@ fun <L, A, B, C, D, E, FF, G, H> tupledN(
   arg5: Kind<Kind<ForEither, L>, FF>,
   arg6: Kind<Kind<ForEither, L>, G>,
   arg7: Kind<Kind<ForEither, L>, H>
-): Either<L, Tuple8<A, B, C, D, E, FF, G, H>> = arrow.core.Either
-  .apply<L>()
-  .tupledN<A, B, C, D, E, FF, G, H>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as
-  arrow.core.Either<L, arrow.core.Tuple8<A, B, C, D, E, FF, G, H>>
+): Either<L, Tuple8<A, B, C, D, E, FF, G, H>> = Either.tupledN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix())
 
 @JvmName("tupled")
 @Suppress(
@@ -806,6 +746,7 @@ fun <L, A, B, C, D, E, FF, G, H> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.tupledN(arg0, arg1, arg2, arg3, arg5, arg6, arg7, arg8)", "arrow.core.tupledN"))
 fun <L, A, B, C, D, E, FF, G, H, I> tupled(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
@@ -816,10 +757,7 @@ fun <L, A, B, C, D, E, FF, G, H, I> tupled(
   arg6: Kind<Kind<ForEither, L>, G>,
   arg7: Kind<Kind<ForEither, L>, H>,
   arg8: Kind<Kind<ForEither, L>, I>
-): Either<L, Tuple9<A, B, C, D, E, FF, G, H, I>> = arrow.core.Either
-  .apply<L>()
-  .tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
-  arrow.core.Either<L, arrow.core.Tuple9<A, B, C, D, E, FF, G, H, I>>
+): Either<L, Tuple9<A, B, C, D, E, FF, G, H, I>> = Either.tupledN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix())
 
 @JvmName("tupledN")
 @Suppress(
@@ -828,6 +766,7 @@ fun <L, A, B, C, D, E, FF, G, H, I> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.tupledN(arg0, arg1, arg2, arg3, arg5, arg6, arg7, arg8)", "arrow.core.tupledN"))
 fun <L, A, B, C, D, E, FF, G, H, I> tupledN(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
@@ -838,10 +777,7 @@ fun <L, A, B, C, D, E, FF, G, H, I> tupledN(
   arg6: Kind<Kind<ForEither, L>, G>,
   arg7: Kind<Kind<ForEither, L>, H>,
   arg8: Kind<Kind<ForEither, L>, I>
-): Either<L, Tuple9<A, B, C, D, E, FF, G, H, I>> = arrow.core.Either
-  .apply<L>()
-  .tupledN<A, B, C, D, E, FF, G, H, I>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
-  arrow.core.Either<L, arrow.core.Tuple9<A, B, C, D, E, FF, G, H, I>>
+): Either<L, Tuple9<A, B, C, D, E, FF, G, H, I>> = Either.tupledN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix())
 
 @JvmName("tupled")
 @Suppress(
@@ -850,6 +786,7 @@ fun <L, A, B, C, D, E, FF, G, H, I> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.tupledN(arg0, arg1, arg2, arg3, arg5, arg6, arg7, arg8, arg9)", "arrow.core.tupledN"))
 fun <L, A, B, C, D, E, FF, G, H, I, J> tupled(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
@@ -861,10 +798,7 @@ fun <L, A, B, C, D, E, FF, G, H, I, J> tupled(
   arg7: Kind<Kind<ForEither, L>, H>,
   arg8: Kind<Kind<ForEither, L>, I>,
   arg9: Kind<Kind<ForEither, L>, J>
-): Either<L, Tuple10<A, B, C, D, E, FF, G, H, I, J>> = arrow.core.Either
-  .apply<L>()
-  .tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) as arrow.core.Either<L,
-  arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, J>>
+): Either<L, Tuple10<A, B, C, D, E, FF, G, H, I, J>> = Either.tupledN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix(), arg9.fix())
 
 @JvmName("tupledN")
 @Suppress(
@@ -873,6 +807,7 @@ fun <L, A, B, C, D, E, FF, G, H, I, J> tupled(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.tupledN(arg0, arg1, arg2, arg3, arg5, arg6, arg7, arg8, arg9)", "arrow.core.tupledN"))
 fun <L, A, B, C, D, E, FF, G, H, I, J> tupledN(
   arg0: Kind<Kind<ForEither, L>, A>,
   arg1: Kind<Kind<ForEither, L>, B>,
@@ -884,11 +819,7 @@ fun <L, A, B, C, D, E, FF, G, H, I, J> tupledN(
   arg7: Kind<Kind<ForEither, L>, H>,
   arg8: Kind<Kind<ForEither, L>, I>,
   arg9: Kind<Kind<ForEither, L>, J>
-): Either<L, Tuple10<A, B, C, D, E, FF, G, H, I, J>> = arrow.core.Either
-  .apply<L>()
-  .tupledN<A, B, C, D, E, FF, G, H, I,
-    J>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) as arrow.core.Either<L,
-  arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, J>>
+): Either<L, Tuple10<A, B, C, D, E, FF, G, H, I, J>> = Either.tupledN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix(), arg9.fix())
 
 @JvmName("followedBy")
 @Suppress(
@@ -897,10 +828,9 @@ fun <L, A, B, C, D, E, FF, G, H, I, J> tupledN(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-fun <L, A, B> Kind<Kind<ForEither, L>, A>.followedBy(arg1: Kind<Kind<ForEither, L>, B>): Either<L,
-  B> = arrow.core.Either.apply<L>().run {
-  this@followedBy.followedBy<A, B>(arg1) as arrow.core.Either<L, B>
-}
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("flatMap { arg1 }", "arrow.core.flatMap"))
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.followedBy(arg1: Kind<Kind<ForEither, L>, B>): Either<L, B> =
+  _flatMap { arg1.fix() }
 
 @JvmName("apTap")
 @Suppress(
@@ -909,14 +839,14 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.followedBy(arg1: Kind<Kind<ForEither, 
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.mapN(this, fb) { left, _ -> left }", "arrow.core.mapN"))
 fun <L, A, B> Kind<Kind<ForEither, L>, A>.apTap(arg1: Kind<Kind<ForEither, L>, B>): Either<L, A> =
-  arrow.core.Either.apply<L>().run {
-    this@apTap.apTap<A, B>(arg1) as arrow.core.Either<L, A>
-  }
+  Either.mapN(fix(), arg1.fix()) { left, _ -> left }
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("Apply typeclasses is deprecated. Use concrete methods on Validated")
 inline fun <L> Companion.apply(): EitherApply<L> = apply_singleton as
   arrow.core.extensions.EitherApply<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/bicrosswalk/EitherBicrosswalk.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/bicrosswalk/EitherBicrosswalk.kt
@@ -1,0 +1,54 @@
+package arrow.core.extensions.either.bicrosswalk
+
+import arrow.Kind
+import arrow.core.Either.Companion
+import arrow.core.ForEither
+import arrow.core.extensions.EitherBicrosswalk
+import arrow.typeclasses.Align
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val bicrosswalk_singleton: EitherBicrosswalk = object :
+  arrow.core.extensions.EitherBicrosswalk {}
+
+@JvmName("bicrosswalk")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <F, A, B, C, D> bicrosswalk(
+  arg0: Align<F>,
+  arg1: Kind<Kind<ForEither, A>, B>,
+  arg2: Function1<A, Kind<F, C>>,
+  arg3: Function1<B, Kind<F, D>>
+): Kind<F, Kind<Kind<ForEither, C>, D>> = arrow.core.Either
+  .bicrosswalk()
+  .bicrosswalk<F, A, B, C, D>(arg0, arg1, arg2, arg3) as arrow.Kind<F,
+  arrow.Kind<arrow.Kind<arrow.core.ForEither, C>, D>>
+
+@JvmName("bisequenceL")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <F, A, B> bisequenceL(arg0: Align<F>, arg1: Kind<Kind<ForEither, Kind<F, A>>, Kind<F, B>>):
+  Kind<F, Kind<Kind<ForEither, A>, B>> = arrow.core.Either
+  .bicrosswalk()
+  .bisequenceL<F, A, B>(arg0, arg1) as arrow.Kind<F, arrow.Kind<arrow.Kind<arrow.core.ForEither,
+  A>, B>>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+inline fun Companion.bicrosswalk(): EitherBicrosswalk = bicrosswalk_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/bicrosswalk/EitherBicrosswalk.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/bicrosswalk/EitherBicrosswalk.kt
@@ -24,6 +24,7 @@ internal val bicrosswalk_singleton: EitherBicrosswalk = object :
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated. Replace with bitraverse or bitraverseValidated from arrow.core.*")
 fun <F, A, B, C, D> bicrosswalk(
   arg0: Align<F>,
   arg1: Kind<Kind<ForEither, A>, B>,
@@ -41,6 +42,7 @@ fun <F, A, B, C, D> bicrosswalk(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated. Replace with bisequence or bisequenceValidated from arrow.core.*")
 fun <F, A, B> bisequenceL(arg0: Align<F>, arg1: Kind<Kind<ForEither, Kind<F, A>>, Kind<F, B>>):
   Kind<F, Kind<Kind<ForEither, A>, B>> = arrow.core.Either
   .bicrosswalk()
@@ -51,4 +53,5 @@ fun <F, A, B> bisequenceL(arg0: Align<F>, arg1: Kind<Kind<ForEither, Kind<F, A>>
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("Bicrosswalk typeclasses is deprecated. Use concrete methods on Either")
 inline fun Companion.bicrosswalk(): EitherBicrosswalk = bicrosswalk_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/bifoldable/EitherBifoldable.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/bifoldable/EitherBifoldable.kt
@@ -1,0 +1,71 @@
+package arrow.core.extensions.either.bifoldable
+
+import arrow.Kind
+import arrow.core.Either.Companion
+import arrow.core.Eval
+import arrow.core.ForEither
+import arrow.core.extensions.EitherBifoldable
+import arrow.typeclasses.Monoid
+import kotlin.Function1
+import kotlin.Function2
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val bifoldable_singleton: EitherBifoldable = object :
+  arrow.core.extensions.EitherBifoldable {}
+
+@JvmName("bifoldLeft")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <A, B, C> Kind<Kind<ForEither, A>, B>.bifoldLeft(
+  arg1: C,
+  arg2: Function2<C, A, C>,
+  arg3: Function2<C, B, C>
+): C = arrow.core.Either.bifoldable().run {
+  this@bifoldLeft.bifoldLeft<A, B, C>(arg1, arg2, arg3) as C
+}
+
+@JvmName("bifoldRight")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <A, B, C> Kind<Kind<ForEither, A>, B>.bifoldRight(
+  arg1: Eval<C>,
+  arg2: Function2<A, Eval<C>, Eval<C>>,
+  arg3: Function2<B, Eval<C>, Eval<C>>
+): Eval<C> = arrow.core.Either.bifoldable().run {
+  this@bifoldRight.bifoldRight<A, B, C>(arg1, arg2, arg3) as arrow.core.Eval<C>
+}
+
+@JvmName("bifoldMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <A, B, C> Kind<Kind<ForEither, A>, B>.bifoldMap(
+  arg1: Monoid<C>,
+  arg2: Function1<A, C>,
+  arg3: Function1<B, C>
+): C = arrow.core.Either.bifoldable().run {
+  this@bifoldMap.bifoldMap<A, B, C>(arg1, arg2, arg3) as C
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+inline fun Companion.bifoldable(): EitherBifoldable = bifoldable_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/bifoldable/EitherBifoldable.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/bifoldable/EitherBifoldable.kt
@@ -5,6 +5,7 @@ import arrow.core.Either.Companion
 import arrow.core.Eval
 import arrow.core.ForEither
 import arrow.core.extensions.EitherBifoldable
+import arrow.core.fix
 import arrow.typeclasses.Monoid
 import kotlin.Function1
 import kotlin.Function2
@@ -26,13 +27,13 @@ internal val bifoldable_singleton: EitherBifoldable = object :
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("bifoldLeft(arg1, arg2, arg3)"))
 fun <A, B, C> Kind<Kind<ForEither, A>, B>.bifoldLeft(
   arg1: C,
   arg2: Function2<C, A, C>,
   arg3: Function2<C, B, C>
-): C = arrow.core.Either.bifoldable().run {
-  this@bifoldLeft.bifoldLeft<A, B, C>(arg1, arg2, arg3) as C
-}
+): C =
+  fix().bifoldLeft(arg1, arg2, arg3)
 
 @JvmName("bifoldRight")
 @Suppress(
@@ -41,13 +42,13 @@ fun <A, B, C> Kind<Kind<ForEither, A>, B>.bifoldLeft(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("bifoldRight(arg1, arg2, arg3)"))
 fun <A, B, C> Kind<Kind<ForEither, A>, B>.bifoldRight(
   arg1: Eval<C>,
   arg2: Function2<A, Eval<C>, Eval<C>>,
   arg3: Function2<B, Eval<C>, Eval<C>>
-): Eval<C> = arrow.core.Either.bifoldable().run {
-  this@bifoldRight.bifoldRight<A, B, C>(arg1, arg2, arg3) as arrow.core.Eval<C>
-}
+): Eval<C> =
+  fix().bifoldRight(arg1, arg2, arg3)
 
 @JvmName("bifoldMap")
 @Suppress(
@@ -56,16 +57,17 @@ fun <A, B, C> Kind<Kind<ForEither, A>, B>.bifoldRight(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("bifoldMap(arg1, arg2, arg3)"))
 fun <A, B, C> Kind<Kind<ForEither, A>, B>.bifoldMap(
   arg1: Monoid<C>,
   arg2: Function1<A, C>,
   arg3: Function1<B, C>
-): C = arrow.core.Either.bifoldable().run {
-  this@bifoldMap.bifoldMap<A, B, C>(arg1, arg2, arg3) as C
-}
+): C =
+  fix().bifoldMap(arg1, arg2, arg3)
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("BiFoldable typeclasses is deprecated. Use concrete methods on Validated")
 inline fun Companion.bifoldable(): EitherBifoldable = bifoldable_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/bifunctor/EitherBifunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/bifunctor/EitherBifunctor.kt
@@ -46,7 +46,6 @@ fun <A, B, C, D> lift(arg0: Function1<A, C>, arg1: Function1<B, D>): Function1<K
   .lift<A, B, C, D>(arg0, arg1) as kotlin.Function1<arrow.Kind<arrow.Kind<arrow.core.ForEither, A>,
   B>, arrow.Kind<arrow.Kind<arrow.core.ForEither, C>, D>>
 
-
 @JvmName("mapLeft")
 @Suppress(
   "UNCHECKED_CAST",

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/bifunctor/EitherBifunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/bifunctor/EitherBifunctor.kt
@@ -1,0 +1,97 @@
+package arrow.core.extensions.either.bifunctor
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.Either.Companion
+import arrow.core.ForEither
+import arrow.core.extensions.EitherBifunctor
+import arrow.typeclasses.Conested
+import arrow.typeclasses.Functor
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val bifunctor_singleton: EitherBifunctor = object : arrow.core.extensions.EitherBifunctor {}
+
+@JvmName("bimap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <A, B, C, D> Kind<Kind<ForEither, A>, B>.bimap(arg1: Function1<A, C>, arg2: Function1<B, D>):
+  Either<C, D> = arrow.core.Either.bifunctor().run {
+  this@bimap.bimap<A, B, C, D>(arg1, arg2) as arrow.core.Either<C, D>
+}
+
+@JvmName("lift")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <A, B, C, D> lift(arg0: Function1<A, C>, arg1: Function1<B, D>): Function1<Kind<Kind<ForEither,
+  A>, B>, Kind<Kind<ForEither, C>, D>> = arrow.core.Either
+  .bifunctor()
+  .lift<A, B, C, D>(arg0, arg1) as kotlin.Function1<arrow.Kind<arrow.Kind<arrow.core.ForEither, A>,
+  B>, arrow.Kind<arrow.Kind<arrow.core.ForEither, C>, D>>
+
+@JvmName("mapLeft")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <A, B, C> Kind<Kind<ForEither, A>, B>.mapLeft(arg1: Function1<A, C>): Either<C, B> =
+  arrow.core.Either.bifunctor().run {
+    this@mapLeft.mapLeft<A, B, C>(arg1) as arrow.core.Either<C, B>
+  }
+
+@JvmName("rightFunctor")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <X> rightFunctor(): Functor<Kind<ForEither, X>> = arrow.core.Either
+  .bifunctor()
+  .rightFunctor<X>() as arrow.typeclasses.Functor<arrow.Kind<arrow.core.ForEither, X>>
+
+@JvmName("leftFunctor")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <X> leftFunctor(): Functor<Conested<ForEither, X>> = arrow.core.Either
+  .bifunctor()
+  .leftFunctor<X>() as arrow.typeclasses.Functor<arrow.typeclasses.Conested<arrow.core.ForEither,
+  X>>
+
+@JvmName("leftWiden")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <AA, B, A : AA> Kind<Kind<ForEither, A>, B>.leftWiden(): Either<AA, B> =
+  arrow.core.Either.bifunctor().run {
+    this@leftWiden.leftWiden<AA, B, A>() as arrow.core.Either<AA, B>
+  }
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+inline fun Companion.bifunctor(): EitherBifunctor = bifunctor_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/bifunctor/EitherBifunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/bifunctor/EitherBifunctor.kt
@@ -41,10 +41,8 @@ fun <A, B, C, D> Kind<Kind<ForEither, A>, B>.bimap(arg1: Function1<A, C>, arg2: 
 )
 @Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.lift(arg0, arg1)"))
 fun <A, B, C, D> lift(arg0: Function1<A, C>, arg1: Function1<B, D>): Function1<Kind<Kind<ForEither,
-  A>, B>, Kind<Kind<ForEither, C>, D>> = arrow.core.Either
-  .bifunctor()
-  .lift<A, B, C, D>(arg0, arg1) as kotlin.Function1<arrow.Kind<arrow.Kind<arrow.core.ForEither, A>,
-  B>, arrow.Kind<arrow.Kind<arrow.core.ForEither, C>, D>>
+  A>, B>, Kind<Kind<ForEither, C>, D>> =
+  Either.lift(arg0, arg1)
 
 @JvmName("mapLeft")
 @Suppress(

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/bifunctor/EitherBifunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/bifunctor/EitherBifunctor.kt
@@ -41,8 +41,11 @@ fun <A, B, C, D> Kind<Kind<ForEither, A>, B>.bimap(arg1: Function1<A, C>, arg2: 
 )
 @Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.lift(arg0, arg1)"))
 fun <A, B, C, D> lift(arg0: Function1<A, C>, arg1: Function1<B, D>): Function1<Kind<Kind<ForEither,
-  A>, B>, Kind<Kind<ForEither, C>, D>> =
-  Either.lift(arg0, arg1)
+  A>, B>, Kind<Kind<ForEither, C>, D>> = arrow.core.Either
+  .bifunctor()
+  .lift<A, B, C, D>(arg0, arg1) as kotlin.Function1<arrow.Kind<arrow.Kind<arrow.core.ForEither, A>,
+  B>, arrow.Kind<arrow.Kind<arrow.core.ForEither, C>, D>>
+
 
 @JvmName("mapLeft")
 @Suppress(

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/bifunctor/EitherBifunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/bifunctor/EitherBifunctor.kt
@@ -2,9 +2,11 @@ package arrow.core.extensions.either.bifunctor
 
 import arrow.Kind
 import arrow.core.Either
+import arrow.core.leftWiden as _leftWiden
 import arrow.core.Either.Companion
 import arrow.core.ForEither
 import arrow.core.extensions.EitherBifunctor
+import arrow.core.fix
 import arrow.typeclasses.Conested
 import arrow.typeclasses.Functor
 import kotlin.Function1
@@ -25,10 +27,10 @@ internal val bifunctor_singleton: EitherBifunctor = object : arrow.core.extensio
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("bimap(arg1, arg2)"))
 fun <A, B, C, D> Kind<Kind<ForEither, A>, B>.bimap(arg1: Function1<A, C>, arg2: Function1<B, D>):
-  Either<C, D> = arrow.core.Either.bifunctor().run {
-  this@bimap.bimap<A, B, C, D>(arg1, arg2) as arrow.core.Either<C, D>
-}
+  Either<C, D> =
+  fix().bimap(arg1, arg2)
 
 @JvmName("lift")
 @Suppress(
@@ -37,6 +39,7 @@ fun <A, B, C, D> Kind<Kind<ForEither, A>, B>.bimap(arg1: Function1<A, C>, arg2: 
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.lift(arg0, arg1)"))
 fun <A, B, C, D> lift(arg0: Function1<A, C>, arg1: Function1<B, D>): Function1<Kind<Kind<ForEither,
   A>, B>, Kind<Kind<ForEither, C>, D>> = arrow.core.Either
   .bifunctor()
@@ -50,10 +53,9 @@ fun <A, B, C, D> lift(arg0: Function1<A, C>, arg1: Function1<B, D>): Function1<K
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("mapLeft(arg1)"))
 fun <A, B, C> Kind<Kind<ForEither, A>, B>.mapLeft(arg1: Function1<A, C>): Either<C, B> =
-  arrow.core.Either.bifunctor().run {
-    this@mapLeft.mapLeft<A, B, C>(arg1) as arrow.core.Either<C, B>
-  }
+  fix().mapLeft(arg1)
 
 @JvmName("rightFunctor")
 @Suppress(
@@ -62,6 +64,7 @@ fun <A, B, C> Kind<Kind<ForEither, A>, B>.mapLeft(arg1: Function1<A, C>): Either
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("Functor typeclasses is deprecated. Use concrete methods on Either")
 fun <X> rightFunctor(): Functor<Kind<ForEither, X>> = arrow.core.Either
   .bifunctor()
   .rightFunctor<X>() as arrow.typeclasses.Functor<arrow.Kind<arrow.core.ForEither, X>>
@@ -73,6 +76,7 @@ fun <X> rightFunctor(): Functor<Kind<ForEither, X>> = arrow.core.Either
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("Functor typeclasses is deprecated. Use concrete methods on Either")
 fun <X> leftFunctor(): Functor<Conested<ForEither, X>> = arrow.core.Either
   .bifunctor()
   .leftFunctor<X>() as arrow.typeclasses.Functor<arrow.typeclasses.Conested<arrow.core.ForEither,
@@ -86,12 +90,11 @@ fun <X> leftFunctor(): Functor<Conested<ForEither, X>> = arrow.core.Either
   "UNUSED_PARAMETER"
 )
 fun <AA, B, A : AA> Kind<Kind<ForEither, A>, B>.leftWiden(): Either<AA, B> =
-  arrow.core.Either.bifunctor().run {
-    this@leftWiden.leftWiden<AA, B, A>() as arrow.core.Either<AA, B>
-  }
+  fix()._leftWiden()
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("BiFunctor typeclasses is deprecated. Use concrete methods on Either")
 inline fun Companion.bifunctor(): EitherBifunctor = bifunctor_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/bitraverse/EitherBitraverse.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/bitraverse/EitherBitraverse.kt
@@ -81,7 +81,7 @@ fun <A, B, C, D> Kind<Kind<ForEither, A>, B>.bimap(arg1: Function1<A, C>, arg2: 
  *  fun main() {
  *  //sampleStart
  *  val f: (Int) -> Option<Int> = { Some(it + 1) }
- * 3) }
+ *  val g: (Int) -> Option<Int> = { Some(it * 3) }
  *
  *  val tuple = Tuple2(1, 2)
  *  val bitraverseResult = tuple.bitraverse(Option.applicative(), f, g)

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/bitraverse/EitherBitraverse.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/bitraverse/EitherBitraverse.kt
@@ -1,0 +1,111 @@
+package arrow.core.extensions.either.bitraverse
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.Either.Companion
+import arrow.core.ForEither
+import arrow.core.extensions.EitherBitraverse
+import arrow.typeclasses.Applicative
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val bitraverse_singleton: EitherBitraverse = object :
+  arrow.core.extensions.EitherBitraverse {}
+
+@JvmName("bitraverse")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <G, A, B, C, D> Kind<Kind<ForEither, A>, B>.bitraverse(
+  arg1: Applicative<G>,
+  arg2: Function1<A, Kind<G, C>>,
+  arg3: Function1<B, Kind<G, D>>
+): Kind<G, Kind<Kind<ForEither, C>, D>> = arrow.core.Either.bitraverse().run {
+  this@bitraverse.bitraverse<G, A, B, C, D>(arg1, arg2, arg3) as arrow.Kind<G,
+    arrow.Kind<arrow.Kind<arrow.core.ForEither, C>, D>>
+}
+
+@JvmName("bisequence")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <G, A, B> Kind<Kind<ForEither, Kind<G, A>>, Kind<G, B>>.bisequence(arg1: Applicative<G>):
+  Kind<G, Kind<Kind<ForEither, A>, B>> = arrow.core.Either.bitraverse().run {
+  this@bisequence.bisequence<G, A, B>(arg1) as arrow.Kind<G,
+    arrow.Kind<arrow.Kind<arrow.core.ForEither, A>, B>>
+}
+
+@JvmName("bimap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <A, B, C, D> Kind<Kind<ForEither, A>, B>.bimap(arg1: Function1<A, C>, arg2: Function1<B, D>):
+  Either<C, D> = arrow.core.Either.bitraverse().run {
+  this@bimap.bimap<A, B, C, D>(arg1, arg2) as arrow.core.Either<C, D>
+}
+
+/**
+ *  ank_macro_hierarchy(arrow.typeclasses.Bitraverse)
+ *
+ *  The type class `Bitraverse` defines the behaviour of two separetes `Traverse` over a data type.
+ *
+ *  Every instance of `Bitraverse<F>` must contains the next functions:
+ *
+ *  ## Bitraverse
+ *
+ *  `Bitraverse` perfoms a`Traverse` over both side of the Data type which is `Bifoldable`.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.core.*
+ *  import arrow.core.extensions.option.applicative.applicative
+ *  import arrow.core.extensions.*
+ *  import arrow.core.extensions.tuple2.bitraverse.bitraverse
+ *  fun main() {
+ *  //sampleStart
+ *  val f: (Int) -> Option<Int> = { Some(it + 1) }
+ * 3) }
+ *
+ *  val tuple = Tuple2(1, 2)
+ *  val bitraverseResult = tuple.bitraverse(Option.applicative(), f, g)
+ *  //sampleEnd
+ *  println(bitraverseResult)
+ *  }
+ *  ```
+ *
+ *  ## Bisequence
+ *
+ *  `Bisequence` invert the original structure `F<G<A,B>>` to `G<F<A>,F<B>>`
+ *  ```kotlin:ank:playground
+ *  import arrow.core.*
+ *  import arrow.core.extensions.*
+ *  import arrow.core.extensions.option.applicative.applicative
+ *  import arrow.core.extensions.tuple2.bitraverse.bisequence
+ *  fun main() {
+ *  //sampleStart
+ *  val tuple = Tuple2(Some(1), Some(2))
+ *  val sequenceResult = tuple.bisequence(Option.applicative())
+ *  //sampleEnd
+ *  println(sequenceResult)
+ *  }
+ *  ```
+ */
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+inline fun Companion.bitraverse(): EitherBitraverse = bitraverse_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/bitraverse/EitherBitraverse.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/bitraverse/EitherBitraverse.kt
@@ -5,6 +5,7 @@ import arrow.core.Either
 import arrow.core.Either.Companion
 import arrow.core.ForEither
 import arrow.core.extensions.EitherBitraverse
+import arrow.core.fix
 import arrow.typeclasses.Applicative
 import kotlin.Function1
 import kotlin.PublishedApi
@@ -25,6 +26,7 @@ internal val bitraverse_singleton: EitherBitraverse = object :
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated. Replace with bitraverse or bitraverseValidated from arrow.core.*")
 fun <G, A, B, C, D> Kind<Kind<ForEither, A>, B>.bitraverse(
   arg1: Applicative<G>,
   arg2: Function1<A, Kind<G, C>>,
@@ -41,6 +43,7 @@ fun <G, A, B, C, D> Kind<Kind<ForEither, A>, B>.bitraverse(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated. Replace with bisequence or bisequenceValidated from arrow.core.*")
 fun <G, A, B> Kind<Kind<ForEither, Kind<G, A>>, Kind<G, B>>.bisequence(arg1: Applicative<G>):
   Kind<G, Kind<Kind<ForEither, A>, B>> = arrow.core.Either.bitraverse().run {
   this@bisequence.bisequence<G, A, B>(arg1) as arrow.Kind<G,
@@ -54,10 +57,10 @@ fun <G, A, B> Kind<Kind<ForEither, Kind<G, A>>, Kind<G, B>>.bisequence(arg1: App
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("bimap(arg1, arg2)"))
 fun <A, B, C, D> Kind<Kind<ForEither, A>, B>.bimap(arg1: Function1<A, C>, arg2: Function1<B, D>):
-  Either<C, D> = arrow.core.Either.bitraverse().run {
-  this@bimap.bimap<A, B, C, D>(arg1, arg2) as arrow.core.Either<C, D>
-}
+  Either<C, D> =
+  fix().bimap(arg1, arg2)
 
 /**
  *  ank_macro_hierarchy(arrow.typeclasses.Bitraverse)
@@ -108,4 +111,5 @@ fun <A, B, C, D> Kind<Kind<ForEither, A>, B>.bimap(arg1: Function1<A, C>, arg2: 
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("Functor typeclasses is deprecated. Use concrete methods on Either")
 inline fun Companion.bitraverse(): EitherBitraverse = bitraverse_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/eq/EitherEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/eq/EitherEq.kt
@@ -15,6 +15,7 @@ import kotlin.jvm.JvmName
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension projected functions are deprecated", ReplaceWith("neqv(EQL, EQR, arg1)", "arrow.core.neqv"))
 fun <L, R> Either<L, R>.neqv(
   EQL: Eq<L>,
   EQR: Eq<R>,
@@ -27,6 +28,7 @@ fun <L, R> Either<L, R>.neqv(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("@extension projected functions are deprecated", ReplaceWith("eq(EQL, EQR)", "arrow.core.eq"))
 inline fun <L, R> Companion.eq(EQL: Eq<L>, EQR: Eq<R>): EitherEq<L, R> = object :
   arrow.core.extensions.EitherEq<L, R> {
   override fun EQL(): arrow.typeclasses.Eq<L> = EQL

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/eq/EitherEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/eq/EitherEq.kt
@@ -1,0 +1,35 @@
+package arrow.core.extensions.either.eq
+
+import arrow.core.Either
+import arrow.core.Either.Companion
+import arrow.core.extensions.EitherEq
+import arrow.typeclasses.Eq
+import kotlin.Boolean
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+@JvmName("neqv")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, R> Either<L, R>.neqv(
+  EQL: Eq<L>,
+  EQR: Eq<R>,
+  arg1: Either<L, R>
+): Boolean = arrow.core.Either.eq<L, R>(EQL, EQR).run {
+  this@neqv.neqv(arg1) as kotlin.Boolean
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+inline fun <L, R> Companion.eq(EQL: Eq<L>, EQR: Eq<R>): EitherEq<L, R> = object :
+  arrow.core.extensions.EitherEq<L, R> {
+  override fun EQL(): arrow.typeclasses.Eq<L> = EQL
+
+  override fun EQR(): arrow.typeclasses.Eq<R> = EQR
+}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/eq/EitherEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/eq/EitherEq.kt
@@ -28,7 +28,7 @@ fun <L, R> Either<L, R>.neqv(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("@extension projected functions are deprecated", ReplaceWith("eq(EQL, EQR)", "arrow.core.eq"))
+@Deprecated("@extension projected functions are deprecated", ReplaceWith("Either.eq(EQL, EQR)", "arrow.core.eq"))
 inline fun <L, R> Companion.eq(EQL: Eq<L>, EQR: Eq<R>): EitherEq<L, R> = object :
   arrow.core.extensions.EitherEq<L, R> {
   override fun EQL(): arrow.typeclasses.Eq<L> = EQL

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/eqK/EitherEqK.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/eqK/EitherEqK.kt
@@ -16,6 +16,7 @@ import kotlin.jvm.JvmName
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
 fun <L, A> Kind<Kind<ForEither, L>, A>.eqK(
   EQL: Eq<L>,
   arg1: Kind<Kind<ForEither, L>, A>,
@@ -31,6 +32,7 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.eqK(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
 fun <L, A> liftEq(EQL: Eq<L>, arg0: Eq<A>): Eq<Kind<Kind<ForEither, L>, A>> = arrow.core.Either
   .eqK<L>(EQL)
   .liftEq<A>(arg0) as arrow.typeclasses.Eq<arrow.Kind<arrow.Kind<arrow.core.ForEither, L>, A>>
@@ -39,6 +41,7 @@ fun <L, A> liftEq(EQL: Eq<L>, arg0: Eq<A>): Eq<Kind<Kind<ForEither, L>, A>> = ar
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
 inline fun <L> Companion.eqK(EQL: Eq<L>): EitherEqK<L> = object : arrow.core.extensions.EitherEqK<L> {
   override fun EQL(): arrow.typeclasses.Eq<L> = EQL
 }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/eqK/EitherEqK.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/eqK/EitherEqK.kt
@@ -1,0 +1,44 @@
+package arrow.core.extensions.either.eqK
+
+import arrow.Kind
+import arrow.core.Either.Companion
+import arrow.core.ForEither
+import arrow.core.extensions.EitherEqK
+import arrow.typeclasses.Eq
+import kotlin.Boolean
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+@JvmName("eqK")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.eqK(
+  EQL: Eq<L>,
+  arg1: Kind<Kind<ForEither, L>, A>,
+  arg2: Eq<A>
+): Boolean = arrow.core.Either.eqK<L>(EQL).run {
+  this@eqK.eqK<A>(arg1, arg2) as kotlin.Boolean
+}
+
+@JvmName("liftEq")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> liftEq(EQL: Eq<L>, arg0: Eq<A>): Eq<Kind<Kind<ForEither, L>, A>> = arrow.core.Either
+  .eqK<L>(EQL)
+  .liftEq<A>(arg0) as arrow.typeclasses.Eq<arrow.Kind<arrow.Kind<arrow.core.ForEither, L>, A>>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+inline fun <L> Companion.eqK(EQL: Eq<L>): EitherEqK<L> = object : arrow.core.extensions.EitherEqK<L> {
+  override fun EQL(): arrow.typeclasses.Eq<L> = EQL
+}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/eqK2/EitherEqK2.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/eqK2/EitherEqK2.kt
@@ -1,0 +1,50 @@
+package arrow.core.extensions.either.eqK2
+
+import arrow.Kind
+import arrow.core.Either.Companion
+import arrow.core.ForEither
+import arrow.core.extensions.EitherEqK2
+import arrow.typeclasses.Eq
+import kotlin.Boolean
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val eqK2_singleton: EitherEqK2 = object : arrow.core.extensions.EitherEqK2 {}
+
+@JvmName("eqK")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <A, B> Kind<Kind<ForEither, A>, B>.eqK(
+  arg1: Kind<Kind<ForEither, A>, B>,
+  arg2: Eq<A>,
+  arg3: Eq<B>
+): Boolean = arrow.core.Either.eqK2().run {
+  this@eqK.eqK<A, B>(arg1, arg2, arg3) as kotlin.Boolean
+}
+
+@JvmName("liftEq")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <A, B> liftEq(arg0: Eq<A>, arg1: Eq<B>): Eq<Kind<Kind<ForEither, A>, B>> = arrow.core.Either
+  .eqK2()
+  .liftEq<A, B>(arg0, arg1) as arrow.typeclasses.Eq<arrow.Kind<arrow.Kind<arrow.core.ForEither, A>,
+  B>>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+inline fun Companion.eqK2(): EitherEqK2 = eqK2_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/eqK2/EitherEqK2.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/eqK2/EitherEqK2.kt
@@ -23,6 +23,7 @@ internal val eqK2_singleton: EitherEqK2 = object : arrow.core.extensions.EitherE
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
 fun <A, B> Kind<Kind<ForEither, A>, B>.eqK(
   arg1: Kind<Kind<ForEither, A>, B>,
   arg2: Eq<A>,
@@ -38,6 +39,7 @@ fun <A, B> Kind<Kind<ForEither, A>, B>.eqK(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
 fun <A, B> liftEq(arg0: Eq<A>, arg1: Eq<B>): Eq<Kind<Kind<ForEither, A>, B>> = arrow.core.Either
   .eqK2()
   .liftEq<A, B>(arg0, arg1) as arrow.typeclasses.Eq<arrow.Kind<arrow.Kind<arrow.core.ForEither, A>,
@@ -47,4 +49,5 @@ fun <A, B> liftEq(arg0: Eq<A>, arg1: Eq<B>): Eq<Kind<Kind<ForEither, A>, B>> = a
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
 inline fun Companion.eqK2(): EitherEqK2 = eqK2_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/foldable/EitherFoldable.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/foldable/EitherFoldable.kt
@@ -2,10 +2,16 @@ package arrow.core.extensions.either.foldable
 
 import arrow.Kind
 import arrow.core.Either
+import arrow.core.Option
 import arrow.core.Either.Companion
 import arrow.core.Eval
 import arrow.core.ForEither
+import arrow.core.None
+import arrow.core.Some
 import arrow.core.extensions.EitherFoldable
+import arrow.core.fix
+import arrow.core.orNull
+import arrow.core.right
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Monad
 import arrow.typeclasses.Monoid
@@ -33,10 +39,9 @@ internal val foldable_singleton: EitherFoldable<Any?> = object : EitherFoldable<
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("foldLeft(arg1, arg2)"))
 fun <L, A, B> Kind<Kind<ForEither, L>, A>.foldLeft(arg1: B, arg2: Function2<B, A, B>): B =
-  arrow.core.Either.foldable<L>().run {
-    this@foldLeft.foldLeft<A, B>(arg1, arg2) as B
-  }
+  fix().foldLeft(arg1, arg2)
 
 @JvmName("foldRight")
 @Suppress(
@@ -45,12 +50,12 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.foldLeft(arg1: B, arg2: Function2<B, A
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("foldRight(arg1, arg2)"))
 fun <L, A, B> Kind<Kind<ForEither, L>, A>.foldRight(
   arg1: Eval<B>,
   arg2: Function2<A, Eval<B>, Eval<B>>
-): Eval<B> = arrow.core.Either.foldable<L>().run {
-  this@foldRight.foldRight<A, B>(arg1, arg2) as arrow.core.Eval<B>
-}
+): Eval<B> =
+  fix().foldRight(arg1, arg2)
 
 @JvmName("fold")
 @Suppress(
@@ -59,10 +64,9 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.foldRight(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("fold({ arg1.empty() }, { it })"))
 fun <L, A> Kind<Kind<ForEither, L>, A>.fold(arg1: Monoid<A>): A =
-  arrow.core.Either.foldable<L>().run {
-    this@fold.fold<A>(arg1) as A
-  }
+  fix().fold({ arg1.empty() }, { it })
 
 @JvmName("reduceLeftToOption")
 @Suppress(
@@ -71,12 +75,12 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.fold(arg1: Monoid<A>): A =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Option.fromNullable(map(arg1).orNull()), { it })", "arrow.core.Option"))
 fun <L, A, B> Kind<Kind<ForEither, L>, A>.reduceLeftToOption(
   arg1: Function1<A, B>,
   arg2: Function2<B, A, B>
-): Option<B> = arrow.core.Either.foldable<L>().run {
-  this@reduceLeftToOption.reduceLeftToOption<A, B>(arg1, arg2) as arrow.core.Option<B>
-}
+): Option<B> =
+  Option.fromNullable(fix().map(arg1).orNull())
 
 @JvmName("reduceRightToOption")
 @Suppress(
@@ -85,13 +89,12 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.reduceLeftToOption(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Eval.now(Option.fromNullable(map(arg1).orNull()))", "arrow.core.Option", "arrow.core.Eval"))
 fun <L, A, B> Kind<Kind<ForEither, L>, A>.reduceRightToOption(
   arg1: Function1<A, B>,
   arg2: Function2<A, Eval<B>, Eval<B>>
-): Eval<Option<B>> = arrow.core.Either.foldable<L>().run {
-  this@reduceRightToOption.reduceRightToOption<A, B>(arg1, arg2) as
-    arrow.core.Eval<arrow.core.Option<B>>
-}
+): Eval<Option<B>> =
+  Eval.now(Option.fromNullable(fix().map(arg1).orNull()))
 
 @JvmName("reduceLeftOption")
 @Suppress(
@@ -100,10 +103,9 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.reduceRightToOption(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Option.fromNullable(orNull())", "arrow.core.Option"))
 fun <L, A> Kind<Kind<ForEither, L>, A>.reduceLeftOption(arg1: Function2<A, A, A>): Option<A> =
-  arrow.core.Either.foldable<L>().run {
-    this@reduceLeftOption.reduceLeftOption<A>(arg1) as arrow.core.Option<A>
-  }
+  Option.fromNullable(orNull())
 
 @JvmName("reduceRightOption")
 @Suppress(
@@ -112,10 +114,9 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.reduceLeftOption(arg1: Function2<A, A, A>
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-fun <L, A> Kind<Kind<ForEither, L>, A>.reduceRightOption(arg1: Function2<A, Eval<A>, Eval<A>>):
-  Eval<Option<A>> = arrow.core.Either.foldable<L>().run {
-  this@reduceRightOption.reduceRightOption<A>(arg1) as arrow.core.Eval<arrow.core.Option<A>>
-}
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Eval.now(Option.fromNullable(orNull()))", "arrow.core.Option", "arrow.core.Eval"))
+fun <L, A> Kind<Kind<ForEither, L>, A>.reduceRightOption(arg1: Function2<A, Eval<A>, Eval<A>>): Eval<Option<A>> =
+  Eval.now(Option.fromNullable(orNull()))
 
 @JvmName("combineAll")
 @Suppress(
@@ -124,10 +125,9 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.reduceRightOption(arg1: Function2<A, Eval
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("fold({ arg1.empty() }, { it })"))
 fun <L, A> Kind<Kind<ForEither, L>, A>.combineAll(arg1: Monoid<A>): A =
-  arrow.core.Either.foldable<L>().run {
-    this@combineAll.combineAll<A>(arg1) as A
-  }
+  fix().fold({ arg1.empty() }, { it })
 
 @JvmName("foldMap")
 @Suppress(
@@ -136,10 +136,9 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.combineAll(arg1: Monoid<A>): A =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("foldMap(arg1, arg2)"))
 fun <L, A, B> Kind<Kind<ForEither, L>, A>.foldMap(arg1: Monoid<B>, arg2: Function1<A, B>): B =
-  arrow.core.Either.foldable<L>().run {
-    this@foldMap.foldMap<A, B>(arg1, arg2) as B
-  }
+  fix().foldMap(arg1, arg2)
 
 @JvmName("orEmpty")
 @Suppress(
@@ -148,10 +147,9 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.foldMap(arg1: Monoid<B>, arg2: Functio
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg1.empty().right()", "arrow.core.right"))
 fun <L, A> orEmpty(arg0: Applicative<Kind<ForEither, L>>, arg1: Monoid<A>): Either<L, A> =
-  arrow.core.Either
-    .foldable<L>()
-    .orEmpty<A>(arg0, arg1) as arrow.core.Either<L, A>
+  arg1.empty().right()
 
 @JvmName("traverse_")
 @Suppress(
@@ -160,6 +158,7 @@ fun <L, A> orEmpty(arg0: Applicative<Kind<ForEither, L>>, arg1: Monoid<A>): Eith
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated. Replace with traverse_ or traverseValidated_ from arrow.core.*")
 fun <L, G, A, B> Kind<Kind<ForEither, L>, A>.traverse_(
   arg1: Applicative<G>,
   arg2: Function1<A, Kind<G, B>>
@@ -174,6 +173,7 @@ fun <L, G, A, B> Kind<Kind<ForEither, L>, A>.traverse_(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated. Replace with sequence_ or sequenceValidated_ from arrow.core.*")
 fun <L, G, A> Kind<Kind<ForEither, L>, Kind<G, A>>.sequence_(arg1: Applicative<G>): Kind<G, Unit> =
   arrow.core.Either.foldable<L>().run {
     this@sequence_.sequence_<G, A>(arg1) as arrow.Kind<G, kotlin.Unit>
@@ -186,10 +186,9 @@ fun <L, G, A> Kind<Kind<ForEither, L>, Kind<G, A>>.sequence_(arg1: Applicative<G
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Option.fromNullable(findOrNull(arg1))", "arrow.core.Option"))
 fun <L, A> Kind<Kind<ForEither, L>, A>.find(arg1: Function1<A, Boolean>): Option<A> =
-  arrow.core.Either.foldable<L>().run {
-    this@find.find<A>(arg1) as arrow.core.Option<A>
-  }
+  Option.fromNullable(fix().findOrNull(arg1))
 
 @JvmName("exists")
 @Suppress(
@@ -198,10 +197,9 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.find(arg1: Function1<A, Boolean>): Option
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("exists(arg1)"))
 fun <L, A> Kind<Kind<ForEither, L>, A>.exists(arg1: Function1<A, Boolean>): Boolean =
-  arrow.core.Either.foldable<L>().run {
-    this@exists.exists<A>(arg1) as kotlin.Boolean
-  }
+  fix().exists(arg1)
 
 @JvmName("forAll")
 @Suppress(
@@ -210,10 +208,9 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.exists(arg1: Function1<A, Boolean>): Bool
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("all(arg1)"))
 fun <L, A> Kind<Kind<ForEither, L>, A>.forAll(arg1: Function1<A, Boolean>): Boolean =
-  arrow.core.Either.foldable<L>().run {
-    this@forAll.all(arg1) as kotlin.Boolean
-  }
+  fix().all(arg1)
 
 @JvmName("all")
 @Suppress(
@@ -222,10 +219,9 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.forAll(arg1: Function1<A, Boolean>): Bool
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("all(arg1)"))
 fun <L, A> Kind<Kind<ForEither, L>, A>.all(arg1: Function1<A, Boolean>): Boolean =
-  arrow.core.Either.foldable<L>().run {
-    this@all.all<A>(arg1) as kotlin.Boolean
-  }
+  fix().all(arg1)
 
 @JvmName("isEmpty")
 @Suppress(
@@ -234,9 +230,9 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.all(arg1: Function1<A, Boolean>): Boolean
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-fun <L, A> Kind<Kind<ForEither, L>, A>.isEmpty(): Boolean = arrow.core.Either.foldable<L>().run {
-  this@isEmpty.isEmpty<A>() as kotlin.Boolean
-}
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("isEmpty()"))
+fun <L, A> Kind<Kind<ForEither, L>, A>.isEmpty(): Boolean =
+  fix().isEmpty()
 
 @JvmName("nonEmpty")
 @Suppress(
@@ -245,9 +241,9 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.isEmpty(): Boolean = arrow.core.Either.fo
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-fun <L, A> Kind<Kind<ForEither, L>, A>.nonEmpty(): Boolean = arrow.core.Either.foldable<L>().run {
-  this@nonEmpty.isNotEmpty() as kotlin.Boolean
-}
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("isNotEmpty()"))
+fun <L, A> Kind<Kind<ForEither, L>, A>.nonEmpty(): Boolean =
+  fix().isNotEmpty()
 
 @JvmName("isNotEmpty")
 @Suppress(
@@ -256,9 +252,9 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.nonEmpty(): Boolean = arrow.core.Either.f
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-fun <L, A> Kind<Kind<ForEither, L>, A>.isNotEmpty(): Boolean = arrow.core.Either.foldable<L>().run {
-  this@isNotEmpty.isNotEmpty<A>() as kotlin.Boolean
-}
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("isNotEmpty()"))
+fun <L, A> Kind<Kind<ForEither, L>, A>.isNotEmpty(): Boolean =
+  fix().isNotEmpty()
 
 @JvmName("size")
 @Suppress(
@@ -267,10 +263,9 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.isNotEmpty(): Boolean = arrow.core.Either
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("fold({ 0 }, { 1 })"))
 fun <L, A> Kind<Kind<ForEither, L>, A>.size(arg1: Monoid<Long>): Long =
-  arrow.core.Either.foldable<L>().run {
-    this@size.size<A>(arg1) as kotlin.Long
-  }
+  fix().fold({ 0 }, { 1 })
 
 @JvmName("foldMapA")
 @Suppress(
@@ -279,6 +274,7 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.size(arg1: Monoid<Long>): Long =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("Applicative typeclasses is deprecated. Use concrete methods on Validated")
 fun <L, G, A, B, AP : Applicative<G>, MO : Monoid<B>> Kind<Kind<ForEither, L>, A>.foldMapA(
   arg1: AP,
   arg2: MO,
@@ -294,6 +290,7 @@ fun <L, G, A, B, AP : Applicative<G>, MO : Monoid<B>> Kind<Kind<ForEither, L>, A
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("Applicative typeclasses is deprecated. Use concrete methods on Validated")
 fun <L, G, A, B, MA : Monad<G>, MO : Monoid<B>> Kind<Kind<ForEither, L>, A>.foldMapM(
   arg1: MA,
   arg2: MO,
@@ -309,6 +306,7 @@ fun <L, G, A, B, MA : Monad<G>, MO : Monoid<B>> Kind<Kind<ForEither, L>, A>.fold
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("Applicative typeclasses is deprecated. Use concrete methods on Validated")
 fun <L, G, A, B> Kind<Kind<ForEither, L>, A>.foldM(
   arg1: Monad<G>,
   arg2: B,
@@ -324,10 +322,12 @@ fun <L, G, A, B> Kind<Kind<ForEither, L>, A>.foldM(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated(
+  "@extension kinded projected functions are deprecated.",
+  ReplaceWith("if (arg1 < 0L) None else fix().fold({ None }, { if(arg1 == 0L) Some(it) else None })", "arrow.core.None", "arrow.core.Some")
+)
 fun <L, A> Kind<Kind<ForEither, L>, A>.get(arg1: Long): Option<A> =
-  arrow.core.Either.foldable<L>().run {
-    this@get.get<A>(arg1) as arrow.core.Option<A>
-  }
+  if (arg1 < 0L) None else fix().fold({ None }, { if (arg1 == 0L) Some(it) else None })
 
 @JvmName("firstOption")
 @Suppress(
@@ -336,10 +336,9 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.get(arg1: Long): Option<A> =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated.", ReplaceWith("Option.fromNullable(orNull())", "arrow.core.Option"))
 fun <L, A> Kind<Kind<ForEither, L>, A>.firstOption(): Option<A> =
-  arrow.core.Either.foldable<L>().run {
-    this@firstOption.firstOrNone() as arrow.core.Option<A>
-  }
+  Option.fromNullable(orNull())
 
 @JvmName("firstOption")
 @Suppress(
@@ -348,10 +347,9 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.firstOption(): Option<A> =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated.", ReplaceWith("Option.fromNullable(findOrNull(arg1))", "arrow.core.Option"))
 fun <L, A> Kind<Kind<ForEither, L>, A>.firstOption(arg1: Function1<A, Boolean>): Option<A> =
-  arrow.core.Either.foldable<L>().run {
-    this@firstOption.firstOrNone(arg1) as arrow.core.Option<A>
-  }
+  Option.fromNullable(fix().findOrNull(arg1))
 
 @JvmName("firstOrNone")
 @Suppress(
@@ -360,10 +358,9 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.firstOption(arg1: Function1<A, Boolean>):
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated.", ReplaceWith("Option.fromNullable(orNull())", "arrow.core.Option"))
 fun <L, A> Kind<Kind<ForEither, L>, A>.firstOrNone(): Option<A> =
-  arrow.core.Either.foldable<L>().run {
-    this@firstOrNone.firstOrNone<A>() as arrow.core.Option<A>
-  }
+  Option.fromNullable(orNull())
 
 @JvmName("firstOrNone")
 @Suppress(
@@ -372,10 +369,9 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.firstOrNone(): Option<A> =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated.", ReplaceWith("Option.fromNullable(findOrNull(arg1))", "arrow.core.Option"))
 fun <L, A> Kind<Kind<ForEither, L>, A>.firstOrNone(arg1: Function1<A, Boolean>): Option<A> =
-  arrow.core.Either.foldable<L>().run {
-    this@firstOrNone.firstOrNone<A>(arg1) as arrow.core.Option<A>
-  }
+  Option.fromNullable(fix().findOrNull(arg1))
 
 @JvmName("toList")
 @Suppress(
@@ -384,13 +380,14 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.firstOrNone(arg1: Function1<A, Boolean>):
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-fun <L, A> Kind<Kind<ForEither, L>, A>.toList(): List<A> = arrow.core.Either.foldable<L>().run {
-  this@toList.toList<A>() as kotlin.collections.List<A>
-}
+@Deprecated("@extension kinded projected functions are deprecated.", ReplaceWith("listOfNotNull(orNull())"))
+fun <L, A> Kind<Kind<ForEither, L>, A>.toList(): List<A> =
+  listOfNotNull(orNull())
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("Foldable typeclasses is deprecated. Use concrete methods on Either")
 inline fun <L> Companion.foldable(): EitherFoldable<L> = foldable_singleton as
   arrow.core.extensions.EitherFoldable<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/foldable/EitherFoldable.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/foldable/EitherFoldable.kt
@@ -1,0 +1,396 @@
+package arrow.core.extensions.either.foldable
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.Either.Companion
+import arrow.core.Eval
+import arrow.core.ForEither
+import arrow.core.extensions.EitherFoldable
+import arrow.typeclasses.Applicative
+import arrow.typeclasses.Monad
+import arrow.typeclasses.Monoid
+import kotlin.Any
+import kotlin.Boolean
+import kotlin.Function1
+import kotlin.Function2
+import kotlin.Long
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.List
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val foldable_singleton: EitherFoldable<Any?> = object : EitherFoldable<Any?> {}
+
+@JvmName("foldLeft")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.foldLeft(arg1: B, arg2: Function2<B, A, B>): B =
+  arrow.core.Either.foldable<L>().run {
+    this@foldLeft.foldLeft<A, B>(arg1, arg2) as B
+  }
+
+@JvmName("foldRight")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.foldRight(
+  arg1: Eval<B>,
+  arg2: Function2<A, Eval<B>, Eval<B>>
+): Eval<B> = arrow.core.Either.foldable<L>().run {
+  this@foldRight.foldRight<A, B>(arg1, arg2) as arrow.core.Eval<B>
+}
+
+@JvmName("fold")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.fold(arg1: Monoid<A>): A =
+  arrow.core.Either.foldable<L>().run {
+    this@fold.fold<A>(arg1) as A
+  }
+
+@JvmName("reduceLeftToOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.reduceLeftToOption(
+  arg1: Function1<A, B>,
+  arg2: Function2<B, A, B>
+): Option<B> = arrow.core.Either.foldable<L>().run {
+  this@reduceLeftToOption.reduceLeftToOption<A, B>(arg1, arg2) as arrow.core.Option<B>
+}
+
+@JvmName("reduceRightToOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.reduceRightToOption(
+  arg1: Function1<A, B>,
+  arg2: Function2<A, Eval<B>, Eval<B>>
+): Eval<Option<B>> = arrow.core.Either.foldable<L>().run {
+  this@reduceRightToOption.reduceRightToOption<A, B>(arg1, arg2) as
+    arrow.core.Eval<arrow.core.Option<B>>
+}
+
+@JvmName("reduceLeftOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.reduceLeftOption(arg1: Function2<A, A, A>): Option<A> =
+  arrow.core.Either.foldable<L>().run {
+    this@reduceLeftOption.reduceLeftOption<A>(arg1) as arrow.core.Option<A>
+  }
+
+@JvmName("reduceRightOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.reduceRightOption(arg1: Function2<A, Eval<A>, Eval<A>>):
+  Eval<Option<A>> = arrow.core.Either.foldable<L>().run {
+  this@reduceRightOption.reduceRightOption<A>(arg1) as arrow.core.Eval<arrow.core.Option<A>>
+}
+
+@JvmName("combineAll")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.combineAll(arg1: Monoid<A>): A =
+  arrow.core.Either.foldable<L>().run {
+    this@combineAll.combineAll<A>(arg1) as A
+  }
+
+@JvmName("foldMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.foldMap(arg1: Monoid<B>, arg2: Function1<A, B>): B =
+  arrow.core.Either.foldable<L>().run {
+    this@foldMap.foldMap<A, B>(arg1, arg2) as B
+  }
+
+@JvmName("orEmpty")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> orEmpty(arg0: Applicative<Kind<ForEither, L>>, arg1: Monoid<A>): Either<L, A> =
+  arrow.core.Either
+    .foldable<L>()
+    .orEmpty<A>(arg0, arg1) as arrow.core.Either<L, A>
+
+@JvmName("traverse_")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, G, A, B> Kind<Kind<ForEither, L>, A>.traverse_(
+  arg1: Applicative<G>,
+  arg2: Function1<A, Kind<G, B>>
+): Kind<G, Unit> = arrow.core.Either.foldable<L>().run {
+  this@traverse_.traverse_<G, A, B>(arg1, arg2) as arrow.Kind<G, kotlin.Unit>
+}
+
+@JvmName("sequence_")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, G, A> Kind<Kind<ForEither, L>, Kind<G, A>>.sequence_(arg1: Applicative<G>): Kind<G, Unit> =
+  arrow.core.Either.foldable<L>().run {
+    this@sequence_.sequence_<G, A>(arg1) as arrow.Kind<G, kotlin.Unit>
+  }
+
+@JvmName("find")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.find(arg1: Function1<A, Boolean>): Option<A> =
+  arrow.core.Either.foldable<L>().run {
+    this@find.find<A>(arg1) as arrow.core.Option<A>
+  }
+
+@JvmName("exists")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.exists(arg1: Function1<A, Boolean>): Boolean =
+  arrow.core.Either.foldable<L>().run {
+    this@exists.exists<A>(arg1) as kotlin.Boolean
+  }
+
+@JvmName("forAll")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.forAll(arg1: Function1<A, Boolean>): Boolean =
+  arrow.core.Either.foldable<L>().run {
+    this@forAll.all(arg1) as kotlin.Boolean
+  }
+
+@JvmName("all")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.all(arg1: Function1<A, Boolean>): Boolean =
+  arrow.core.Either.foldable<L>().run {
+    this@all.all<A>(arg1) as kotlin.Boolean
+  }
+
+@JvmName("isEmpty")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.isEmpty(): Boolean = arrow.core.Either.foldable<L>().run {
+  this@isEmpty.isEmpty<A>() as kotlin.Boolean
+}
+
+@JvmName("nonEmpty")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.nonEmpty(): Boolean = arrow.core.Either.foldable<L>().run {
+  this@nonEmpty.isNotEmpty() as kotlin.Boolean
+}
+
+@JvmName("isNotEmpty")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.isNotEmpty(): Boolean = arrow.core.Either.foldable<L>().run {
+  this@isNotEmpty.isNotEmpty<A>() as kotlin.Boolean
+}
+
+@JvmName("size")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.size(arg1: Monoid<Long>): Long =
+  arrow.core.Either.foldable<L>().run {
+    this@size.size<A>(arg1) as kotlin.Long
+  }
+
+@JvmName("foldMapA")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, G, A, B, AP : Applicative<G>, MO : Monoid<B>> Kind<Kind<ForEither, L>, A>.foldMapA(
+  arg1: AP,
+  arg2: MO,
+  arg3: Function1<A, Kind<G, B>>
+): Kind<G, B> = arrow.core.Either.foldable<L>().run {
+  this@foldMapA.foldMapA<G, A, B, AP, MO>(arg1, arg2, arg3) as arrow.Kind<G, B>
+}
+
+@JvmName("foldMapM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, G, A, B, MA : Monad<G>, MO : Monoid<B>> Kind<Kind<ForEither, L>, A>.foldMapM(
+  arg1: MA,
+  arg2: MO,
+  arg3: Function1<A, Kind<G, B>>
+): Kind<G, B> = arrow.core.Either.foldable<L>().run {
+  this@foldMapM.foldMapM<G, A, B, MA, MO>(arg1, arg2, arg3) as arrow.Kind<G, B>
+}
+
+@JvmName("foldM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, G, A, B> Kind<Kind<ForEither, L>, A>.foldM(
+  arg1: Monad<G>,
+  arg2: B,
+  arg3: Function2<B, A, Kind<G, B>>
+): Kind<G, B> = arrow.core.Either.foldable<L>().run {
+  this@foldM.foldM<G, A, B>(arg1, arg2, arg3) as arrow.Kind<G, B>
+}
+
+@JvmName("get")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.get(arg1: Long): Option<A> =
+  arrow.core.Either.foldable<L>().run {
+    this@get.get<A>(arg1) as arrow.core.Option<A>
+  }
+
+@JvmName("firstOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.firstOption(): Option<A> =
+  arrow.core.Either.foldable<L>().run {
+    this@firstOption.firstOrNone() as arrow.core.Option<A>
+  }
+
+@JvmName("firstOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.firstOption(arg1: Function1<A, Boolean>): Option<A> =
+  arrow.core.Either.foldable<L>().run {
+    this@firstOption.firstOrNone(arg1) as arrow.core.Option<A>
+  }
+
+@JvmName("firstOrNone")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.firstOrNone(): Option<A> =
+  arrow.core.Either.foldable<L>().run {
+    this@firstOrNone.firstOrNone<A>() as arrow.core.Option<A>
+  }
+
+@JvmName("firstOrNone")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.firstOrNone(arg1: Function1<A, Boolean>): Option<A> =
+  arrow.core.Either.foldable<L>().run {
+    this@firstOrNone.firstOrNone<A>(arg1) as arrow.core.Option<A>
+  }
+
+@JvmName("toList")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.toList(): List<A> = arrow.core.Either.foldable<L>().run {
+  this@toList.toList<A>() as kotlin.collections.List<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+inline fun <L> Companion.foldable(): EitherFoldable<L> = foldable_singleton as
+  arrow.core.extensions.EitherFoldable<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/functor/EitherFunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/functor/EitherFunctor.kt
@@ -361,6 +361,6 @@ fun <L, B, A : B> Kind<Kind<ForEither, L>, A>.widen(): Either<L, B> =
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("Functor typeclasses is deprecated. Use concrete methods on Validated")
+@Deprecated("Functor typeclasses is deprecated. Use concrete methods on Either")
 inline fun <L> Companion.functor(): EitherFunctor<L> = functor_singleton as
   arrow.core.extensions.EitherFunctor<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/functor/EitherFunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/functor/EitherFunctor.kt
@@ -5,7 +5,9 @@ import arrow.core.Either
 import arrow.core.Either.Companion
 import arrow.core.ForEither
 import arrow.core.Tuple2
+import arrow.core.widen as _widen
 import arrow.core.extensions.EitherFunctor
+import arrow.core.fix
 import kotlin.Any
 import kotlin.Function1
 import kotlin.PublishedApi
@@ -47,10 +49,9 @@ internal val functor_singleton: EitherFunctor<Any?> = object : EitherFunctor<Any
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("map(arg1)"))
 fun <L, A, B> Kind<Kind<ForEither, L>, A>.map(arg1: Function1<A, B>): Either<L, B> =
-  arrow.core.Either.functor<L>().run {
-    this@map.map<A, B>(arg1) as arrow.core.Either<L, B>
-  }
+  fix().map(arg1)
 
 @JvmName("imap")
 @Suppress(
@@ -59,10 +60,9 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.map(arg1: Function1<A, B>): Either<L, 
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-fun <L, A, B> Kind<Kind<ForEither, L>, A>.imap(arg1: Function1<A, B>, arg2: Function1<B, A>):
-  Either<L, B> = arrow.core.Either.functor<L>().run {
-  this@imap.imap<A, B>(arg1, arg2) as arrow.core.Either<L, B>
-}
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("map(arg1)"))
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.imap(arg1: Function1<A, B>, arg2: Function1<B, A>): Either<L, B> =
+  fix().map(arg1)
 
 /**
  *  Lifts a function `A -> B` to the [F] structure returning a polymorphic function
@@ -94,11 +94,11 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.imap(arg1: Function1<A, B>, arg2: Func
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-fun <L, A, B> lift(arg0: Function1<A, B>): Function1<Kind<Kind<ForEither, L>, A>,
-  Kind<Kind<ForEither, L>, B>> = arrow.core.Either
-  .functor<L>()
-  .lift<A, B>(arg0) as kotlin.Function1<arrow.Kind<arrow.Kind<arrow.core.ForEither, L>, A>,
-  arrow.Kind<arrow.Kind<arrow.core.ForEither, L>, B>>
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.lift(arg0)", "arrow.core.lift"))
+fun <L, A, B> lift(arg0: Function1<A, B>): Function1<Kind<Kind<ForEither, L>, A>, Kind<Kind<ForEither, L>, B>> =
+  Either.functor<L>()
+    .lift<A, B>(arg0) as kotlin.Function1<arrow.Kind<arrow.Kind<arrow.core.ForEither, L>, A>,
+    arrow.Kind<arrow.Kind<arrow.core.ForEither, L>, B>>
 
 @JvmName("void")
 @Suppress(
@@ -107,22 +107,9 @@ fun <L, A, B> lift(arg0: Function1<A, B>): Function1<Kind<Kind<ForEither, L>, A>
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("void()", "arrow.core.void"))
 fun <L, A> Kind<Kind<ForEither, L>, A>.void(): Either<L, Unit> =
-  arrow.core.Either.functor<L>().run {
-    this@void.void<A>() as arrow.core.Either<L, kotlin.Unit>
-  }
-
-@JvmName("unit")
-@Suppress(
-  "UNCHECKED_CAST",
-  "USELESS_CAST",
-  "EXTENSION_SHADOWED_BY_MEMBER",
-  "UNUSED_PARAMETER"
-)
-fun <L, A> Kind<Kind<ForEither, L>, A>.unit(): Either<L, Unit> =
-  arrow.core.Either.functor<L>().run {
-    this@unit.unit<A>() as arrow.core.Either<L, kotlin.Unit>
-  }
+  fix().void()
 
 /**
  *  Applies [f] to an [A] inside [F] and returns the [F] structure with a tuple of the [A] value and the
@@ -154,10 +141,9 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.unit(): Either<L, Unit> =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("fproduct(arg1)"))
 fun <L, A, B> Kind<Kind<ForEither, L>, A>.fproduct(arg1: Function1<A, B>): Either<L, Tuple2<A, B>> =
-  arrow.core.Either.functor<L>().run {
-    this@fproduct.fproduct<A, B>(arg1) as arrow.core.Either<L, arrow.core.Tuple2<A, B>>
-  }
+  fix().fproduct(arg1)
 
 /**
  *  Replaces [A] inside [F] with [B] resulting in a Kind<F, B>
@@ -188,10 +174,9 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.fproduct(arg1: Function1<A, B>): Eithe
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("mapConst(arg1)"))
 fun <L, A, B> Kind<Kind<ForEither, L>, A>.mapConst(arg1: B): Either<L, B> =
-  arrow.core.Either.functor<L>().run {
-    this@mapConst.mapConst<A, B>(arg1) as arrow.core.Either<L, B>
-  }
+  fix().mapConst(arg1)
 
 /**
  *  Replaces the [B] value inside [F] with [A] resulting in a Kind<F, A>
@@ -203,10 +188,9 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.mapConst(arg1: B): Either<L, B> =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg1.mapConst(this)"))
 fun <L, A, B> A.mapConst(arg1: Kind<Kind<ForEither, L>, B>): Either<L, A> =
-  arrow.core.Either.functor<L>().run {
-    this@mapConst.mapConst<A, B>(arg1) as arrow.core.Either<L, A>
-  }
+  arg1.fix().mapConst(this)
 
 /**
  *  Pairs [B] with [A] returning a Kind<F, Tuple2<B, A>>
@@ -237,10 +221,9 @@ fun <L, A, B> A.mapConst(arg1: Kind<Kind<ForEither, L>, B>): Either<L, A> =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("tupleLeft(arg1"))
 fun <L, A, B> Kind<Kind<ForEither, L>, A>.tupleLeft(arg1: B): Either<L, Tuple2<B, A>> =
-  arrow.core.Either.functor<L>().run {
-    this@tupleLeft.tupleLeft<A, B>(arg1) as arrow.core.Either<L, arrow.core.Tuple2<B, A>>
-  }
+  fix().tupleLeft(arg1)
 
 /**
  *  Pairs [A] with [B] returning a Kind<F, Tuple2<A, B>>
@@ -271,10 +254,9 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.tupleLeft(arg1: B): Either<L, Tuple2<B
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("tupleRight(arg1"))
 fun <L, A, B> Kind<Kind<ForEither, L>, A>.tupleRight(arg1: B): Either<L, Tuple2<A, B>> =
-  arrow.core.Either.functor<L>().run {
-    this@tupleRight.tupleRight<A, B>(arg1) as arrow.core.Either<L, arrow.core.Tuple2<A, B>>
-  }
+  fix().tupleRight(arg1)
 
 /**
  *  Given [A] is a sub type of [B], re-type this value from Kind<F, A> to Kind<F, B>
@@ -307,10 +289,9 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.tupleRight(arg1: B): Either<L, Tuple2<
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("widen()", "arrow.core.widen"))
 fun <L, B, A : B> Kind<Kind<ForEither, L>, A>.widen(): Either<L, B> =
-  arrow.core.Either.functor<L>().run {
-    this@widen.widen<B, A>() as arrow.core.Either<L, B>
-  }
+  fix()._widen()
 
 /**
  *  ank_macro_hierarchy(arrow.typeclasses.Functor)
@@ -380,5 +361,6 @@ fun <L, B, A : B> Kind<Kind<ForEither, L>, A>.widen(): Either<L, B> =
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("Functor typeclasses is deprecated. Use concrete methods on Validated")
 inline fun <L> Companion.functor(): EitherFunctor<L> = functor_singleton as
   arrow.core.extensions.EitherFunctor<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/functor/EitherFunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/functor/EitherFunctor.kt
@@ -1,0 +1,384 @@
+package arrow.core.extensions.either.functor
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.Either.Companion
+import arrow.core.ForEither
+import arrow.core.Tuple2
+import arrow.core.extensions.EitherFunctor
+import kotlin.Any
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val functor_singleton: EitherFunctor<Any?> = object : EitherFunctor<Any?> {}
+
+/**
+ *  Transform the [F] wrapped value [A] into [B] preserving the [F] structure
+ *  Kind<F, A> -> Kind<F, B>
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.core.*
+ * import arrow.core.extensions.either.functor.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.core.extensions.either.applicative.just
+ *
+ *  fun main(args: Array<String>) {
+ *   val result =
+ *   //sampleStart
+ *   "Hello".just<String, String>().map<String, String, String>({ "$it World" })
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.map(arg1: Function1<A, B>): Either<L, B> =
+  arrow.core.Either.functor<L>().run {
+    this@map.map<A, B>(arg1) as arrow.core.Either<L, B>
+  }
+
+@JvmName("imap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.imap(arg1: Function1<A, B>, arg2: Function1<B, A>):
+  Either<L, B> = arrow.core.Either.functor<L>().run {
+  this@imap.imap<A, B>(arg1, arg2) as arrow.core.Either<L, B>
+}
+
+/**
+ *  Lifts a function `A -> B` to the [F] structure returning a polymorphic function
+ *  that can be applied over all [F] values in the shape of Kind<F, A>
+ *
+ *  `A -> B -> Kind<F, A> -> Kind<F, B>`
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.core.*
+ * import arrow.core.extensions.either.functor.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.core.extensions.either.applicative.just
+ *
+ *  fun main(args: Array<String>) {
+ *   val result =
+ *   //sampleStart
+ *   lift<String, String, String>({ s: CharSequence -> "$s World" })("Hello".just<String, String>())
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("lift")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> lift(arg0: Function1<A, B>): Function1<Kind<Kind<ForEither, L>, A>,
+  Kind<Kind<ForEither, L>, B>> = arrow.core.Either
+  .functor<L>()
+  .lift<A, B>(arg0) as kotlin.Function1<arrow.Kind<arrow.Kind<arrow.core.ForEither, L>, A>,
+  arrow.Kind<arrow.Kind<arrow.core.ForEither, L>, B>>
+
+@JvmName("void")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.void(): Either<L, Unit> =
+  arrow.core.Either.functor<L>().run {
+    this@void.void<A>() as arrow.core.Either<L, kotlin.Unit>
+  }
+
+@JvmName("unit")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.unit(): Either<L, Unit> =
+  arrow.core.Either.functor<L>().run {
+    this@unit.unit<A>() as arrow.core.Either<L, kotlin.Unit>
+  }
+
+/**
+ *  Applies [f] to an [A] inside [F] and returns the [F] structure with a tuple of the [A] value and the
+ *  computed [B] value as result of applying [f]
+ *
+ *  Kind<F, A> -> Kind<F, Tuple2<A, B>>
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.core.*
+ * import arrow.core.extensions.either.functor.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.core.extensions.either.applicative.just
+ *
+ *  fun main(args: Array<String>) {
+ *   val result =
+ *   //sampleStart
+ *   "Hello".just<String, String>().fproduct<String, String, String>({ "$it World" })
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("fproduct")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.fproduct(arg1: Function1<A, B>): Either<L, Tuple2<A, B>> =
+  arrow.core.Either.functor<L>().run {
+    this@fproduct.fproduct<A, B>(arg1) as arrow.core.Either<L, arrow.core.Tuple2<A, B>>
+  }
+
+/**
+ *  Replaces [A] inside [F] with [B] resulting in a Kind<F, B>
+ *
+ *  Kind<F, A> -> Kind<F, B>
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.core.*
+ * import arrow.core.extensions.either.functor.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.core.extensions.either.applicative.just
+ *
+ *  fun main(args: Array<String>) {
+ *   val result =
+ *   //sampleStart
+ *   "Hello World".just<String, String>().mapConst<String, String, String>("...")
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("mapConst")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.mapConst(arg1: B): Either<L, B> =
+  arrow.core.Either.functor<L>().run {
+    this@mapConst.mapConst<A, B>(arg1) as arrow.core.Either<L, B>
+  }
+
+/**
+ *  Replaces the [B] value inside [F] with [A] resulting in a Kind<F, A>
+ */
+@JvmName("mapConst")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> A.mapConst(arg1: Kind<Kind<ForEither, L>, B>): Either<L, A> =
+  arrow.core.Either.functor<L>().run {
+    this@mapConst.mapConst<A, B>(arg1) as arrow.core.Either<L, A>
+  }
+
+/**
+ *  Pairs [B] with [A] returning a Kind<F, Tuple2<B, A>>
+ *
+ *  Kind<F, A> -> Kind<F, Tuple2<B, A>>
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.core.*
+ * import arrow.core.extensions.either.functor.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.core.extensions.either.applicative.just
+ *
+ *  fun main(args: Array<String>) {
+ *   val result =
+ *   //sampleStart
+ *   "Hello".just<String, String>().tupleLeft<String, String, String>("World")
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("tupleLeft")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.tupleLeft(arg1: B): Either<L, Tuple2<B, A>> =
+  arrow.core.Either.functor<L>().run {
+    this@tupleLeft.tupleLeft<A, B>(arg1) as arrow.core.Either<L, arrow.core.Tuple2<B, A>>
+  }
+
+/**
+ *  Pairs [A] with [B] returning a Kind<F, Tuple2<A, B>>
+ *
+ *  Kind<F, A> -> Kind<F, Tuple2<A, B>>
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.core.*
+ * import arrow.core.extensions.either.functor.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.core.extensions.either.applicative.just
+ *
+ *  fun main(args: Array<String>) {
+ *   val result =
+ *   //sampleStart
+ *   "Hello".just<String, String>().tupleRight<String, String, String>("World")
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("tupleRight")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.tupleRight(arg1: B): Either<L, Tuple2<A, B>> =
+  arrow.core.Either.functor<L>().run {
+    this@tupleRight.tupleRight<A, B>(arg1) as arrow.core.Either<L, arrow.core.Tuple2<A, B>>
+  }
+
+/**
+ *  Given [A] is a sub type of [B], re-type this value from Kind<F, A> to Kind<F, B>
+ *
+ *  Kind<F, A> -> Kind<F, B>
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.core.*
+ * import arrow.core.extensions.either.functor.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.core.extensions.either.applicative.just
+ *  import arrow.Kind
+ *
+ *  fun main(args: Array<String>) {
+ *   val result: Kind<*, CharSequence> =
+ *   //sampleStart
+ *   "Hello".just<String, String>().map<String, String, String>({ "$it World" }).widen<String,
+ * String, String>()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("widen")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, B, A : B> Kind<Kind<ForEither, L>, A>.widen(): Either<L, B> =
+  arrow.core.Either.functor<L>().run {
+    this@widen.widen<B, A>() as arrow.core.Either<L, B>
+  }
+
+/**
+ *  ank_macro_hierarchy(arrow.typeclasses.Functor)
+ *
+ *  The [Functor] type class abstracts the ability to [map] over the computational context of a type constructor.
+ *  Examples of type constructors that can implement instances of the Functor type class include
+ *  [arrow.core.Option], [arrow.core.NonEmptyList], [List] and many other data types that include a [map] function with the shape
+ *  `fun <F, A, B> Kind<F, A>.map(f: (A) -> B): Kind<F, B>` where `F` refers to any type constructor whose contents can be transformed.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.core.*
+ * import arrow.core.extensions.either.functor.*
+ * import arrow.core.*
+ *
+ *
+ *
+ *  fun main(args: Array<String>) {
+ *   val result =
+ *   //sampleStart
+ *   Either.functor<String>()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ *
+ *  ### Example
+ *
+ *  Oftentimes we find ourselves in situations where we need to transform the contents of some data type.
+ *  [map] allows us to safely compute over values under the assumption that they'll be there returning the
+ *  transformation encapsulated in the same context.
+ *
+ *  Consider [arrow.core.Option] and [arrow.core.Either]:
+ *
+ *  `Option<A>` allows us to model absence and has two possible states, `Some(a: A)` if the value is not absent and `None` to represent an empty case.
+ *  In a similar fashion `Either<L, R>` may have two possible cases `Left(l: L)` and `Right(r: R)`. By convention, `Left` is used to model the exceptional
+ *  case and `Right` for the successful case.
+ *
+ *  Both [arrow.core.Either] and [arrow.core.Option] are examples of data types that can be computed over transforming their inner results.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.*
+ *  import arrow.core.*
+ *
+ *  suspend fun main(args: Array<String>) {
+ *   val result =
+ *   //sampleStart
+ * 2 }
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.*
+ *  import arrow.core.*
+ *
+ *  fun main(args: Array<String>) {
+ *   val result =
+ *   //sampleStart
+ * 2 }
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+inline fun <L> Companion.functor(): EitherFunctor<L> = functor_singleton as
+  arrow.core.extensions.EitherFunctor<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/functor/EitherFunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/functor/EitherFunctor.kt
@@ -338,7 +338,7 @@ fun <L, B, A : B> Kind<Kind<ForEither, L>, A>.widen(): Either<L, B> =
  *  suspend fun main(args: Array<String>) {
  *   val result =
  *   //sampleStart
- * 2 }
+ *   Either.catch { "1".toInt() }.map { it * 2 }
  *   //sampleEnd
  *   println(result)
  *  }
@@ -351,7 +351,7 @@ fun <L, B, A : B> Kind<Kind<ForEither, L>, A>.widen(): Either<L, B> =
  *  fun main(args: Array<String>) {
  *   val result =
  *   //sampleStart
- * 2 }
+ *   Option(1).map { it * 2 }
  *   //sampleEnd
  *   println(result)
  *  }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/hash/EitherHash.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/hash/EitherHash.kt
@@ -1,0 +1,17 @@
+package arrow.core.extensions.either.hash
+
+import arrow.core.Either.Companion
+import arrow.core.extensions.EitherHash
+import arrow.typeclasses.Hash
+import kotlin.Suppress
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+inline fun <L, R> Companion.hash(HL: Hash<L>, HR: Hash<R>): EitherHash<L, R> = object :
+  arrow.core.extensions.EitherHash<L, R> {
+  override fun HL(): arrow.typeclasses.Hash<L> = HL
+
+  override fun HR(): arrow.typeclasses.Hash<R> = HR
+}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/hash/EitherHash.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/hash/EitherHash.kt
@@ -9,6 +9,7 @@ import kotlin.Suppress
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.hash(HL, HR)"))
 inline fun <L, R> Companion.hash(HL: Hash<L>, HR: Hash<R>): EitherHash<L, R> = object :
   arrow.core.extensions.EitherHash<L, R> {
   override fun HL(): arrow.typeclasses.Hash<L> = HL

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/monad/EitherMonad.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/monad/EitherMonad.kt
@@ -2,11 +2,18 @@ package arrow.core.extensions.either.monad
 
 import arrow.Kind
 import arrow.core.Either
+import arrow.core.flatMap as _flatMap
+import arrow.core.flatten as _flatten
+import arrow.core.ap as _ap
+import arrow.core.ifM as _ifM
+import arrow.core.selectM as _selectM
+import arrow.core.mproduct as _mproduct
 import arrow.core.Either.Companion
 import arrow.core.Eval
 import arrow.core.ForEither
 import arrow.core.Tuple2
 import arrow.core.extensions.EitherMonad
+import arrow.core.fix
 import kotlin.Any
 import kotlin.Boolean
 import kotlin.Function0
@@ -28,10 +35,9 @@ internal val monad_singleton: EitherMonad<Any?> = object : EitherMonad<Any?> {}
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-fun <L, A, B> Kind<Kind<ForEither, L>, A>.flatMap(arg1: Function1<A, Kind<Kind<ForEither, L>, B>>):
-  Either<L, B> = arrow.core.Either.monad<L>().run {
-  this@flatMap.flatMap<A, B>(arg1) as arrow.core.Either<L, B>
-}
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("flatMap(arg1)", "arrow.core.flatMap"))
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.flatMap(arg1: Function1<A, Kind<Kind<ForEither, L>, B>>): Either<L, B> =
+  fix()._flatMap{ arg1(it).fix() }
 
 @JvmName("tailRecM")
 @Suppress(
@@ -40,10 +46,9 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.flatMap(arg1: Function1<A, Kind<Kind<F
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-fun <L, A, B> tailRecM(arg0: A, arg1: Function1<A, Kind<Kind<ForEither, L>, Either<A, B>>>):
-  Either<L, B> = arrow.core.Either
-  .monad<L>()
-  .tailRecM<A, B>(arg0, arg1) as arrow.core.Either<L, B>
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.tailRecM(arg0, arg1)", "arrow.core.tailRecM"))
+fun <L, A, B> tailRecM(arg0: A, arg1: Function1<A, Kind<Kind<ForEither, L>, Either<A, B>>>): Either<L, B> =
+  Either.tailRecM(arg0, arg1)
 
 @JvmName("map")
 @Suppress(
@@ -52,10 +57,9 @@ fun <L, A, B> tailRecM(arg0: A, arg1: Function1<A, Kind<Kind<ForEither, L>, Eith
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("map(arg1)"))
 fun <L, A, B> Kind<Kind<ForEither, L>, A>.map(arg1: Function1<A, B>): Either<L, B> =
-  arrow.core.Either.monad<L>().run {
-    this@map.map<A, B>(arg1) as arrow.core.Either<L, B>
-  }
+  fix().map(arg1)
 
 /**
  *  @see [Apply.ap]
@@ -67,10 +71,9 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.map(arg1: Function1<A, B>): Either<L, 
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-fun <L, A, B> Kind<Kind<ForEither, L>, A>.ap(arg1: Kind<Kind<ForEither, L>, Function1<A, B>>):
-  Either<L, B> = arrow.core.Either.monad<L>().run {
-  this@EitherMonad.mapN<A, (A) -> B, B>(this@ap, arg1) { (a, f) -> f(a) } as arrow.core.Either<L, B>
-}
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("ap(arg1)", "arrow.core.ap"))
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.ap(arg1: Kind<Kind<ForEither, L>, Function1<A, B>>): Either<L, B> =
+  _ap(arg1)
 
 @JvmName("flatten")
 @Suppress(
@@ -79,10 +82,9 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.ap(arg1: Kind<Kind<ForEither, L>, Func
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("flatten()", "arrow.core.flatten"))
 fun <L, A> Kind<Kind<ForEither, L>, Kind<Kind<ForEither, L>, A>>.flatten(): Either<L, A> =
-  arrow.core.Either.monad<L>().run {
-    this@flatten.flatten<A>() as arrow.core.Either<L, A>
-  }
+  map { it.fix() }._flatten()
 
 @JvmName("followedBy")
 @Suppress(
@@ -91,10 +93,9 @@ fun <L, A> Kind<Kind<ForEither, L>, Kind<Kind<ForEither, L>, A>>.flatten(): Eith
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-fun <L, A, B> Kind<Kind<ForEither, L>, A>.followedBy(arg1: Kind<Kind<ForEither, L>, B>): Either<L,
-  B> = arrow.core.Either.monad<L>().run {
-  this@followedBy.followedBy<A, B>(arg1) as arrow.core.Either<L, B>
-}
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("flatMap { arg1 }", "arrow.core.flatMap"))
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.followedBy(arg1: Kind<Kind<ForEither, L>, B>): Either<L, B> =
+  _flatMap { arg1.fix() }
 
 @JvmName("apTap")
 @Suppress(
@@ -103,10 +104,9 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.followedBy(arg1: Kind<Kind<ForEither, 
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.mapN(this, fb) { left, _ -> left }", "arrow.core.mapN"))
 fun <L, A, B> Kind<Kind<ForEither, L>, A>.apTap(arg1: Kind<Kind<ForEither, L>, B>): Either<L, A> =
-  arrow.core.Either.monad<L>().run {
-    this@apTap.apTap<A, B>(arg1) as arrow.core.Either<L, A>
-  }
+  Either.mapN(fix(), arg1.fix()) { left, _ -> left }
 
 @JvmName("followedByEval")
 @Suppress(
@@ -115,10 +115,9 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.apTap(arg1: Kind<Kind<ForEither, L>, B
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-fun <L, A, B> Kind<Kind<ForEither, L>, A>.followedByEval(arg1: Eval<Kind<Kind<ForEither, L>, B>>):
-  Either<L, B> = arrow.core.Either.monad<L>().run {
-  this@followedByEval.followedByEval<A, B>(arg1) as arrow.core.Either<L, B>
-}
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("flatMap { arg1.value() }", "arrow.core.flatMap"))
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.followedByEval(arg1: Eval<Kind<Kind<ForEither, L>, B>>): Either<L, B> =
+  _flatMap { arg1.value().fix() }
 
 @JvmName("effectM")
 @Suppress(
@@ -127,10 +126,9 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.followedByEval(arg1: Eval<Kind<Kind<Fo
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-fun <L, A, B> Kind<Kind<ForEither, L>, A>.effectM(arg1: Function1<A, Kind<Kind<ForEither, L>, B>>):
-  Either<L, A> = arrow.core.Either.monad<L>().run {
-  this@effectM.flatTap(arg1) as arrow.core.Either<L, A>
-}
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("flatMap { a -> arg1(a).map { a } }", "arrow.core.flatMap"))
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.effectM(arg1: Function1<A, Kind<Kind<ForEither, L>, B>>): Either<L, A> =
+  _flatMap { a -> arg1(a).map { a } }
 
 @JvmName("flatTap")
 @Suppress(
@@ -139,10 +137,9 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.effectM(arg1: Function1<A, Kind<Kind<F
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-fun <L, A, B> Kind<Kind<ForEither, L>, A>.flatTap(arg1: Function1<A, Kind<Kind<ForEither, L>, B>>):
-  Either<L, A> = arrow.core.Either.monad<L>().run {
-  this@flatTap.flatTap<A, B>(arg1) as arrow.core.Either<L, A>
-}
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("flatMap { a -> arg1(a).map { a } }", "arrow.core.flatMap"))
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.flatTap(arg1: Function1<A, Kind<Kind<ForEither, L>, B>>): Either<L, A> =
+  _flatMap { a -> arg1(a).map { a } }
 
 @JvmName("productL")
 @Suppress(
@@ -151,10 +148,9 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.flatTap(arg1: Function1<A, Kind<Kind<F
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("flatMap { a -> arg1.map { a } }", "arrow.core.flatMap"))
 fun <L, A, B> Kind<Kind<ForEither, L>, A>.productL(arg1: Kind<Kind<ForEither, L>, B>): Either<L, A> =
-  arrow.core.Either.monad<L>().run {
-    this@productL.productL<A, B>(arg1) as arrow.core.Either<L, A>
-  }
+  _flatMap { a -> arg1.map { a } }
 
 @JvmName("forEffect")
 @Suppress(
@@ -163,10 +159,9 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.productL(arg1: Kind<Kind<ForEither, L>
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("flatMap { a -> arg1.map { a } }", "arrow.core.flatMap"))
 fun <L, A, B> Kind<Kind<ForEither, L>, A>.forEffect(arg1: Kind<Kind<ForEither, L>, B>): Either<L, A> =
-  arrow.core.Either.monad<L>().run {
-    this@forEffect.productL(arg1) as arrow.core.Either<L, A>
-  }
+  _flatMap { a -> arg1.map { a } }
 
 @JvmName("productLEval")
 @Suppress(
@@ -175,10 +170,9 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.forEffect(arg1: Kind<Kind<ForEither, L
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-fun <L, A, B> Kind<Kind<ForEither, L>, A>.productLEval(arg1: Eval<Kind<Kind<ForEither, L>, B>>):
-  Either<L, A> = arrow.core.Either.monad<L>().run {
-  this@productLEval.productLEval<A, B>(arg1) as arrow.core.Either<L, A>
-}
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("flatMap { a -> arg1.value().map { a } }", "arrow.core.flatMap"))
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.productLEval(arg1: Eval<Kind<Kind<ForEither, L>, B>>): Either<L, A> =
+  _flatMap { a -> arg1.value().map { a } }
 
 @JvmName("forEffectEval")
 @Suppress(
@@ -187,10 +181,9 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.productLEval(arg1: Eval<Kind<Kind<ForE
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-fun <L, A, B> Kind<Kind<ForEither, L>, A>.forEffectEval(arg1: Eval<Kind<Kind<ForEither, L>, B>>):
-  Either<L, A> = arrow.core.Either.monad<L>().run {
-  this@forEffectEval.productLEval(arg1) as arrow.core.Either<L, A>
-}
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("flatMap { a -> arg1.value().map { a } }", "arrow.core.flatMap"))
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.forEffectEval(arg1: Eval<Kind<Kind<ForEither, L>, B>>): Either<L, A> =
+  _flatMap { a -> arg1.value().map { a } }
 
 @JvmName("mproduct")
 @Suppress(
@@ -199,10 +192,9 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.forEffectEval(arg1: Eval<Kind<Kind<For
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-fun <L, A, B> Kind<Kind<ForEither, L>, A>.mproduct(arg1: Function1<A, Kind<Kind<ForEither, L>, B>>):
-  Either<L, Tuple2<A, B>> = arrow.core.Either.monad<L>().run {
-  this@mproduct.mproduct<A, B>(arg1) as arrow.core.Either<L, arrow.core.Tuple2<A, B>>
-}
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("mproduct { arg1(it) }", "arrow.core.mproduct"))
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.mproduct(arg1: Function1<A, Kind<Kind<ForEither, L>, B>>): Either<L, Tuple2<A, B>> =
+  fix()._mproduct { arg1(it).fix() }
 
 @JvmName("ifM")
 @Suppress(
@@ -211,12 +203,12 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.mproduct(arg1: Function1<A, Kind<Kind<
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("ifM({ arg1() }, { arg2() })", "arrow.core.ifM"))
 fun <L, B> Kind<Kind<ForEither, L>, Boolean>.ifM(
   arg1: Function0<Kind<Kind<ForEither, L>, B>>,
   arg2: Function0<Kind<Kind<ForEither, L>, B>>
-): Either<L, B> = arrow.core.Either.monad<L>().run {
-  this@ifM.ifM<B>(arg1, arg2) as arrow.core.Either<L, B>
-}
+): Either<L, B> =
+  fix()._ifM({ arg1().fix() }, { arg2().fix() })
 
 @JvmName("selectM")
 @Suppress(
@@ -225,12 +217,12 @@ fun <L, B> Kind<Kind<ForEither, L>, Boolean>.ifM(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("selectM(arg1)", "arrow.core.selectM"))
 fun <L, A, B> Kind<Kind<ForEither, L>, Either<A, B>>.selectM(
   arg1: Kind<Kind<ForEither, L>,
     Function1<A, B>>
-): Either<L, B> = arrow.core.Either.monad<L>().run {
-  this@selectM.selectM<A, B>(arg1) as arrow.core.Either<L, B>
-}
+): Either<L, B> =
+  fix()._selectM(arg1.fix())
 
 @JvmName("select")
 @Suppress(
@@ -239,12 +231,12 @@ fun <L, A, B> Kind<Kind<ForEither, L>, Either<A, B>>.selectM(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("selectM(arg1)", "arrow.core.selectM"))
 fun <L, A, B> Kind<Kind<ForEither, L>, Either<A, B>>.select(
   arg1: Kind<Kind<ForEither, L>,
     Function1<A, B>>
-): Either<L, B> = arrow.core.Either.monad<L>().run {
-  this@select.select<A, B>(arg1) as arrow.core.Either<L, B>
-}
+): Either<L, B> =
+  fix()._selectM(arg1.fix())
 
 /**
  *  ank_macro_hierarchy(arrow.typeclasses.Monad)
@@ -264,5 +256,6 @@ fun <L, A, B> Kind<Kind<ForEither, L>, Either<A, B>>.select(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("Monad typeclasses is deprecated. Use concrete methods on Either")
 inline fun <L> Companion.monad(): EitherMonad<L> = monad_singleton as
   arrow.core.extensions.EitherMonad<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/monad/EitherMonad.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/monad/EitherMonad.kt
@@ -1,0 +1,268 @@
+package arrow.core.extensions.either.monad
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.Either.Companion
+import arrow.core.Eval
+import arrow.core.ForEither
+import arrow.core.Tuple2
+import arrow.core.extensions.EitherMonad
+import kotlin.Any
+import kotlin.Boolean
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monad_singleton: EitherMonad<Any?> = object : EitherMonad<Any?> {}
+
+@JvmName("flatMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.flatMap(arg1: Function1<A, Kind<Kind<ForEither, L>, B>>):
+  Either<L, B> = arrow.core.Either.monad<L>().run {
+  this@flatMap.flatMap<A, B>(arg1) as arrow.core.Either<L, B>
+}
+
+@JvmName("tailRecM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> tailRecM(arg0: A, arg1: Function1<A, Kind<Kind<ForEither, L>, Either<A, B>>>):
+  Either<L, B> = arrow.core.Either
+  .monad<L>()
+  .tailRecM<A, B>(arg0, arg1) as arrow.core.Either<L, B>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.map(arg1: Function1<A, B>): Either<L, B> =
+  arrow.core.Either.monad<L>().run {
+    this@map.map<A, B>(arg1) as arrow.core.Either<L, B>
+  }
+
+/**
+ *  @see [Apply.ap]
+ */
+@JvmName("ap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.ap(arg1: Kind<Kind<ForEither, L>, Function1<A, B>>):
+  Either<L, B> = arrow.core.Either.monad<L>().run {
+  this@EitherMonad.mapN<A, (A) -> B, B>(this@ap, arg1) { (a, f) -> f(a) } as arrow.core.Either<L, B>
+}
+
+@JvmName("flatten")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, Kind<Kind<ForEither, L>, A>>.flatten(): Either<L, A> =
+  arrow.core.Either.monad<L>().run {
+    this@flatten.flatten<A>() as arrow.core.Either<L, A>
+  }
+
+@JvmName("followedBy")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.followedBy(arg1: Kind<Kind<ForEither, L>, B>): Either<L,
+  B> = arrow.core.Either.monad<L>().run {
+  this@followedBy.followedBy<A, B>(arg1) as arrow.core.Either<L, B>
+}
+
+@JvmName("apTap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.apTap(arg1: Kind<Kind<ForEither, L>, B>): Either<L, A> =
+  arrow.core.Either.monad<L>().run {
+    this@apTap.apTap<A, B>(arg1) as arrow.core.Either<L, A>
+  }
+
+@JvmName("followedByEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.followedByEval(arg1: Eval<Kind<Kind<ForEither, L>, B>>):
+  Either<L, B> = arrow.core.Either.monad<L>().run {
+  this@followedByEval.followedByEval<A, B>(arg1) as arrow.core.Either<L, B>
+}
+
+@JvmName("effectM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.effectM(arg1: Function1<A, Kind<Kind<ForEither, L>, B>>):
+  Either<L, A> = arrow.core.Either.monad<L>().run {
+  this@effectM.flatTap(arg1) as arrow.core.Either<L, A>
+}
+
+@JvmName("flatTap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.flatTap(arg1: Function1<A, Kind<Kind<ForEither, L>, B>>):
+  Either<L, A> = arrow.core.Either.monad<L>().run {
+  this@flatTap.flatTap<A, B>(arg1) as arrow.core.Either<L, A>
+}
+
+@JvmName("productL")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.productL(arg1: Kind<Kind<ForEither, L>, B>): Either<L, A> =
+  arrow.core.Either.monad<L>().run {
+    this@productL.productL<A, B>(arg1) as arrow.core.Either<L, A>
+  }
+
+@JvmName("forEffect")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.forEffect(arg1: Kind<Kind<ForEither, L>, B>): Either<L, A> =
+  arrow.core.Either.monad<L>().run {
+    this@forEffect.productL(arg1) as arrow.core.Either<L, A>
+  }
+
+@JvmName("productLEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.productLEval(arg1: Eval<Kind<Kind<ForEither, L>, B>>):
+  Either<L, A> = arrow.core.Either.monad<L>().run {
+  this@productLEval.productLEval<A, B>(arg1) as arrow.core.Either<L, A>
+}
+
+@JvmName("forEffectEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.forEffectEval(arg1: Eval<Kind<Kind<ForEither, L>, B>>):
+  Either<L, A> = arrow.core.Either.monad<L>().run {
+  this@forEffectEval.productLEval(arg1) as arrow.core.Either<L, A>
+}
+
+@JvmName("mproduct")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.mproduct(arg1: Function1<A, Kind<Kind<ForEither, L>, B>>):
+  Either<L, Tuple2<A, B>> = arrow.core.Either.monad<L>().run {
+  this@mproduct.mproduct<A, B>(arg1) as arrow.core.Either<L, arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("ifM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, B> Kind<Kind<ForEither, L>, Boolean>.ifM(
+  arg1: Function0<Kind<Kind<ForEither, L>, B>>,
+  arg2: Function0<Kind<Kind<ForEither, L>, B>>
+): Either<L, B> = arrow.core.Either.monad<L>().run {
+  this@ifM.ifM<B>(arg1, arg2) as arrow.core.Either<L, B>
+}
+
+@JvmName("selectM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, Either<A, B>>.selectM(
+  arg1: Kind<Kind<ForEither, L>,
+    Function1<A, B>>
+): Either<L, B> = arrow.core.Either.monad<L>().run {
+  this@selectM.selectM<A, B>(arg1) as arrow.core.Either<L, B>
+}
+
+@JvmName("select")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, Either<A, B>>.select(
+  arg1: Kind<Kind<ForEither, L>,
+    Function1<A, B>>
+): Either<L, B> = arrow.core.Either.monad<L>().run {
+  this@select.select<A, B>(arg1) as arrow.core.Either<L, B>
+}
+
+/**
+ *  ank_macro_hierarchy(arrow.typeclasses.Monad)
+ *
+ *  [Monad] abstract over the ability to declare sequential computations that are dependent in the order or
+ *  the results of previous computations.
+ *
+ *  Given a type constructor [F] with a value of [A] we can compose multiple operations of type
+ *  `Kind<F, ?>` where `?` denotes a value being transformed.
+ *
+ *  This is true for all type constructors that can support the [Monad] type class including and not limited to
+ *  [IO], [ObservableK], [Option], [Either], [List] ...
+ *
+ *  [The Monad Tutorial](https://arrow-kt.io/docs/patterns/monads/)
+ */
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+inline fun <L> Companion.monad(): EitherMonad<L> = monad_singleton as
+  arrow.core.extensions.EitherMonad<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/monadError/EitherMonadError.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/monadError/EitherMonadError.kt
@@ -2,9 +2,13 @@ package arrow.core.extensions.either.monadError
 
 import arrow.Kind
 import arrow.core.Either
+import arrow.core.ensure as _ensure
+import arrow.core.redeemWith as _redeemWith
+import arrow.core.flatten as _flatten
 import arrow.core.Either.Companion
 import arrow.core.ForEither
 import arrow.core.extensions.EitherMonadError
+import arrow.core.fix
 import kotlin.Any
 import kotlin.Boolean
 import kotlin.Function0
@@ -26,10 +30,10 @@ internal val monadError_singleton: EitherMonadError<Any?> = object : EitherMonad
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("ensure(arg1, arg2)", "arrow.core.ensure"))
 fun <L, A> Kind<Kind<ForEither, L>, A>.ensure(arg1: Function0<L>, arg2: Function1<A, Boolean>):
-  Either<L, A> = arrow.core.Either.monadError<L>().run {
-  this@ensure.ensure<A>(arg1, arg2) as arrow.core.Either<L, A>
-}
+  Either<L, A> =
+  fix()._ensure(arg1, arg2)
 
 @JvmName("redeemWith")
 @Suppress(
@@ -38,14 +42,13 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.ensure(arg1: Function0<L>, arg2: Function
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("redeemWith(arg1, arg2)", "arrow.core.redeemWith"))
 fun <L, A, B> Kind<Kind<ForEither, L>, A>.redeemWith(
   arg1: Function1<L, Kind<Kind<ForEither, L>,
     B>>,
   arg2: Function1<A, Kind<Kind<ForEither, L>, B>>
 ): Either<L, B> =
-  arrow.core.Either.monadError<L>().run {
-    this@redeemWith.redeemWith<A, B>(arg1, arg2) as arrow.core.Either<L, B>
-  }
+  fix()._redeemWith({ arg1(it).fix() }, { arg2(it).fix() })
 
 @JvmName("rethrow")
 @Suppress(
@@ -54,14 +57,14 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.redeemWith(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("flatten()", "arrow.core.flatten"))
 fun <L, A> Kind<Kind<ForEither, L>, Either<L, A>>.rethrow(): Either<L, A> =
-  arrow.core.Either.monadError<L>().run {
-    this@rethrow.rethrow<A>() as arrow.core.Either<L, A>
-  }
+  fix()._flatten()
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("MonadError typeclasses is deprecated. Use concrete methods on Either")
 inline fun <L> Companion.monadError(): EitherMonadError<L> = monadError_singleton as
   arrow.core.extensions.EitherMonadError<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/monadError/EitherMonadError.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/monadError/EitherMonadError.kt
@@ -1,0 +1,67 @@
+package arrow.core.extensions.either.monadError
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.Either.Companion
+import arrow.core.ForEither
+import arrow.core.extensions.EitherMonadError
+import kotlin.Any
+import kotlin.Boolean
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadError_singleton: EitherMonadError<Any?> = object : EitherMonadError<Any?> {}
+
+@JvmName("ensure")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.ensure(arg1: Function0<L>, arg2: Function1<A, Boolean>):
+  Either<L, A> = arrow.core.Either.monadError<L>().run {
+  this@ensure.ensure<A>(arg1, arg2) as arrow.core.Either<L, A>
+}
+
+@JvmName("redeemWith")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.redeemWith(
+  arg1: Function1<L, Kind<Kind<ForEither, L>,
+    B>>,
+  arg2: Function1<A, Kind<Kind<ForEither, L>, B>>
+): Either<L, B> =
+  arrow.core.Either.monadError<L>().run {
+    this@redeemWith.redeemWith<A, B>(arg1, arg2) as arrow.core.Either<L, B>
+  }
+
+@JvmName("rethrow")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, Either<L, A>>.rethrow(): Either<L, A> =
+  arrow.core.Either.monadError<L>().run {
+    this@rethrow.rethrow<A>() as arrow.core.Either<L, A>
+  }
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+inline fun <L> Companion.monadError(): EitherMonadError<L> = monadError_singleton as
+  arrow.core.extensions.EitherMonadError<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/monoid/EitherMonoid.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/monoid/EitherMonoid.kt
@@ -1,0 +1,48 @@
+package arrow.core.extensions.either.monoid
+
+import arrow.core.Either
+import arrow.core.Either.Companion
+import arrow.core.extensions.EitherMonoid
+import arrow.typeclasses.Monoid
+import kotlin.Suppress
+import kotlin.collections.Collection
+import kotlin.collections.List
+import kotlin.jvm.JvmName
+
+@JvmName("combineAll")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, R> Collection<Either<L, R>>.combineAll(MOL: Monoid<L>, MOR: Monoid<R>): Either<L, R> =
+  arrow.core.Either.monoid<L, R>(MOL, MOR).run {
+    this@combineAll.combineAll() as arrow.core.Either<L, R>
+  }
+
+@JvmName("combineAll")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, R> combineAll(
+  MOL: Monoid<L>,
+  MOR: Monoid<R>,
+  arg0: List<Either<L, R>>
+): Either<L, R> = arrow.core.Either
+  .monoid<L, R>(MOL, MOR)
+  .combineAll(arg0) as arrow.core.Either<L, R>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+inline fun <L, R> Companion.monoid(MOL: Monoid<L>, MOR: Monoid<R>): EitherMonoid<L, R> = object :
+  arrow.core.extensions.EitherMonoid<L, R> {
+  override fun MOL(): arrow.typeclasses.Monoid<L> = MOL
+
+  override fun MOR(): arrow.typeclasses.Monoid<R> = MOR
+}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/monoid/EitherMonoid.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/monoid/EitherMonoid.kt
@@ -16,6 +16,7 @@ import kotlin.jvm.JvmName
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("combineAll(MOL, MOR)", "arrow.core.combineAll"))
 fun <L, R> Collection<Either<L, R>>.combineAll(MOL: Monoid<L>, MOR: Monoid<R>): Either<L, R> =
   arrow.core.Either.monoid<L, R>(MOL, MOR).run {
     this@combineAll.combineAll() as arrow.core.Either<L, R>
@@ -28,6 +29,7 @@ fun <L, R> Collection<Either<L, R>>.combineAll(MOL: Monoid<L>, MOR: Monoid<R>): 
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg0.combineAll(MOL, MOR)", "arrow.core.combineAll"))
 fun <L, R> combineAll(
   MOL: Monoid<L>,
   MOR: Monoid<R>,
@@ -40,6 +42,7 @@ fun <L, R> combineAll(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.monoid(MOL, MOR)", "arrow.core.monoid"))
 inline fun <L, R> Companion.monoid(MOL: Monoid<L>, MOR: Monoid<R>): EitherMonoid<L, R> = object :
   arrow.core.extensions.EitherMonoid<L, R> {
   override fun MOL(): arrow.typeclasses.Monoid<L> = MOL

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/order/EitherOrder.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/order/EitherOrder.kt
@@ -1,0 +1,157 @@
+package arrow.core.extensions.either.order
+
+import arrow.core.Either
+import arrow.core.Either.Companion
+import arrow.core.Tuple2
+import arrow.core.extensions.EitherOrder
+import arrow.typeclasses.Order
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+@JvmName("compareTo")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, R> Either<L, R>.compareTo(
+  OL: Order<L>,
+  OR: Order<R>,
+  arg1: Either<L, R>
+): Int = arrow.core.Either.order<L, R>(OL, OR).run {
+  this@compareTo.compareTo(arg1) as kotlin.Int
+}
+
+@JvmName("eqv")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, R> Either<L, R>.eqv(
+  OL: Order<L>,
+  OR: Order<R>,
+  arg1: Either<L, R>
+): Boolean = arrow.core.Either.order<L, R>(OL, OR).run {
+  this@eqv.eqv(arg1) as kotlin.Boolean
+}
+
+@JvmName("lt")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, R> Either<L, R>.lt(
+  OL: Order<L>,
+  OR: Order<R>,
+  arg1: Either<L, R>
+): Boolean = arrow.core.Either.order<L, R>(OL, OR).run {
+  this@lt.lt(arg1) as kotlin.Boolean
+}
+
+@JvmName("lte")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, R> Either<L, R>.lte(
+  OL: Order<L>,
+  OR: Order<R>,
+  arg1: Either<L, R>
+): Boolean = arrow.core.Either.order<L, R>(OL, OR).run {
+  this@lte.lte(arg1) as kotlin.Boolean
+}
+
+@JvmName("gt")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, R> Either<L, R>.gt(
+  OL: Order<L>,
+  OR: Order<R>,
+  arg1: Either<L, R>
+): Boolean = arrow.core.Either.order<L, R>(OL, OR).run {
+  this@gt.gt(arg1) as kotlin.Boolean
+}
+
+@JvmName("gte")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, R> Either<L, R>.gte(
+  OL: Order<L>,
+  OR: Order<R>,
+  arg1: Either<L, R>
+): Boolean = arrow.core.Either.order<L, R>(OL, OR).run {
+  this@gte.gte(arg1) as kotlin.Boolean
+}
+
+@JvmName("max")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, R> Either<L, R>.max(
+  OL: Order<L>,
+  OR: Order<R>,
+  arg1: Either<L, R>
+): Either<L, R> = arrow.core.Either.order<L, R>(OL, OR).run {
+  this@max.max(arg1) as arrow.core.Either<L, R>
+}
+
+@JvmName("min")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, R> Either<L, R>.min(
+  OL: Order<L>,
+  OR: Order<R>,
+  arg1: Either<L, R>
+): Either<L, R> = arrow.core.Either.order<L, R>(OL, OR).run {
+  this@min.min(arg1) as arrow.core.Either<L, R>
+}
+
+@JvmName("sort")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, R> Either<L, R>.sort(
+  OL: Order<L>,
+  OR: Order<R>,
+  arg1: Either<L, R>
+): Tuple2<Either<L, R>, Either<L, R>> = arrow.core.Either.order<L, R>(OL, OR).run {
+  this@sort.sort(arg1) as arrow.core.Tuple2<arrow.core.Either<L, R>, arrow.core.Either<L, R>>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+inline fun <L, R> Companion.order(OL: Order<L>, OR: Order<R>): EitherOrder<L, R> = object :
+  arrow.core.extensions.EitherOrder<L, R> {
+  override fun OL(): arrow.typeclasses.Order<L> = OL
+
+  override fun OR(): arrow.typeclasses.Order<R> = OR
+}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/order/EitherOrder.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/order/EitherOrder.kt
@@ -17,6 +17,7 @@ import kotlin.jvm.JvmName
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("compareTo(OL, OR, arg1)", "arrow.core.compareTo"))
 fun <L, R> Either<L, R>.compareTo(
   OL: Order<L>,
   OR: Order<R>,
@@ -32,6 +33,7 @@ fun <L, R> Either<L, R>.compareTo(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("eqv(OL, OR, arg1)", "arrow.core.eqv"))
 fun <L, R> Either<L, R>.eqv(
   OL: Order<L>,
   OR: Order<R>,
@@ -47,6 +49,7 @@ fun <L, R> Either<L, R>.eqv(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("lt(OL, OR, arg1)", "arrow.core.lt"))
 fun <L, R> Either<L, R>.lt(
   OL: Order<L>,
   OR: Order<R>,
@@ -62,6 +65,7 @@ fun <L, R> Either<L, R>.lt(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("lte(OL, OR, arg1)", "arrow.core.lte"))
 fun <L, R> Either<L, R>.lte(
   OL: Order<L>,
   OR: Order<R>,
@@ -77,6 +81,7 @@ fun <L, R> Either<L, R>.lte(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("gt(OL, OR, arg1)", "arrow.core.gt"))
 fun <L, R> Either<L, R>.gt(
   OL: Order<L>,
   OR: Order<R>,
@@ -92,6 +97,7 @@ fun <L, R> Either<L, R>.gt(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("gte(OL, OR, arg1)", "arrow.core.gte"))
 fun <L, R> Either<L, R>.gte(
   OL: Order<L>,
   OR: Order<R>,
@@ -107,6 +113,7 @@ fun <L, R> Either<L, R>.gte(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("max(OL, OR, arg1)", "arrow.core.max"))
 fun <L, R> Either<L, R>.max(
   OL: Order<L>,
   OR: Order<R>,
@@ -122,6 +129,7 @@ fun <L, R> Either<L, R>.max(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("min(OL, OR, arg1)", "arrow.core.min"))
 fun <L, R> Either<L, R>.min(
   OL: Order<L>,
   OR: Order<R>,
@@ -137,6 +145,7 @@ fun <L, R> Either<L, R>.min(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("sort(OL, OR, arg1)", "arrow.core.sort"))
 fun <L, R> Either<L, R>.sort(
   OL: Order<L>,
   OR: Order<R>,
@@ -149,6 +158,7 @@ fun <L, R> Either<L, R>.sort(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.order(OL, OR)", "arrow.core.order"))
 inline fun <L, R> Companion.order(OL: Order<L>, OR: Order<R>): EitherOrder<L, R> = object :
   arrow.core.extensions.EitherOrder<L, R> {
   override fun OL(): arrow.typeclasses.Order<L> = OL

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/semigroup/EitherSemigroup.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/semigroup/EitherSemigroup.kt
@@ -1,0 +1,50 @@
+package arrow.core.extensions.either.semigroup
+
+import arrow.core.Either
+import arrow.core.Either.Companion
+import arrow.core.extensions.EitherSemigroup
+import arrow.typeclasses.Semigroup
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+@JvmName("plus")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, R> Either<L, R>.plus(
+  SGL: Semigroup<L>,
+  SGR: Semigroup<R>,
+  arg1: Either<L, R>
+): Either<L, R> = arrow.core.Either.semigroup<L, R>(SGL, SGR).run {
+  this@plus.plus(arg1) as arrow.core.Either<L, R>
+}
+
+@JvmName("maybeCombine")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, R> Either<L, R>.maybeCombine(
+  SGL: Semigroup<L>,
+  SGR: Semigroup<R>,
+  arg1: Either<L, R>
+): Either<L, R> = arrow.core.Either.semigroup<L, R>(SGL, SGR).run {
+  this@maybeCombine.maybeCombine(arg1) as arrow.core.Either<L, R>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+inline fun <L, R> Companion.semigroup(SGL: Semigroup<L>, SGR: Semigroup<R>): EitherSemigroup<L, R> =
+  object : arrow.core.extensions.EitherSemigroup<L, R> {
+    override fun SGL():
+      arrow.typeclasses.Semigroup<L> = SGL
+
+    override fun SGR(): arrow.typeclasses.Semigroup<R> = SGR
+  }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/semigroup/EitherSemigroup.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/semigroup/EitherSemigroup.kt
@@ -14,6 +14,7 @@ import kotlin.jvm.JvmName
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("combine(SGL, SGR, arg1)", "arrow.core.combine"))
 fun <L, R> Either<L, R>.plus(
   SGL: Semigroup<L>,
   SGR: Semigroup<R>,
@@ -29,6 +30,7 @@ fun <L, R> Either<L, R>.plus(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("maybeCombine(SGL, SGR, arg1)", "arrow.core.combine"))
 fun <L, R> Either<L, R>.maybeCombine(
   SGL: Semigroup<L>,
   SGR: Semigroup<R>,
@@ -41,6 +43,7 @@ fun <L, R> Either<L, R>.maybeCombine(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.semigroup(SGL, SGR)", "arrow.core.semigroup"))
 inline fun <L, R> Companion.semigroup(SGL: Semigroup<L>, SGR: Semigroup<R>): EitherSemigroup<L, R> =
   object : arrow.core.extensions.EitherSemigroup<L, R> {
     override fun SGL():

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/semigroupK/EitherSemigroupK.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/semigroupK/EitherSemigroupK.kt
@@ -24,6 +24,7 @@ internal val semigroupK_singleton: EitherSemigroupK<Any?> = object : EitherSemig
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
 fun <L, A> Kind<Kind<ForEither, L>, A>.combineK(arg1: Kind<Kind<ForEither, L>, A>): Either<L, A> =
   arrow.core.Either.semigroupK<L>().run {
     this@combineK.combineK<A>(arg1) as arrow.core.Either<L, A>
@@ -36,6 +37,7 @@ fun <L, A> Kind<Kind<ForEither, L>, A>.combineK(arg1: Kind<Kind<ForEither, L>, A
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
 fun <L, A> algebra(): Semigroup<Kind<Kind<ForEither, L>, A>> = arrow.core.Either
   .semigroupK<L>()
   .algebra<A>() as arrow.typeclasses.Semigroup<arrow.Kind<arrow.Kind<arrow.core.ForEither, L>, A>>
@@ -44,5 +46,6 @@ fun <L, A> algebra(): Semigroup<Kind<Kind<ForEither, L>, A>> = arrow.core.Either
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
 inline fun <L> Companion.semigroupK(): EitherSemigroupK<L> = semigroupK_singleton as
   arrow.core.extensions.EitherSemigroupK<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/semigroupK/EitherSemigroupK.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/semigroupK/EitherSemigroupK.kt
@@ -1,0 +1,48 @@
+package arrow.core.extensions.either.semigroupK
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.Either.Companion
+import arrow.core.ForEither
+import arrow.core.extensions.EitherSemigroupK
+import arrow.typeclasses.Semigroup
+import kotlin.Any
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val semigroupK_singleton: EitherSemigroupK<Any?> = object : EitherSemigroupK<Any?> {}
+
+@JvmName("combineK")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> Kind<Kind<ForEither, L>, A>.combineK(arg1: Kind<Kind<ForEither, L>, A>): Either<L, A> =
+  arrow.core.Either.semigroupK<L>().run {
+    this@combineK.combineK<A>(arg1) as arrow.core.Either<L, A>
+  }
+
+@JvmName("algebra")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A> algebra(): Semigroup<Kind<Kind<ForEither, L>, A>> = arrow.core.Either
+  .semigroupK<L>()
+  .algebra<A>() as arrow.typeclasses.Semigroup<arrow.Kind<arrow.Kind<arrow.core.ForEither, L>, A>>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+inline fun <L> Companion.semigroupK(): EitherSemigroupK<L> = semigroupK_singleton as
+  arrow.core.extensions.EitherSemigroupK<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/show/EitherShow.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/show/EitherShow.kt
@@ -1,0 +1,17 @@
+package arrow.core.extensions.either.show
+
+import arrow.core.Either.Companion
+import arrow.core.extensions.EitherShow
+import arrow.typeclasses.Show
+import kotlin.Suppress
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+inline fun <L, R> Companion.show(SL: Show<L>, SR: Show<R>): EitherShow<L, R> = object :
+  arrow.core.extensions.EitherShow<L, R> {
+  override fun SL(): arrow.typeclasses.Show<L> = SL
+
+  override fun SR(): arrow.typeclasses.Show<R> = SR
+}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/show/EitherShow.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/show/EitherShow.kt
@@ -9,6 +9,7 @@ import kotlin.Suppress
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.show(HL, HR)", "arrow.core.hash"))
 inline fun <L, R> Companion.show(SL: Show<L>, SR: Show<R>): EitherShow<L, R> = object :
   arrow.core.extensions.EitherShow<L, R> {
   override fun SL(): arrow.typeclasses.Show<L> = SL

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/traverse/EitherTraverse.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/traverse/EitherTraverse.kt
@@ -5,6 +5,7 @@ import arrow.core.Either
 import arrow.core.Either.Companion
 import arrow.core.ForEither
 import arrow.core.extensions.EitherTraverse
+import arrow.core.fix
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Monad
 import kotlin.Any
@@ -26,6 +27,7 @@ internal val traverse_singleton: EitherTraverse<Any?> = object : EitherTraverse<
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated. Replace with traverse or traverseValidated from arrow.core.*")
 fun <L, G, A, B> Kind<Kind<ForEither, L>, A>.traverse(
   arg1: Applicative<G>,
   arg2: Function1<A, Kind<G, B>>
@@ -41,6 +43,7 @@ fun <L, G, A, B> Kind<Kind<ForEither, L>, A>.traverse(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated. Replace with sequence or sequenceValidated from arrow.core.*")
 fun <L, G, A> Kind<Kind<ForEither, L>, Kind<G, A>>.sequence(arg1: Applicative<G>): Kind<G,
   Kind<Kind<ForEither, L>, A>> = arrow.core.Either.traverse<L>().run {
   this@sequence.sequence<G, A>(arg1) as arrow.Kind<G, arrow.Kind<arrow.Kind<arrow.core.ForEither,
@@ -54,10 +57,9 @@ fun <L, G, A> Kind<Kind<ForEither, L>, Kind<G, A>>.sequence(arg1: Applicative<G>
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("map(arg1)"))
 fun <L, A, B> Kind<Kind<ForEither, L>, A>.map(arg1: Function1<A, B>): Either<L, B> =
-  arrow.core.Either.traverse<L>().run {
-    this@map.map<A, B>(arg1) as arrow.core.Either<L, B>
-  }
+  fix().map(arg1)
 
 @JvmName("flatTraverse")
 @Suppress(
@@ -66,6 +68,7 @@ fun <L, A, B> Kind<Kind<ForEither, L>, A>.map(arg1: Function1<A, B>): Either<L, 
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
+@Deprecated("@extension kinded projected functions are deprecated. This signature is not valid for Validated.")
 fun <L, G, A, B> Kind<Kind<ForEither, L>, A>.flatTraverse(
   arg1: Monad<Kind<ForEither, L>>,
   arg2: Applicative<G>,
@@ -79,5 +82,6 @@ fun <L, G, A, B> Kind<Kind<ForEither, L>, A>.flatTraverse(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("Traverse typeclasses is deprecated. Use concrete methods on Validated")
 inline fun <L> Companion.traverse(): EitherTraverse<L> = traverse_singleton as
   arrow.core.extensions.EitherTraverse<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/traverse/EitherTraverse.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/traverse/EitherTraverse.kt
@@ -1,0 +1,83 @@
+package arrow.core.extensions.either.traverse
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.Either.Companion
+import arrow.core.ForEither
+import arrow.core.extensions.EitherTraverse
+import arrow.typeclasses.Applicative
+import arrow.typeclasses.Monad
+import kotlin.Any
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val traverse_singleton: EitherTraverse<Any?> = object : EitherTraverse<Any?> {}
+
+@JvmName("traverse")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, G, A, B> Kind<Kind<ForEither, L>, A>.traverse(
+  arg1: Applicative<G>,
+  arg2: Function1<A, Kind<G, B>>
+): Kind<G, Kind<Kind<ForEither, L>, B>> = arrow.core.Either.traverse<L>().run {
+  this@traverse.traverse<G, A, B>(arg1, arg2) as arrow.Kind<G,
+    arrow.Kind<arrow.Kind<arrow.core.ForEither, L>, B>>
+}
+
+@JvmName("sequence")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, G, A> Kind<Kind<ForEither, L>, Kind<G, A>>.sequence(arg1: Applicative<G>): Kind<G,
+  Kind<Kind<ForEither, L>, A>> = arrow.core.Either.traverse<L>().run {
+  this@sequence.sequence<G, A>(arg1) as arrow.Kind<G, arrow.Kind<arrow.Kind<arrow.core.ForEither,
+    L>, A>>
+}
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, A, B> Kind<Kind<ForEither, L>, A>.map(arg1: Function1<A, B>): Either<L, B> =
+  arrow.core.Either.traverse<L>().run {
+    this@map.map<A, B>(arg1) as arrow.core.Either<L, B>
+  }
+
+@JvmName("flatTraverse")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+fun <L, G, A, B> Kind<Kind<ForEither, L>, A>.flatTraverse(
+  arg1: Monad<Kind<ForEither, L>>,
+  arg2: Applicative<G>,
+  arg3: Function1<A, Kind<G, Kind<Kind<ForEither, L>, B>>>
+): Kind<G, Kind<Kind<ForEither, L>, B>> = arrow.core.Either.traverse<L>().run {
+  this@flatTraverse.flatTraverse<G, A, B>(arg1, arg2, arg3) as arrow.Kind<G,
+    arrow.Kind<arrow.Kind<arrow.core.ForEither, L>, B>>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+inline fun <L> Companion.traverse(): EitherTraverse<L> = traverse_singleton as
+  arrow.core.extensions.EitherTraverse<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/eq/ValidatedEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/eq/ValidatedEq.kt
@@ -29,7 +29,7 @@ fun <L, R> Validated<L, R>.neqv(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("@extension projected functions are deprecated", ReplaceWith("eq(EQL, EQR)", "arrow.core.eq"))
+@Deprecated("@extension projected functions are deprecated", ReplaceWith("Validated.eq(EQL, EQR)", "arrow.core.eq"))
 inline fun <L, R> Companion.eq(EQL: Eq<L>, EQR: Eq<R>): ValidatedEq<L, R> = object :
   arrow.core.extensions.ValidatedEq<L, R> {
   override fun EQL(): arrow.typeclasses.Eq<L> = EQL

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/functor/ValidatedFunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/functor/ValidatedFunctor.kt
@@ -8,7 +8,6 @@ import arrow.core.Validated.Companion
 import arrow.core.extensions.ValidatedFunctor
 import arrow.core.fix
 import arrow.core.widen
-import arrow.core.mapConst as _mapConst
 import kotlin.Any
 import kotlin.Function1
 import kotlin.PublishedApi
@@ -102,9 +101,9 @@ fun <E, A, B> Kind<Kind<ForValidated, E>, A>.mapConst(arg1: B): Validated<E, B> 
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("mapConst(arg1)", "arrow.core.mapConst"))
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("arg1.mapConst(this)", "arrow.core.mapConst"))
 fun <E, A, B> A.mapConst(arg1: Kind<Kind<ForValidated, E>, B>): Validated<E, A> =
-  _mapConst(arg1.fix())
+  arg1.fix().mapConst(this)
 
 @JvmName("tupleLeft")
 @Suppress(


### PR DESCRIPTION
- [x] Eq (EqK, EqK2)
- [x] Order
- [x] Hash
- [x] Show
- [x] Semigroup (SemigroupK)
- [x] Monoid
- [x] Functor    
- [x] Apply
- [x] Applicative
- [x] ApplicativeError
- [x] Monad
- [x] MonadError
- [x] Traverse
- [x] BiTraverse
- [x] Foldable
- [x] BiFoldable
- [x] BiFunctor
- [x] BiCrosswalk

Needs to be merged together with:
 - https://github.com/arrow-kt/arrow-incubator/pull/140
 - https://github.com/arrow-kt/arrow-fx/pull/354