### PR TITLE
Adding Iter interface

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -805,7 +805,7 @@ inline fun <A, B> EitherOf<A, B>.fix(): Either<A, B> =
  * ```
  *
  */
-sealed class Either<out A, out B> : EitherOf<A, B> {
+sealed class Either<out A, out B> : EitherOf<A, B>, Iter<B> {
 
   /**
    * Returns `true` if this is a [Right], `false` otherwise.
@@ -1064,6 +1064,8 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
   fun isEmpty(): Boolean = isLeft
 
   fun isNotEmpty(): Boolean = isRight
+
+  override fun iterator(): Iterator<B> = fold({ emptyList<B>().iterator() }, { iterator { yield(it) }})
 
   /**
    * The left side of the disjoint union, as opposed to the [Right] side.

--- a/arrow-core-data/src/main/kotlin/arrow/core/Iter.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Iter.kt
@@ -2,4 +2,6 @@ package arrow.core
 
 fun interface Iter<out A> {
   fun iterator(): Iterator<A>
+
+  fun iterable(): Iterable<A> = Iterable { iterator() }
 }

--- a/arrow-core-data/src/main/kotlin/arrow/core/Iter.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Iter.kt
@@ -1,0 +1,5 @@
+package arrow.core
+
+fun interface Iter<out A> {
+  fun iterator(): Iterator<A>
+}

--- a/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
@@ -368,7 +368,7 @@ import arrow.typeclasses.Show
   ReplaceWith("A?")
 )
 @higherkind
-sealed class Option<out A> : OptionOf<A> {
+sealed class Option<out A> : OptionOf<A>, Iter<A> {
 
   companion object {
 
@@ -552,6 +552,8 @@ sealed class Option<out A> : OptionOf<A> {
       "Some(${SA.run { it.show() }})"
     }
   )
+
+  override fun iterator(): Iterator<A> = fold({ emptyList<A>().iterator() }, { iterator { yield(it) } })
 }
 
 object None : Option<Nothing>() {

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -434,7 +434,7 @@ inline fun <E, A> ValidatedOf<E, A>.fix(): Validated<E, A> =
  *
  * ```
  */
-sealed class Validated<out E, out A> : ValidatedOf<E, A> {
+sealed class Validated<out E, out A> : ValidatedOf<E, A>, Iter<A> {
 
   companion object {
 
@@ -928,6 +928,8 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
     { e -> HL.run { e.hashWithSalt(salt.hashWithSalt(0)) } },
     { a -> HR.run { a.hashWithSalt(salt.hashWithSalt(1)) } }
   )
+
+  override fun iterator(): Iterator<A> = fold({ emptyList<A>().iterator() }, { iterator { yield(it) } })
 
   data class Valid<out A>(val a: A) : Validated<Nothing, A>() {
     override fun toString(): String = show(Show.any(), Show.any())


### PR DESCRIPTION
This pull request adds a new interface called Iter that will allow the data types to implement the foldMap method for Traversal in Arrow Optics easily once the Kind type is removed.

It also provide an implementation of the interface for Either, Option and Validated