### PR TITLE
Move nullable mapN to Nullable, and deprecate top-level ones

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/Nullable.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Nullable.kt
@@ -1,41 +1,45 @@
 @file:Suppress("NAME_SHADOWING")
+
 package arrow.core
 
-inline fun <A, R> mapN(a: A?, fn: (A) -> R): R? =
-  mapN(a, Unit) { a, _ -> fn(a) }
+object Nullable {
 
-inline fun <A, B, R> mapN(a: A?, b: B?, fn: (A, B) -> R): R? =
-  mapN(a, b, Unit) { a, b, _ -> fn(a, b) }
+  inline fun <A, R> mapN(a: A?, fn: (A) -> R): R? =
+    mapN(a, Unit) { a, _ -> fn(a) }
 
-inline fun <A, B, C, R> mapN(a: A?, b: B?, c: C?, fn: (A, B, C) -> R): R? =
-  mapN(a, b, c, Unit) { a, b, c, _ -> fn(a, b, c) }
+  inline fun <A, B, R> mapN(a: A?, b: B?, fn: (A, B) -> R): R? =
+    mapN(a, b, Unit) { a, b, _ -> fn(a, b) }
 
-inline fun <A, B, C, D, R> mapN(a: A?, b: B?, c: C?, d: D?, fn: (A, B, C, D) -> R): R? =
-  mapN(a, b, c, d, Unit) { a, b, c, d, _ -> fn(a, b, c, d) }
+  inline fun <A, B, C, R> mapN(a: A?, b: B?, c: C?, fn: (A, B, C) -> R): R? =
+    mapN(a, b, c, Unit) { a, b, c, _ -> fn(a, b, c) }
 
-inline fun <A, B, C, D, E, R> mapN(a: A?, b: B?, c: C?, d: D?, e: E?, fn: (A, B, C, D, E) -> R): R? =
-  mapN(a, b, c, d, e, Unit) { a, b, c, d, e, _ -> fn(a, b, c, d, e) }
+  inline fun <A, B, C, D, R> mapN(a: A?, b: B?, c: C?, d: D?, fn: (A, B, C, D) -> R): R? =
+    mapN(a, b, c, d, Unit) { a, b, c, d, _ -> fn(a, b, c, d) }
 
-inline fun <A, B, C, D, E, F, R> mapN(a: A?, b: B?, c: C?, d: D?, e: E?, f: F?, fn: (A, B, C, D, E, F) -> R): R? =
-  mapN(a, b, c, d, e, f, Unit) { a, b, c, d, e, f, _ -> fn(a, b, c, d, e, f) }
+  inline fun <A, B, C, D, E, R> mapN(a: A?, b: B?, c: C?, d: D?, e: E?, fn: (A, B, C, D, E) -> R): R? =
+    mapN(a, b, c, d, e, Unit) { a, b, c, d, e, _ -> fn(a, b, c, d, e) }
 
-inline fun <A, B, C, D, E, F, G, R> mapN(a: A?, b: B?, c: C?, d: D?, e: E?, f: F?, g: G?, fn: (A, B, C, D, E, F, G) -> R): R? =
-  mapN(a, b, c, d, e, f, g, Unit) { a, b, c, d, e, f, g, _ -> fn(a, b, c, d, e, f, g) }
+  inline fun <A, B, C, D, E, F, R> mapN(a: A?, b: B?, c: C?, d: D?, e: E?, f: F?, fn: (A, B, C, D, E, F) -> R): R? =
+    mapN(a, b, c, d, e, f, Unit) { a, b, c, d, e, f, _ -> fn(a, b, c, d, e, f) }
 
-inline fun <A, B, C, D, E, F, G, H, R> mapN(a: A?, b: B?, c: C?, d: D?, e: E?, f: F?, g: G?, h: H?, fn: (A, B, C, D, E, F, G, H) -> R): R? =
-  mapN(a, b, c, d, e, f, g, h, Unit) { a, b, c, d, e, f, g, h, _ -> fn(a, b, c, d, e, f, g, h) }
+  inline fun <A, B, C, D, E, F, G, R> mapN(a: A?, b: B?, c: C?, d: D?, e: E?, f: F?, g: G?, fn: (A, B, C, D, E, F, G) -> R): R? =
+    mapN(a, b, c, d, e, f, g, Unit) { a, b, c, d, e, f, g, _ -> fn(a, b, c, d, e, f, g) }
 
-inline fun <A, B, C, D, E, F, G, H, I, R> mapN(a: A?, b: B?, c: C?, d: D?, e: E?, f: F?, g: G?, h: H?, i: I?, fn: (A, B, C, D, E, F, G, H, I) -> R): R? =
-  a?.let { a ->
-    b?.let { b ->
-      c?.let { c ->
-        d?.let { d ->
-          e?.let { e ->
-            f?.let { f ->
-              g?.let { g ->
-                h?.let { h ->
-                  i?.let { i ->
-                    fn(a, b, c, d, e, f, g, h, i)
+  inline fun <A, B, C, D, E, F, G, H, R> mapN(a: A?, b: B?, c: C?, d: D?, e: E?, f: F?, g: G?, h: H?, fn: (A, B, C, D, E, F, G, H) -> R): R? =
+    mapN(a, b, c, d, e, f, g, h, Unit) { a, b, c, d, e, f, g, h, _ -> fn(a, b, c, d, e, f, g, h) }
+
+  inline fun <A, B, C, D, E, F, G, H, I, R> mapN(a: A?, b: B?, c: C?, d: D?, e: E?, f: F?, g: G?, h: H?, i: I?, fn: (A, B, C, D, E, F, G, H, I) -> R): R? =
+    a?.let { a ->
+      b?.let { b ->
+        c?.let { c ->
+          d?.let { d ->
+            e?.let { e ->
+              f?.let { f ->
+                g?.let { g ->
+                  h?.let { h ->
+                    i?.let { i ->
+                      fn(a, b, c, d, e, f, g, h, i)
+                    }
                   }
                 }
               }
@@ -44,4 +48,40 @@ inline fun <A, B, C, D, E, F, G, H, I, R> mapN(a: A?, b: B?, c: C?, d: D?, e: E?
         }
       }
     }
-  }
+}
+
+@Deprecated("Top-level mapN function for A? conflicts with other types such as List<A> and Map<K, V>", ReplaceWith("Nullable.mapN(a, fn", "arrow.core.mapN"))
+inline fun <A, R> mapN(a: A?, fn: (A) -> R): R? =
+  Nullable.mapN(a, fn)
+
+@Deprecated("Top-level mapN function for A? conflicts with other types such as List<A> and Map<K, V>", ReplaceWith("Nullable.mapN(a, b, fn", "arrow.core.mapN"))
+inline fun <A, B, R> mapN(a: A?, b: B?, fn: (A, B) -> R): R? =
+  Nullable.mapN(a, b, fn)
+
+@Deprecated("Top-level mapN function for A? conflicts with other types such as List<A> and Map<K, V>", ReplaceWith("Nullable.mapN(a, b, c, fn", "arrow.core.mapN"))
+inline fun <A, B, C, R> mapN(a: A?, b: B?, c: C?, fn: (A, B, C) -> R): R? =
+  Nullable.mapN(a, b, c, fn)
+
+@Deprecated("Top-level mapN function for A? conflicts with other types such as List<A> and Map<K, V>", ReplaceWith("Nullable.mapN(a, b, c, d, fn", "arrow.core.mapN"))
+inline fun <A, B, C, D, R> mapN(a: A?, b: B?, c: C?, d: D?, fn: (A, B, C, D) -> R): R? =
+  Nullable.mapN(a, b, c, d, fn)
+
+@Deprecated("Top-level mapN function for A? conflicts with other types such as List<A> and Map<K, V>", ReplaceWith("Nullable.mapN(a, b, c, d, e, fn", "arrow.core.mapN"))
+inline fun <A, B, C, D, E, R> mapN(a: A?, b: B?, c: C?, d: D?, e: E?, fn: (A, B, C, D, E) -> R): R? =
+  Nullable.mapN(a, b, c, d, e, fn)
+
+@Deprecated("Top-level mapN function for A? conflicts with other types such as List<A> and Map<K, V>", ReplaceWith("Nullable.mapN(a, b, c, d, e, f, fn", "arrow.core.mapN"))
+inline fun <A, B, C, D, E, F, R> mapN(a: A?, b: B?, c: C?, d: D?, e: E?, f: F?, fn: (A, B, C, D, E, F) -> R): R? =
+  Nullable.mapN(a, b, c, d, e, f, fn)
+
+@Deprecated("Top-level mapN function for A? conflicts with other types such as List<A> and Map<K, V>", ReplaceWith("Nullable.mapN(a, b, c, d, e, f, g, fn", "arrow.core.mapN"))
+inline fun <A, B, C, D, E, F, G, R> mapN(a: A?, b: B?, c: C?, d: D?, e: E?, f: F?, g: G?, fn: (A, B, C, D, E, F, G) -> R): R? =
+  Nullable.mapN(a, b, c, d, e, f, g, fn)
+
+@Deprecated("Top-level mapN function for A? conflicts with other types such as List<A> and Map<K, V>", ReplaceWith("Nullable.mapN(a, b, c, d, e, f, g, h, fn", "arrow.core.mapN"))
+inline fun <A, B, C, D, E, F, G, H, R> mapN(a: A?, b: B?, c: C?, d: D?, e: E?, f: F?, g: G?, h: H?, fn: (A, B, C, D, E, F, G, H) -> R): R? =
+  Nullable.mapN(a, b, c, d, e, f, g, h, fn)
+
+@Deprecated("Top-level mapN function for A? conflicts with other types such as List<A> and Map<K, V>", ReplaceWith("Nullable.mapN(a, b, c, d, e, f, g, h, i, fn", "arrow.core.mapN"))
+inline fun <A, B, C, D, E, F, G, H, I, R> mapN(a: A?, b: B?, c: C?, d: D?, e: E?, f: F?, g: G?, h: H?, i: I?, fn: (A, B, C, D, E, F, G, H, I) -> R): R? =
+  Nullable.mapN(a, b, c, d, e, f, g, h, i, fn)


### PR DESCRIPTION
Currently we cannot define `mapN` for `List` or `Map` since they don't have `companion object` in the Std, and they conflict with the `A?` nullable version of `mapN`.

To solve this we need to move the top-level `nullable` extension functions to `object Nullable`, this allows us to write extensions for `nullable` in a way they don't pollute the namespace for all other types.

See discussion: https://github.com/arrow-kt/arrow-core/pull/276#discussion_r546416592 for more details.

cc\\ original author @tapegram