### PR TITLE
Deprecate extension methods for NonEmptyList

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
@@ -1,9 +1,17 @@
 package arrow.core
 
 import arrow.Kind
-import arrow.higherkind
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Show
+
+@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
+class ForNonEmptyList private constructor() { companion object }
+typealias NonEmptyListOf<A> = arrow.Kind<ForNonEmptyList, A>
+
+@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
+@Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
+inline fun <A> NonEmptyListOf<A>.fix(): NonEmptyList<A> =
+  this as NonEmptyList<A>
 
 typealias Nel<A> = NonEmptyList<A>
 
@@ -193,7 +201,6 @@ typealias Nel<A> = NonEmptyList<A>
  * ```
  *
  */
-@higherkind
 class NonEmptyList<out A>(
   val head: A,
   val tail: List<A>

--- a/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
@@ -351,7 +351,7 @@ class NonEmptyList<out A>(
     inline fun <B, C, D> mapN(
       b: NonEmptyList<B>,
       c: NonEmptyList<C>,
-      crossinline map: (B, C) -> D
+      map: (B, C) -> D
     ): NonEmptyList<D> =
       mapN(b, c, unit, unit, unit, unit, unit, unit, unit, unit) { b, c, _, _, _, _, _, _, _, _ -> map(b, c) }
 
@@ -359,7 +359,7 @@ class NonEmptyList<out A>(
       b: NonEmptyList<B>,
       c: NonEmptyList<C>,
       d: NonEmptyList<D>,
-      crossinline map: (B, C, D) -> E
+      map: (B, C, D) -> E
     ): NonEmptyList<E> =
       mapN(b, c, d, unit, unit, unit, unit, unit, unit, unit) { b, c, d, _, _, _, _, _, _, _ -> map(b, c, d) }
 
@@ -368,7 +368,7 @@ class NonEmptyList<out A>(
       c: NonEmptyList<C>,
       d: NonEmptyList<D>,
       e: NonEmptyList<E>,
-      crossinline map: (B, C, D, E) -> F
+      map: (B, C, D, E) -> F
     ): NonEmptyList<F> =
       mapN(b, c, d, e, unit, unit, unit, unit, unit, unit) { b, c, d, e, _, _, _, _, _, _ -> map(b, c, d, e) }
 
@@ -378,7 +378,7 @@ class NonEmptyList<out A>(
       d: NonEmptyList<D>,
       e: NonEmptyList<E>,
       f: NonEmptyList<F>,
-      crossinline map: (B, C, D, E, F) -> G
+      map: (B, C, D, E, F) -> G
     ): NonEmptyList<G> =
       mapN(b, c, d, e, f, unit, unit, unit, unit, unit) { b, c, d, e, f, _, _, _, _, _ -> map(b, c, d, e, f) }
 
@@ -389,7 +389,7 @@ class NonEmptyList<out A>(
       e: NonEmptyList<E>,
       f: NonEmptyList<F>,
       g: NonEmptyList<G>,
-      crossinline map: (B, C, D, E, F, G) -> H
+      map: (B, C, D, E, F, G) -> H
     ): NonEmptyList<H> =
       mapN(b, c, d, e, f, g, unit, unit, unit, unit) { b, c, d, e, f, g, _, _, _, _ -> map(b, c, d, e, f, g) }
 
@@ -401,7 +401,7 @@ class NonEmptyList<out A>(
       f: NonEmptyList<F>,
       g: NonEmptyList<G>,
       h: NonEmptyList<H>,
-      crossinline map: (B, C, D, E, F, G, H) -> I
+      map: (B, C, D, E, F, G, H) -> I
     ): NonEmptyList<I> =
       mapN(b, c, d, e, f, g, h, unit, unit, unit) { b, c, d, e, f, g, h, _, _, _ -> map(b, c, d, e, f, g, h) }
 
@@ -428,7 +428,7 @@ class NonEmptyList<out A>(
       h: NonEmptyList<H>,
       i: NonEmptyList<I>,
       j: NonEmptyList<J>,
-      crossinline map: (B, C, D, E, F, G, H, I, J) -> K
+      map: (B, C, D, E, F, G, H, I, J) -> K
     ): NonEmptyList<K> =
       mapN(b, c, d, e, f, g, h, i, j, unit) { b, c, d, e, f, g, h, i, j, _ -> map(b, c, d, e, f, g, h, i, j) }
 
@@ -443,19 +443,22 @@ class NonEmptyList<out A>(
       i: NonEmptyList<I>,
       j: NonEmptyList<J>,
       k: NonEmptyList<K>,
-      crossinline map: (B, C, D, E, F, G, H, I, J, K) -> L
+      map: (B, C, D, E, F, G, H, I, J, K) -> L
     ): NonEmptyList<L> =
-      b.flatMap { bb ->
-        c.flatMap { cc ->
-          d.flatMap { dd ->
-            e.flatMap { ee ->
-              f.flatMap { ff ->
-                g.flatMap { gg ->
-                  h.flatMap { hh ->
-                    i.flatMap { ii ->
-                      j.flatMap { jj ->
-                        k.map { kk ->
-                          map(bb, cc, dd, ee, ff, gg, hh, ii, jj, kk)
+      NonEmptyList(
+        map(b.head, c.head, d.head, e.head, f.head, g.head, h.head, i.head, j.head, k.head),
+        b.tail.flatMap { bb ->
+          c.tail.flatMap { cc ->
+            d.tail.flatMap { dd ->
+              e.tail.flatMap { ee ->
+                f.tail.flatMap { ff ->
+                  g.tail.flatMap { gg ->
+                    h.tail.flatMap { hh ->
+                      i.tail.flatMap { ii ->
+                        j.tail.flatMap { jj ->
+                          k.tail.map { kk ->
+                            map(bb, cc, dd, ee, ff, gg, hh, ii, jj, kk)
+                          }
                         }
                       }
                     }
@@ -465,7 +468,7 @@ class NonEmptyList<out A>(
             }
           }
         }
-      }
+      )
 
     @Suppress("UNCHECKED_CAST")
     private tailrec fun <A, B> go(

--- a/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
@@ -8,7 +8,6 @@ import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
-import kotlin.Function1
 
 @Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
 class ForNonEmptyList private constructor() { companion object }
@@ -433,7 +432,6 @@ class NonEmptyList<out A>(
           }
         }
       }
-
 
     @Suppress("UNCHECKED_CAST")
     private tailrec fun <A, B> go(

--- a/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
@@ -491,6 +491,56 @@ fun <A, B, C> NonEmptyList<C>.unzipWith(f: (C) -> Tuple2<A, B>): Tuple2<NonEmpty
      { NonEmptyList(nel.head.b, it) })
  }
 
+inline fun <E, A, B> NonEmptyList<A>.traverseEither(f: (A) -> Either<E, B>): Either<E, NonEmptyList<B>> =
+  foldRight(f(head).map { NonEmptyList.just(it) }) { a, acc ->
+    f(a).ap(acc.map { bs -> { b: B -> NonEmptyList(b) + bs } })
+  }
+
+inline fun <E, A, B> NonEmptyList<A>.flatTraverseEither(f: (A) -> Either<E, NonEmptyList<B>>): Either<E, NonEmptyList<B>> =
+  foldRight(f(head)) { a, acc ->
+    f(a).ap(acc.map { bs -> { b: NonEmptyList<B> -> b + bs } })
+  }
+
+inline fun <E, A> NonEmptyList<A>.traverseEither_(f: (A) -> Either<E, *>): Either<E, Unit> {
+  val void = { _: Unit -> { _: Any? -> Unit } }
+  return foldRight<A, Either<E, Unit>>(Unit.right()) { a, acc ->
+    f(a).ap(acc.map(void))
+  }
+}
+
+fun <E, A> NonEmptyList<Either<E, A>>.sequenceEither(): Either<E, NonEmptyList<A>> =
+  traverseEither(::identity)
+
+fun <E, A> NonEmptyList<Either<E, NonEmptyList<A>>>.flatSequenceEither(): Either<E, NonEmptyList<A>> =
+  flatTraverseEither(::identity)
+
+fun <E> NonEmptyList<Either<E, *>>.sequenceEither_(): Either<E, Unit> =
+  traverseEither_(::identity)
+
+inline fun <E, A, B> NonEmptyList<A>.traverseValidated(semigroup: Semigroup<E>, f: (A) -> Validated<E, B>): Validated<E, NonEmptyList<B>> =
+  foldRight(f(head).map { NonEmptyList(it) }) { a, acc ->
+    f(a).ap(semigroup, acc.map { bs -> { b: B -> NonEmptyList(b) + bs } })
+  }
+
+inline fun <E, A, B> NonEmptyList<A>.flatTraverseValidated(semigroup: Semigroup<E>, f: (A) -> Validated<E, NonEmptyList<B>>): Validated<E, NonEmptyList<B>> =
+  foldRight(f(head)) { a, acc ->
+    f(a).ap(semigroup, acc.map { bs -> { b: NonEmptyList<B> -> b + bs } })
+  }
+
+inline fun <E, A> NonEmptyList<A>.traverseValidated_(semigroup: Semigroup<E>, f: (A) -> Validated<E, *>): Validated<E, Unit> =
+  foldRight<A, Validated<E, Unit>>(Unit.valid()) { a, acc ->
+    f(a).ap(semigroup, acc.map { { Unit } })
+  }
+
+fun <E, A> NonEmptyList<Validated<E, A>>.sequenceValidated(semigroup: Semigroup<E>): Validated<E, NonEmptyList<A>> =
+  traverseValidated(semigroup, ::identity)
+
+fun <E, A> NonEmptyList<Validated<E, NonEmptyList<A>>>.flatSequenceValidated(semigroup: Semigroup<E>): Validated<E, NonEmptyList<A>> =
+  flatTraverseValidated(semigroup, ::identity)
+
+fun <E> NonEmptyList<Validated<E, *>>.sequenceValidated_(semigroup: Semigroup<E>): Validated<E, Unit> =
+  traverseValidated_(semigroup, ::identity)
+
 /**
  * Check if [this@lt] is `lower than` [b]
  *

--- a/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
@@ -293,7 +293,7 @@ class NonEmptyList<out A>(
   fun <B> zip(other: NonEmptyList<B>): NonEmptyList<Tuple2<A, B>> =
     NonEmptyList(Tuple2(head, other.head), tail.zip(other.tail).map { Tuple2(it.first, it.second) })
 
-  fun <B, C> zipWith(other: NonEmptyList<B>, f: Function2<A, B, C>): NonEmptyList<C> =
+  fun <B, C> zip(other: NonEmptyList<B>, f: (A, B) -> C): NonEmptyList<C> =
     zip(other).map { f(it.a, it.b) }
 
   companion object {
@@ -434,113 +434,6 @@ class NonEmptyList<out A>(
         }
       }
 
-    fun <B, C> tupledN(
-      b: NonEmptyList<B>,
-      c: NonEmptyList<C>
-    ): NonEmptyList<Tuple2<B, C>> =
-      mapN(b, c) { b, c ->
-        Tuple2(b, c)
-      }
-
-    fun <B, C, D> tupledN(
-      b: NonEmptyList<B>,
-      c: NonEmptyList<C>,
-      d: NonEmptyList<D>
-    ): NonEmptyList<Tuple3<B, C, D>> =
-      mapN(b, c, d) { b, c, d ->
-        Tuple3(b, c, d)
-      }
-
-    fun <B, C, D, E> tupledN(
-      b: NonEmptyList<B>,
-      c: NonEmptyList<C>,
-      d: NonEmptyList<D>,
-      e: NonEmptyList<E>
-    ): NonEmptyList<Tuple4<B, C, D, E>> =
-      mapN(b, c, d, e) { b, c, d, e ->
-        Tuple4(b, c, d, e)
-      }
-
-    fun <B, C, D, E, F> tupledN(
-      b: NonEmptyList<B>,
-      c: NonEmptyList<C>,
-      d: NonEmptyList<D>,
-      e: NonEmptyList<E>,
-      f: NonEmptyList<F>
-    ): NonEmptyList<Tuple5<B, C, D, E, F>> =
-      mapN(b, c, d, e, f) { b, c, d, e, f ->
-        Tuple5(b, c, d, e, f)
-      }
-
-    fun <B, C, D, E, F, G> tupledN(
-      b: NonEmptyList<B>,
-      c: NonEmptyList<C>,
-      d: NonEmptyList<D>,
-      e: NonEmptyList<E>,
-      f: NonEmptyList<F>,
-      g: NonEmptyList<G>
-    ): NonEmptyList<Tuple6<B, C, D, E, F, G>> =
-      mapN(b, c, d, e, f, g) { b, c, d, e, f, g ->
-        Tuple6(b, c, d, e, f, g)
-      }
-
-    fun <B, C, D, E, F, G, H> tupledN(
-      b: NonEmptyList<B>,
-      c: NonEmptyList<C>,
-      d: NonEmptyList<D>,
-      e: NonEmptyList<E>,
-      f: NonEmptyList<F>,
-      g: NonEmptyList<G>,
-      h: NonEmptyList<H>
-    ): NonEmptyList<Tuple7<B, C, D, E, F, G, H>> =
-      mapN(b, c, d, e, f, g, h) { b, c, d, e, f, g, h ->
-        Tuple7(b, c, d, e, f, g, h)
-      }
-
-    fun <B, C, D, E, F, G, H, I> tupledN(
-      b: NonEmptyList<B>,
-      c: NonEmptyList<C>,
-      d: NonEmptyList<D>,
-      e: NonEmptyList<E>,
-      f: NonEmptyList<F>,
-      g: NonEmptyList<G>,
-      h: NonEmptyList<H>,
-      i: NonEmptyList<I>
-    ): NonEmptyList<Tuple8<B, C, D, E, F, G, H, I>> =
-      mapN(b, c, d, e, f, g, h, i) { b, c, d, e, f, g, h, i ->
-        Tuple8(b, c, d, e, f, g, h, i)
-      }
-
-    fun <B, C, D, E, F, G, H, I, J> tupledN(
-      b: NonEmptyList<B>,
-      c: NonEmptyList<C>,
-      d: NonEmptyList<D>,
-      e: NonEmptyList<E>,
-      f: NonEmptyList<F>,
-      g: NonEmptyList<G>,
-      h: NonEmptyList<H>,
-      i: NonEmptyList<I>,
-      j: NonEmptyList<J>
-    ): NonEmptyList<Tuple9<B, C, D, E, F, G, H, I, J>> =
-      mapN(b, c, d, e, f, g, h, i, j) { b, c, d, e, f, g, h, i, j ->
-        Tuple9(b, c, d, e, f, g, h, i, j)
-      }
-
-    fun <B, C, D, E, F, G, H, I, J, K> tupledN(
-      b: NonEmptyList<B>,
-      c: NonEmptyList<C>,
-      d: NonEmptyList<D>,
-      e: NonEmptyList<E>,
-      f: NonEmptyList<F>,
-      g: NonEmptyList<G>,
-      h: NonEmptyList<H>,
-      i: NonEmptyList<I>,
-      j: NonEmptyList<J>,
-      k: NonEmptyList<K>
-    ): NonEmptyList<Tuple10<B, C, D, E, F, G, H, I, J, K>> =
-      mapN(b, c, d, e, f, g, h, i, j, k) { b, c, d, e, f, g, h, i, j, k ->
-        Tuple10(b, c, d, e, f, g, h, i, j, k)
-      }
 
     @Suppress("UNCHECKED_CAST")
     private tailrec fun <A, B> go(
@@ -593,7 +486,7 @@ fun <A, B> NonEmptyList<Either<A, B>>.selectM(f: NonEmptyList<(A) -> B>): NonEmp
 fun <A, B> NonEmptyList<Tuple2<A, B>>.unzip(): Tuple2<NonEmptyList<A>, NonEmptyList<B>> =
   this.unzipWith(::identity)
 
-fun <A, B, C> NonEmptyList<C>.unzipWith(f: Function1<C, Tuple2<A, B>>): Tuple2<NonEmptyList<A>, NonEmptyList<B>> =
+fun <A, B, C> NonEmptyList<C>.unzipWith(f: (C) -> Tuple2<A, B>): Tuple2<NonEmptyList<A>, NonEmptyList<B>> =
  this.map(f).let { nel ->
    nel.tail.unzip().bimap(
      { NonEmptyList(nel.head.a, it) },

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/listk/show/ListKShow.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/listk/show/ListKShow.kt
@@ -25,6 +25,6 @@ fun <A> Kind<ForListK, A>.show(SA: Show<A>): String = arrow.core.ListK.show<A>(S
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("@extension projected functions are deprecated", ReplaceWith("Show.list(arg1)", "arrow.core.list", "arrow.core.Show"))
+@Deprecated("@extension projected functions are deprecated", ReplaceWith("Show.list(SA)", "arrow.core.list", "arrow.core.Show"))
 inline fun <A> Companion.show(SA: Show<A>): ListKShow<A> = object :
     arrow.core.extensions.ListKShow<A> { override fun SA(): arrow.typeclasses.Show<A> = SA }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist.kt
@@ -20,7 +20,6 @@ import arrow.core.k
 import arrow.core.leftIor
 import arrow.core.rightIor
 import arrow.core.toT
-import arrow.extension
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Apply
 import arrow.typeclasses.Bimonad
@@ -43,12 +42,10 @@ import arrow.typeclasses.Unzip
 import arrow.typeclasses.Zip
 import arrow.core.combineK as nelCombineK
 
-@extension
 interface NonEmptyListSemigroup<A> : Semigroup<NonEmptyList<A>> {
   override fun NonEmptyList<A>.combine(b: NonEmptyList<A>): NonEmptyList<A> = this + b
 }
 
-@extension
 interface NonEmptyListEq<A> : Eq<NonEmptyList<A>> {
 
   fun EQ(): Eq<A>
@@ -59,19 +56,16 @@ interface NonEmptyListEq<A> : Eq<NonEmptyList<A>> {
     }
 }
 
-@extension
 interface NonEmptyListShow<A> : Show<NonEmptyList<A>> {
   fun SA(): Show<A>
   override fun NonEmptyList<A>.show(): String = show(SA())
 }
 
-@extension
 interface NonEmptyListFunctor : Functor<ForNonEmptyList> {
   override fun <A, B> NonEmptyListOf<A>.map(f: (A) -> B): NonEmptyList<B> =
     fix().map(f)
 }
 
-@extension
 interface NonEmptyListApply : Apply<ForNonEmptyList> {
   override fun <A, B> NonEmptyListOf<A>.ap(ff: NonEmptyListOf<(A) -> B>): NonEmptyList<B> =
     fix().ap(ff)
@@ -80,7 +74,6 @@ interface NonEmptyListApply : Apply<ForNonEmptyList> {
     fix().map(f)
 }
 
-@extension
 interface NonEmptyListApplicative : Applicative<ForNonEmptyList> {
   override fun <A, B> NonEmptyListOf<A>.ap(ff: NonEmptyListOf<(A) -> B>): NonEmptyList<B> =
     fix().ap(ff)
@@ -92,7 +85,6 @@ interface NonEmptyListApplicative : Applicative<ForNonEmptyList> {
     NonEmptyList.just(a)
 }
 
-@extension
 interface NonEmptyListMonad : Monad<ForNonEmptyList> {
   override fun <A, B> NonEmptyListOf<A>.ap(ff: NonEmptyListOf<(A) -> B>): NonEmptyList<B> =
     fix().ap(ff)
@@ -110,7 +102,6 @@ interface NonEmptyListMonad : Monad<ForNonEmptyList> {
     NonEmptyList.just(a)
 }
 
-@extension
 interface NonEmptyListComonad : Comonad<ForNonEmptyList> {
   override fun <A, B> NonEmptyListOf<A>.coflatMap(f: (NonEmptyListOf<A>) -> B): NonEmptyList<B> =
     fix().coflatMap(f)
@@ -122,7 +113,6 @@ interface NonEmptyListComonad : Comonad<ForNonEmptyList> {
     fix().map(f)
 }
 
-@extension
 interface NonEmptyListBimonad : Bimonad<ForNonEmptyList> {
   override fun <A, B> NonEmptyListOf<A>.ap(ff: NonEmptyListOf<(A) -> B>): NonEmptyList<B> =
     fix().ap(ff)
@@ -146,7 +136,6 @@ interface NonEmptyListBimonad : Bimonad<ForNonEmptyList> {
     fix().extract()
 }
 
-@extension
 interface NonEmptyListFoldable : Foldable<ForNonEmptyList> {
   override fun <A, B> NonEmptyListOf<A>.foldLeft(b: B, f: (B, A) -> B): B =
     fix().foldLeft(b, f)
@@ -158,7 +147,6 @@ interface NonEmptyListFoldable : Foldable<ForNonEmptyList> {
     fix().isEmpty()
 }
 
-@extension
 interface NonEmptyListTraverse : Traverse<ForNonEmptyList> {
   override fun <A, B> NonEmptyListOf<A>.map(f: (A) -> B): NonEmptyList<B> =
     fix().map(f)
@@ -176,13 +164,11 @@ interface NonEmptyListTraverse : Traverse<ForNonEmptyList> {
     fix().isEmpty()
 }
 
-@extension
 interface NonEmptyListSemigroupK : SemigroupK<ForNonEmptyList> {
   override fun <A> NonEmptyListOf<A>.combineK(y: NonEmptyListOf<A>): NonEmptyList<A> =
     fix().nelCombineK(y)
 }
 
-@extension
 interface NonEmptyListHash<A> : Hash<NonEmptyList<A>> {
   fun HA(): Hash<A>
 
@@ -190,7 +176,6 @@ interface NonEmptyListHash<A> : Hash<NonEmptyList<A>> {
     HA().run { head.hashWithSalt(ListK.hash(HA()).run { tail.k().hashWithSalt(salt) }) }
 }
 
-@extension
 interface NonEmptyListOrder<A> : Order<NonEmptyList<A>> {
   fun OA(): Order<A>
   override fun NonEmptyList<A>.compare(b: NonEmptyList<A>): Ordering =
@@ -205,7 +190,6 @@ fun <F, A> Reducible<F>.toNonEmptyList(fa: Kind<F, A>): NonEmptyList<A> =
 fun <A> NonEmptyList.Companion.fx(c: suspend MonadSyntax<ForNonEmptyList>.() -> A): NonEmptyList<A> =
   NonEmptyList.monad().fx.monad(c).fix()
 
-@extension
 interface NonEmptyListEqK : EqK<ForNonEmptyList> {
   override fun <A> Kind<ForNonEmptyList, A>.eqK(other: Kind<ForNonEmptyList, A>, EQ: Eq<A>) =
     (this.fix() to other.fix()).let {
@@ -213,7 +197,6 @@ interface NonEmptyListEqK : EqK<ForNonEmptyList> {
     }
 }
 
-@extension
 interface NonEmptyListSemialign : Semialign<ForNonEmptyList>, NonEmptyListFunctor {
   override fun <A, B> align(
     a: Kind<ForNonEmptyList, A>,
@@ -228,7 +211,6 @@ interface NonEmptyListSemialign : Semialign<ForNonEmptyList>, NonEmptyListFuncto
   }
 }
 
-@extension
 interface NonEmptyListZip : Zip<ForNonEmptyList>, NonEmptyListSemialign {
   override fun <A, B> Kind<ForNonEmptyList, A>.zip(other: Kind<ForNonEmptyList, B>): Kind<ForNonEmptyList, Tuple2<A, B>> =
     (this.fix() to other.fix()).let { nel ->
@@ -236,7 +218,6 @@ interface NonEmptyListZip : Zip<ForNonEmptyList>, NonEmptyListSemialign {
     }
 }
 
-@extension
 interface NonEmptyListUnzip : Unzip<ForNonEmptyList>, NonEmptyListZip {
   override fun <A, B> Kind<ForNonEmptyList, Tuple2<A, B>>.unzip(): Tuple2<Kind<ForNonEmptyList, A>, Kind<ForNonEmptyList, B>> =
     this.fix().all.let { list ->

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/applicative/NonEmptyListApplicative.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/applicative/NonEmptyListApplicative.kt
@@ -33,7 +33,7 @@ internal val applicative_singleton: NonEmptyListApplicative = object :
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
     "NonEmptyList.just(this)",
-    "arrow.core.NonEmptyList"
+    "arrow.core.NonEmptyList", "arrow.core.just"
   ),
   DeprecationLevel.WARNING
 )
@@ -52,7 +52,7 @@ fun <A> A.just(): NonEmptyList<A> = arrow.core.NonEmptyList.applicative().run {
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
     "NonEmptyList.just(Unit)",
-    "arrow.core.NonEmptyList"
+    "arrow.core.NonEmptyList", "arrow.core.just"
   ),
   DeprecationLevel.WARNING
 )

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/applicative/NonEmptyListApplicative.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/applicative/NonEmptyListApplicative.kt
@@ -69,7 +69,7 @@ fun unit(): NonEmptyList<Unit> = arrow.core.NonEmptyList
 )
 @Deprecated(
   "@extension kinded projected functions are deprecated",
-  ReplaceWith("this.fix().map<B>(arg1)",
+  ReplaceWith("fix().map<B>(arg1)",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -89,7 +89,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.map(arg1: Function1<A, B>): NonEmptyList<B> 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().replicate<A>(arg1)",
+    "fix().replicate<A>(arg1)",
     "arrow.core.fix", "arrow.core.replicate"
   ),
   DeprecationLevel.WARNING
@@ -109,7 +109,7 @@ fun <A> Kind<ForNonEmptyList, A>.replicate(arg1: Int): NonEmptyList<List<A>> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().replicate<A>(arg1, arg2)",
+    "fix().replicate<A>(arg1, arg2)",
     "arrow.core.fix", "arrow.core.replicate"
   )
 )

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/applicative/NonEmptyListApplicative.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/applicative/NonEmptyListApplicative.kt
@@ -122,4 +122,7 @@ fun <A> Kind<ForNonEmptyList, A>.replicate(arg1: Int, arg2: Monoid<A>): NonEmpty
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated(
+  "Applicative typeclass is deprecated. Use concrete methods on NonEmptyList",
+  level = DeprecationLevel.WARNING)
 inline fun Companion.applicative(): NonEmptyListApplicative = applicative_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/applicative/NonEmptyListApplicative.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/applicative/NonEmptyListApplicative.kt
@@ -32,8 +32,8 @@ internal val applicative_singleton: NonEmptyListApplicative = object :
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "just()",
-  "arrow.core.just"
+    "NonEmptyList.just(this)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -51,8 +51,8 @@ fun <A> A.just(): NonEmptyList<A> = arrow.core.NonEmptyList.applicative().run {
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "unit()",
-  "arrow.core.NonEmptyList.unit"
+    "NonEmptyList.just(Unit)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -69,9 +69,8 @@ fun unit(): NonEmptyList<Unit> = arrow.core.NonEmptyList
 )
 @Deprecated(
   "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "map(arg1)",
-  "arrow.core.map"
+  ReplaceWith("this.fix().map<B>(arg1)",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -90,8 +89,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.map(arg1: Function1<A, B>): NonEmptyList<B> 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "replicate(arg1)",
-  "arrow.core.replicate"
+    "this.fix().replicate<A>(arg1)",
+    "arrow.core.fix", "arrow.core.replicate"
   ),
   DeprecationLevel.WARNING
 )
@@ -110,10 +109,9 @@ fun <A> Kind<ForNonEmptyList, A>.replicate(arg1: Int): NonEmptyList<List<A>> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "replicate(arg1, arg2)",
-  "arrow.core.replicate"
-  ),
-  DeprecationLevel.WARNING
+    "this.fix().replicate<A>(arg1, arg2)",
+    "arrow.core.fix", "arrow.core.replicate"
+  )
 )
 fun <A> Kind<ForNonEmptyList, A>.replicate(arg1: Int, arg2: Monoid<A>): NonEmptyList<A> =
     arrow.core.NonEmptyList.applicative().run {

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/apply/NonEmptyListApply.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/apply/NonEmptyListApply.kt
@@ -15,7 +15,6 @@ import arrow.core.Tuple7
 import arrow.core.Tuple8
 import arrow.core.Tuple9
 import arrow.core.extensions.NonEmptyListApply
-import kotlin.Deprecated
 import kotlin.Function1
 import kotlin.PublishedApi
 import kotlin.Suppress
@@ -38,8 +37,8 @@ internal val apply_singleton: NonEmptyListApply = object : arrow.core.extensions
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "ap(arg1)",
-  "arrow.core.ap"
+    "this.fix().ap<B>(arg1)",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -58,8 +57,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.ap(arg1: Kind<ForNonEmptyList, Function1<A, 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "apEval(arg1)",
-  "arrow.core.apEval"
+    "arg1.map<NonEmptyList<B>> { this.ap<A, B>(it.fix<(A) -> B>()) }",
+    "arrow.core.fix", "arrow.core.k"
   ),
   DeprecationLevel.WARNING
 )
@@ -78,8 +77,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.apEval(arg1: Eval<Kind<ForNonEmptyList, Func
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map2Eval(arg1, arg2)",
-  "arrow.core.map2Eval"
+    "this.apEval(arg1.map<NonEmptyList<(A) -> B>> { it.fix().map { b -> { a: A -> arg2(Tuple2(a, b)) } } })",
+    "arrow.core.map2Eval"
   ),
   DeprecationLevel.WARNING
 )
@@ -89,31 +88,8 @@ fun <A, B, Z> Kind<ForNonEmptyList, A>.map2Eval(
 ): Eval<Kind<ForNonEmptyList, Z>> =
   arrow.core.NonEmptyList.apply().run {
     this@map2Eval.map2Eval<A, B, Z>(arg1, arg2) as
-    arrow.core.Eval<arrow.Kind<arrow.core.ForNonEmptyList, Z>>
-}
-
-@JvmName("map")
-@Suppress(
-  "UNCHECKED_CAST",
-  "USELESS_CAST",
-  "EXTENSION_SHADOWED_BY_MEMBER",
-  "UNUSED_PARAMETER"
-)
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "map(arg0, arg1, arg2)",
-  "arrow.core.NonEmptyList.map"
-  ),
-  DeprecationLevel.WARNING
-)
-fun <A, B, Z> map(
-  arg0: Kind<ForNonEmptyList, A>,
-  arg1: Kind<ForNonEmptyList, B>,
-  arg2: Function1<Tuple2<A, B>, Z>
-): NonEmptyList<Z> = arrow.core.NonEmptyList
-   .apply()
-   .map<A, B, Z>(arg0, arg1, arg2) as arrow.core.NonEmptyList<Z>
+      arrow.core.Eval<arrow.Kind<arrow.core.ForNonEmptyList, Z>>
+  }
 
 @JvmName("mapN")
 @Suppress(
@@ -125,55 +101,8 @@ fun <A, B, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2)",
-  "arrow.core.NonEmptyList.mapN"
-  ),
-  DeprecationLevel.WARNING
-)
-fun <A, B, Z> mapN(
-  arg0: Kind<ForNonEmptyList, A>,
-  arg1: Kind<ForNonEmptyList, B>,
-  arg2: Function1<Tuple2<A, B>, Z>
-): NonEmptyList<Z> = arrow.core.NonEmptyList
-   .apply()
-   .mapN<A, B, Z>(arg0, arg1, arg2) as arrow.core.NonEmptyList<Z>
-
-@JvmName("map")
-@Suppress(
-  "UNCHECKED_CAST",
-  "USELESS_CAST",
-  "EXTENSION_SHADOWED_BY_MEMBER",
-  "UNUSED_PARAMETER"
-)
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "map(arg0, arg1, arg2, arg3)",
-  "arrow.core.NonEmptyList.map"
-  ),
-  DeprecationLevel.WARNING
-)
-fun <A, B, C, Z> map(
-  arg0: Kind<ForNonEmptyList, A>,
-  arg1: Kind<ForNonEmptyList, B>,
-  arg2: Kind<ForNonEmptyList, C>,
-  arg3: Function1<Tuple3<A, B, C>, Z>
-): NonEmptyList<Z> = arrow.core.NonEmptyList
-   .apply()
-   .map<A, B, C, Z>(arg0, arg1, arg2, arg3) as arrow.core.NonEmptyList<Z>
-
-@JvmName("mapN")
-@Suppress(
-  "UNCHECKED_CAST",
-  "USELESS_CAST",
-  "EXTENSION_SHADOWED_BY_MEMBER",
-  "UNUSED_PARAMETER"
-)
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "mapN(arg0, arg1, arg2, arg3)",
-  "arrow.core.NonEmptyList.mapN"
+    "NonEmptyList.tupledN(arg0, arg1, arg2).map(arg3)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -196,8 +125,32 @@ fun <A, B, C, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg0, arg1, arg2, arg3, arg4)",
-  "arrow.core.NonEmptyList.map"
+    "NonEmptyList.tupledN(arg0, arg1, arg2).map(arg3)",
+    "arrow.core.NonEmptyList"
+  ),
+  DeprecationLevel.WARNING
+)
+fun <A, B, C, Z> map(
+  arg0: Kind<ForNonEmptyList, A>,
+  arg1: Kind<ForNonEmptyList, B>,
+  arg2: Kind<ForNonEmptyList, C>,
+  arg3: Function1<Tuple3<A, B, C>, Z>
+): NonEmptyList<Z> = arrow.core.NonEmptyList
+  .apply()
+  .map<A, B, C, Z>(arg0, arg1, arg2, arg3) as arrow.core.NonEmptyList<Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(
+  "@extension kinded projected functions are deprecated",
+  ReplaceWith(
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3).map(arg4)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -211,6 +164,29 @@ fun <A, B, C, D, Z> map(
    .apply()
    .map<A, B, C, D, Z>(arg0, arg1, arg2, arg3, arg4) as arrow.core.NonEmptyList<Z>
 
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(
+  "@extension kinded projected functions are deprecated",
+  ReplaceWith(
+    "NonEmptyList.tupledN(arg0, arg1).map(arg2)",
+    "arrow.core.NonEmptyList"
+  ),
+  DeprecationLevel.WARNING
+)
+fun <A, B, Z> map(
+  arg0: Kind<ForNonEmptyList, A>,
+  arg1: Kind<ForNonEmptyList, B>,
+  arg2: Function1<Tuple2<A, B>, Z>
+): NonEmptyList<Z> = arrow.core.NonEmptyList
+  .apply()
+  .map<A, B, Z>(arg0, arg1, arg2) as arrow.core.NonEmptyList<Z>
+
 @JvmName("mapN")
 @Suppress(
   "UNCHECKED_CAST",
@@ -221,8 +197,8 @@ fun <A, B, C, D, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2, arg3, arg4)",
-  "arrow.core.NonEmptyList.mapN"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3).map(arg4)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -246,8 +222,8 @@ fun <A, B, C, D, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg0, arg1, arg2, arg3, arg4, arg5)",
-  "arrow.core.NonEmptyList.map"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4).map(arg5)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -272,8 +248,8 @@ fun <A, B, C, D, E, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2, arg3, arg4, arg5)",
-  "arrow.core.NonEmptyList.mapN"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4).map(arg5)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -298,8 +274,8 @@ fun <A, B, C, D, E, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-  "arrow.core.NonEmptyList.map"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5).map(arg6)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -326,8 +302,8 @@ fun <A, B, C, D, E, FF, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-  "arrow.core.NonEmptyList.mapN"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5).map(arg6)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -354,8 +330,8 @@ fun <A, B, C, D, E, FF, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-  "arrow.core.NonEmptyList.map"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6).map(arg7)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -383,8 +359,8 @@ fun <A, B, C, D, E, FF, G, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-  "arrow.core.NonEmptyList.mapN"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6).map(arg7)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -412,8 +388,8 @@ fun <A, B, C, D, E, FF, G, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-  "arrow.core.NonEmptyList.map"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7).map(arg8)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -442,8 +418,8 @@ fun <A, B, C, D, E, FF, G, H, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-  "arrow.core.NonEmptyList.mapN"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7).map(arg8)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -472,8 +448,8 @@ fun <A, B, C, D, E, FF, G, H, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-  "arrow.core.NonEmptyList.map"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).map(arg9)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -503,8 +479,8 @@ fun <A, B, C, D, E, FF, G, H, I, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-  "arrow.core.NonEmptyList.mapN"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).map(arg9)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -534,8 +510,8 @@ fun <A, B, C, D, E, FF, G, H, I, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)",
-  "arrow.core.NonEmptyList.map"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).map(arg10)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -567,8 +543,8 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)",
-  "arrow.core.NonEmptyList.mapN"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).map(arg10)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -600,8 +576,8 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map2(arg1, arg2)",
-  "arrow.core.map2"
+    "this.flatMap<A> { a -> arg1.map<B> { b -> arg2(Tuple2(a, b)) }}",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -622,8 +598,8 @@ fun <A, B, Z> Kind<ForNonEmptyList, A>.map2(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.ap(arg1.map<(A) -> Tuple2<A, B>> { b -> { a -> Tuple2<A, B>(a, b) } })",
+    "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
 )
@@ -642,8 +618,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.product(arg1: Kind<ForNonEmptyList, B>): Non
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.flatMap<Tuple3<A, B, Z>> { a -> arg1.map<Tuple3<A, B, Z>> { z -> Tuple3<A, B, Z>(a.a, a.b, z) }}",
+    "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
 )
@@ -662,8 +638,8 @@ fun <A, B, Z> Kind<ForNonEmptyList, Tuple2<A, B>>.product(arg1: Kind<ForNonEmpty
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.flatMap<Tuple4<A, B, C, Z>> { a -> arg1.map<Tuple4<A, B, C, Z>> { z -> Tuple4<A, B, C, Z>(a.a, a.b, a.c, z) }}",
+    "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
 )
@@ -682,8 +658,8 @@ fun <A, B, C, Z> Kind<ForNonEmptyList, Tuple3<A, B, C>>.product(arg1: Kind<ForNo
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.flatMap<Tuple5<A, B, C, D, Z>> { a -> arg1.map<Tuple5<A, B, C, D, Z>> { z -> Tuple5<A, B, C, D, Z>(a.a, a.b, a.c, a.d, z) }}",
+    "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
 )
@@ -704,8 +680,8 @@ fun <A, B, C, D, Z> Kind<ForNonEmptyList, Tuple4<A, B, C, D>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.flatMap<Tuple6<A, B, C, D, E, Z>> { a -> arg1.map<Tuple6<A, B, C, D, E, Z>> { z -> Tuple6<A, B, C, D, E, Z>(a.a, a.b, a.c, a.d, a.e, z) }}",
+    "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
 )
@@ -726,8 +702,8 @@ fun <A, B, C, D, E, Z> Kind<ForNonEmptyList, Tuple5<A, B, C, D,
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.flatMap<Tuple7<A, B, C, D, E, FF, Z>> { a -> arg1.map<Tuple7<A, B, C, D, E, FF, Z>> { z -> Tuple7<A, B, C, D, E, FF, Z>(a.a, a.b, a.c, a.d, a.e, a.f, z) }}",
+    "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
 )
@@ -748,8 +724,8 @@ fun <A, B, C, D, E, FF, Z> Kind<ForNonEmptyList, Tuple6<A, B, C, D, E,
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.flatMap<Tuple8<A, B, C, D, E, FF, G, Z>> { a -> arg1.map<Tuple8<A, B, C, D, E, FF, G, Z>> { z -> Tuple8<A, B, C, D, E, FF, G, Z>(a.a, a.b, a.c, a.d, a.e, a.f, a.g, z) }}",
+    "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
 )
@@ -770,8 +746,8 @@ fun <A, B, C, D, E, FF, G, Z> Kind<ForNonEmptyList, Tuple7<A, B, C, D, E, FF,
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.flatMap<Tuple9<A, B, C, D, E, FF, G, H, Z>> { a -> arg1.map<Tuple9<A, B, C, D, E, FF, G, H, Z>> { z -> Tuple9<A, B, C, D, E, FF, G, H, Z>(a.a, a.b, a.c, a.d, a.e, a.f, a.g, a.h, z) }}",
+    "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
 )
@@ -792,8 +768,8 @@ fun <A, B, C, D, E, FF, G, H, Z> Kind<ForNonEmptyList, Tuple8<A, B, C, D, E, FF,
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.flatMap<Tuple10<A, B, C, D, E, FF, G, H, I, Z>> { a -> arg1.map<Tuple10<A, B, C, D, E, FF, G, H, I, Z>> { z -> Tuple10<A, B, C, D, E, FF, G, H, I, Z>(a.a, a.b, a.c, a.d, a.e, a.f, a.g, a.h, a.i, z) }}",
+    "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
 )
@@ -814,8 +790,8 @@ fun <A, B, C, D, E, FF, G, H, I, Z> Kind<ForNonEmptyList, Tuple9<A, B, C, D, E, 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1)",
-  "arrow.core.NonEmptyList.tupled"
+    "NonEmptyList.tupledN(arg0, arg1)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -834,8 +810,8 @@ fun <A, B> tupled(arg0: Kind<ForNonEmptyList, A>, arg1: Kind<ForNonEmptyList, B>
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1)",
-  "arrow.core.NonEmptyList.tupledN"
+    "NonEmptyList.tupledN(arg0, arg1)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -854,8 +830,8 @@ fun <A, B> tupledN(arg0: Kind<ForNonEmptyList, A>, arg1: Kind<ForNonEmptyList, B
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1, arg2)",
-  "arrow.core.NonEmptyList.tupled"
+    "NonEmptyList.tupledN(arg0, arg1, arg2)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -877,8 +853,8 @@ fun <A, B, C> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1, arg2)",
-  "arrow.core.NonEmptyList.tupledN"
+    "NonEmptyList.tupledN(arg0, arg1, arg2)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -900,8 +876,8 @@ fun <A, B, C> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1, arg2, arg3)",
-  "arrow.core.NonEmptyList.tupled"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -925,8 +901,8 @@ fun <A, B, C, D> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1, arg2, arg3)",
-  "arrow.core.NonEmptyList.tupledN"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -950,8 +926,8 @@ fun <A, B, C, D> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1, arg2, arg3, arg4)",
-  "arrow.core.NonEmptyList.tupled"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -976,8 +952,8 @@ fun <A, B, C, D, E> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1, arg2, arg3, arg4)",
-  "arrow.core.NonEmptyList.tupledN"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -1002,8 +978,8 @@ fun <A, B, C, D, E> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1, arg2, arg3, arg4, arg5)",
-  "arrow.core.NonEmptyList.tupled"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -1029,8 +1005,8 @@ fun <A, B, C, D, E, FF> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1, arg2, arg3, arg4, arg5)",
-  "arrow.core.NonEmptyList.tupledN"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -1056,8 +1032,8 @@ fun <A, B, C, D, E, FF> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-  "arrow.core.NonEmptyList.tupled"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -1084,8 +1060,8 @@ fun <A, B, C, D, E, FF, G> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-  "arrow.core.NonEmptyList.tupledN"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -1112,8 +1088,8 @@ fun <A, B, C, D, E, FF, G> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-  "arrow.core.NonEmptyList.tupled"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -1141,8 +1117,8 @@ fun <A, B, C, D, E, FF, G, H> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-  "arrow.core.NonEmptyList.tupledN"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -1170,8 +1146,8 @@ fun <A, B, C, D, E, FF, G, H> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-  "arrow.core.NonEmptyList.tupled"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -1200,8 +1176,8 @@ fun <A, B, C, D, E, FF, G, H, I> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-  "arrow.core.NonEmptyList.tupledN"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -1230,8 +1206,8 @@ fun <A, B, C, D, E, FF, G, H, I> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-  "arrow.core.NonEmptyList.tupled"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -1262,8 +1238,8 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-  "arrow.core.NonEmptyList.tupledN"
+    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -1294,8 +1270,8 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "followedBy(arg1)",
-  "arrow.core.followedBy"
+    "this.flatMap { arg1 }",
+    "arrow.core.flatMap"
   ),
   DeprecationLevel.WARNING
 )
@@ -1314,8 +1290,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.followedBy(arg1: Kind<ForNonEmptyList, B>): 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "apTap(arg1)",
-  "arrow.core.apTap"
+    "NonEmptyList.mapN(this.fix(), arg1.fix()) { left, _ -> left }",
+    "arrow.core.fix", "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -1328,4 +1304,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.apTap(arg1: Kind<ForNonEmptyList, B>): NonEm
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated(
+  "Apply typeclass is deprecated. Use concrete methods on NonEmptyList",
+  level = DeprecationLevel.WARNING)
 inline fun Companion.apply(): NonEmptyListApply = apply_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/apply/NonEmptyListApply.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/apply/NonEmptyListApply.kt
@@ -37,7 +37,7 @@ internal val apply_singleton: NonEmptyListApply = object : arrow.core.extensions
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().ap<B>(arg1)",
+    "fix().ap<B>(arg1)",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -77,7 +77,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.apEval(arg1: Eval<Kind<ForNonEmptyList, Func
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.apEval(arg1.map<NonEmptyList<(A) -> B>> { it.fix().map { b -> { a: A -> arg2(Tuple2(a, b)) } } })",
+    "apEval(arg1.map<NonEmptyList<(A) -> B>> { it.fix().map { b -> { a: A -> arg2(Tuple2(a, b)) } } })",
     "arrow.core.map2Eval"
   ),
   DeprecationLevel.WARNING
@@ -576,7 +576,7 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.flatMap<A> { a -> arg1.map<B> { b -> arg2(Tuple2(a, b)) }}",
+    "flatMap<A> { a -> arg1.map<B> { b -> arg2(Tuple2(a, b)) }}",
     "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
@@ -598,7 +598,7 @@ fun <A, B, Z> Kind<ForNonEmptyList, A>.map2(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.ap(arg1.map<(A) -> Tuple2<A, B>> { b -> { a -> Tuple2<A, B>(a, b) } })",
+    "ap(arg1.map<(A) -> Tuple2<A, B>> { b -> { a -> Tuple2<A, B>(a, b) } })",
     "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
@@ -618,7 +618,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.product(arg1: Kind<ForNonEmptyList, B>): Non
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.flatMap<Tuple3<A, B, Z>> { a -> arg1.map<Tuple3<A, B, Z>> { z -> Tuple3<A, B, Z>(a.a, a.b, z) }}",
+    "flatMap<Tuple3<A, B, Z>> { a -> arg1.map<Tuple3<A, B, Z>> { z -> Tuple3<A, B, Z>(a.a, a.b, z) }}",
     "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
@@ -638,7 +638,7 @@ fun <A, B, Z> Kind<ForNonEmptyList, Tuple2<A, B>>.product(arg1: Kind<ForNonEmpty
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.flatMap<Tuple4<A, B, C, Z>> { a -> arg1.map<Tuple4<A, B, C, Z>> { z -> Tuple4<A, B, C, Z>(a.a, a.b, a.c, z) }}",
+    "flatMap<Tuple4<A, B, C, Z>> { a -> arg1.map<Tuple4<A, B, C, Z>> { z -> Tuple4<A, B, C, Z>(a.a, a.b, a.c, z) }}",
     "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
@@ -658,7 +658,7 @@ fun <A, B, C, Z> Kind<ForNonEmptyList, Tuple3<A, B, C>>.product(arg1: Kind<ForNo
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.flatMap<Tuple5<A, B, C, D, Z>> { a -> arg1.map<Tuple5<A, B, C, D, Z>> { z -> Tuple5<A, B, C, D, Z>(a.a, a.b, a.c, a.d, z) }}",
+    "flatMap<Tuple5<A, B, C, D, Z>> { a -> arg1.map<Tuple5<A, B, C, D, Z>> { z -> Tuple5<A, B, C, D, Z>(a.a, a.b, a.c, a.d, z) }}",
     "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
@@ -680,7 +680,7 @@ fun <A, B, C, D, Z> Kind<ForNonEmptyList, Tuple4<A, B, C, D>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.flatMap<Tuple6<A, B, C, D, E, Z>> { a -> arg1.map<Tuple6<A, B, C, D, E, Z>> { z -> Tuple6<A, B, C, D, E, Z>(a.a, a.b, a.c, a.d, a.e, z) }}",
+    "flatMap<Tuple6<A, B, C, D, E, Z>> { a -> arg1.map<Tuple6<A, B, C, D, E, Z>> { z -> Tuple6<A, B, C, D, E, Z>(a.a, a.b, a.c, a.d, a.e, z) }}",
     "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
@@ -702,7 +702,7 @@ fun <A, B, C, D, E, Z> Kind<ForNonEmptyList, Tuple5<A, B, C, D,
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.flatMap<Tuple7<A, B, C, D, E, FF, Z>> { a -> arg1.map<Tuple7<A, B, C, D, E, FF, Z>> { z -> Tuple7<A, B, C, D, E, FF, Z>(a.a, a.b, a.c, a.d, a.e, a.f, z) }}",
+    "flatMap<Tuple7<A, B, C, D, E, FF, Z>> { a -> arg1.map<Tuple7<A, B, C, D, E, FF, Z>> { z -> Tuple7<A, B, C, D, E, FF, Z>(a.a, a.b, a.c, a.d, a.e, a.f, z) }}",
     "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
@@ -724,7 +724,7 @@ fun <A, B, C, D, E, FF, Z> Kind<ForNonEmptyList, Tuple6<A, B, C, D, E,
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.flatMap<Tuple8<A, B, C, D, E, FF, G, Z>> { a -> arg1.map<Tuple8<A, B, C, D, E, FF, G, Z>> { z -> Tuple8<A, B, C, D, E, FF, G, Z>(a.a, a.b, a.c, a.d, a.e, a.f, a.g, z) }}",
+    "flatMap<Tuple8<A, B, C, D, E, FF, G, Z>> { a -> arg1.map<Tuple8<A, B, C, D, E, FF, G, Z>> { z -> Tuple8<A, B, C, D, E, FF, G, Z>(a.a, a.b, a.c, a.d, a.e, a.f, a.g, z) }}",
     "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
@@ -746,7 +746,7 @@ fun <A, B, C, D, E, FF, G, Z> Kind<ForNonEmptyList, Tuple7<A, B, C, D, E, FF,
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.flatMap<Tuple9<A, B, C, D, E, FF, G, H, Z>> { a -> arg1.map<Tuple9<A, B, C, D, E, FF, G, H, Z>> { z -> Tuple9<A, B, C, D, E, FF, G, H, Z>(a.a, a.b, a.c, a.d, a.e, a.f, a.g, a.h, z) }}",
+    "flatMap<Tuple9<A, B, C, D, E, FF, G, H, Z>> { a -> arg1.map<Tuple9<A, B, C, D, E, FF, G, H, Z>> { z -> Tuple9<A, B, C, D, E, FF, G, H, Z>(a.a, a.b, a.c, a.d, a.e, a.f, a.g, a.h, z) }}",
     "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
@@ -768,7 +768,7 @@ fun <A, B, C, D, E, FF, G, H, Z> Kind<ForNonEmptyList, Tuple8<A, B, C, D, E, FF,
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.flatMap<Tuple10<A, B, C, D, E, FF, G, H, I, Z>> { a -> arg1.map<Tuple10<A, B, C, D, E, FF, G, H, I, Z>> { z -> Tuple10<A, B, C, D, E, FF, G, H, I, Z>(a.a, a.b, a.c, a.d, a.e, a.f, a.g, a.h, a.i, z) }}",
+    "flatMap<Tuple10<A, B, C, D, E, FF, G, H, I, Z>> { a -> arg1.map<Tuple10<A, B, C, D, E, FF, G, H, I, Z>> { z -> Tuple10<A, B, C, D, E, FF, G, H, I, Z>(a.a, a.b, a.c, a.d, a.e, a.f, a.g, a.h, a.i, z) }}",
     "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
@@ -1270,7 +1270,7 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.flatMap { arg1 }",
+    "flatMap { arg1 }",
     "arrow.core.flatMap"
   ),
   DeprecationLevel.WARNING

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/apply/NonEmptyListApply.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/apply/NonEmptyListApply.kt
@@ -125,7 +125,7 @@ fun <A, B, C, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2).map(arg3)",
+    "NonEmptyList.mapN(arg0, arg1, arg2) { a, b, c -> arg3(Tuple3(a, b, c)) }",
     "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/apply/NonEmptyListApply.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/apply/NonEmptyListApply.kt
@@ -91,6 +91,29 @@ fun <A, B, Z> Kind<ForNonEmptyList, A>.map2Eval(
       arrow.core.Eval<arrow.Kind<arrow.core.ForNonEmptyList, Z>>
   }
 
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(
+  "@extension kinded projected functions are deprecated",
+  ReplaceWith(
+  "NonEmptyList.mapN(arg0.fix(), arg1.fix()) { a, b -> arg2(Tuple2(a, b)) }",
+  "arrow.core.NonEmptyList", "arrow.core.fix"
+  ),
+  DeprecationLevel.WARNING
+)
+fun <A, B, Z> map(
+  arg0: Kind<ForNonEmptyList, A>,
+  arg1: Kind<ForNonEmptyList, B>,
+  arg2: Function1<Tuple2<A, B>, Z>
+): NonEmptyList<Z> = arrow.core.NonEmptyList
+   .apply()
+   .map<A, B, Z>(arg0, arg1, arg2) as arrow.core.NonEmptyList<Z>
+
 @JvmName("mapN")
 @Suppress(
   "UNCHECKED_CAST",
@@ -101,8 +124,55 @@ fun <A, B, Z> Kind<ForNonEmptyList, A>.map2Eval(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2).map(arg3)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN(arg0.fix(), arg1.fix()) { a, b -> arg2(Tuple2(a, b)) }",
+    "arrow.core.NonEmptyList", "arrow.core.fix"
+  ),
+  DeprecationLevel.WARNING
+)
+fun <A, B, Z> mapN(
+  arg0: Kind<ForNonEmptyList, A>,
+  arg1: Kind<ForNonEmptyList, B>,
+  arg2: Function1<Tuple2<A, B>, Z>
+): NonEmptyList<Z> = arrow.core.NonEmptyList
+   .apply()
+   .mapN<A, B, Z>(arg0, arg1, arg2) as arrow.core.NonEmptyList<Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(
+  "@extension kinded projected functions are deprecated",
+  ReplaceWith(
+    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix()) { a, b, c -> arg3(Tuple3(a, b, c)) }",
+    "arrow.core.NonEmptyList", "arrow.core.fix"
+  ),
+  DeprecationLevel.WARNING
+)
+fun <A, B, C, Z> map(
+  arg0: Kind<ForNonEmptyList, A>,
+  arg1: Kind<ForNonEmptyList, B>,
+  arg2: Kind<ForNonEmptyList, C>,
+  arg3: Function1<Tuple3<A, B, C>, Z>
+): NonEmptyList<Z> = arrow.core.NonEmptyList
+   .apply()
+   .map<A, B, C, Z>(arg0, arg1, arg2, arg3) as arrow.core.NonEmptyList<Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(
+  "@extension kinded projected functions are deprecated",
+  ReplaceWith(
+    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix()) { a, b, c -> arg3(Tuple3(a, b, c)) }",
+    "arrow.core.NonEmptyList", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -125,32 +195,8 @@ fun <A, B, C, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.mapN(arg0, arg1, arg2) { a, b, c -> arg3(Tuple3(a, b, c)) }",
-    "arrow.core.NonEmptyList"
-  ),
-  DeprecationLevel.WARNING
-)
-fun <A, B, C, Z> map(
-  arg0: Kind<ForNonEmptyList, A>,
-  arg1: Kind<ForNonEmptyList, B>,
-  arg2: Kind<ForNonEmptyList, C>,
-  arg3: Function1<Tuple3<A, B, C>, Z>
-): NonEmptyList<Z> = arrow.core.NonEmptyList
-  .apply()
-  .map<A, B, C, Z>(arg0, arg1, arg2, arg3) as arrow.core.NonEmptyList<Z>
-
-@JvmName("map")
-@Suppress(
-  "UNCHECKED_CAST",
-  "USELESS_CAST",
-  "EXTENSION_SHADOWED_BY_MEMBER",
-  "UNUSED_PARAMETER"
-)
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3).map(arg4)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix()) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }",
+    "arrow.core.NonEmptyList", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -164,29 +210,6 @@ fun <A, B, C, D, Z> map(
    .apply()
    .map<A, B, C, D, Z>(arg0, arg1, arg2, arg3, arg4) as arrow.core.NonEmptyList<Z>
 
-@JvmName("map")
-@Suppress(
-  "UNCHECKED_CAST",
-  "USELESS_CAST",
-  "EXTENSION_SHADOWED_BY_MEMBER",
-  "UNUSED_PARAMETER"
-)
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1).map(arg2)",
-    "arrow.core.NonEmptyList"
-  ),
-  DeprecationLevel.WARNING
-)
-fun <A, B, Z> map(
-  arg0: Kind<ForNonEmptyList, A>,
-  arg1: Kind<ForNonEmptyList, B>,
-  arg2: Function1<Tuple2<A, B>, Z>
-): NonEmptyList<Z> = arrow.core.NonEmptyList
-  .apply()
-  .map<A, B, Z>(arg0, arg1, arg2) as arrow.core.NonEmptyList<Z>
-
 @JvmName("mapN")
 @Suppress(
   "UNCHECKED_CAST",
@@ -197,8 +220,8 @@ fun <A, B, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3).map(arg4)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix()) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }",
+    "arrow.core.NonEmptyList", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -222,8 +245,8 @@ fun <A, B, C, D, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4).map(arg5)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix()) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }",
+    "arrow.core.NonEmptyList", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -248,8 +271,8 @@ fun <A, B, C, D, E, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4).map(arg5)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix()) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }",
+    "arrow.core.NonEmptyList", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -274,8 +297,8 @@ fun <A, B, C, D, E, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5).map(arg6)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix()) { a, b, c, d, e, f -> arg6(Tuple6(a, b, c, d, e, f)) }",
+    "arrow.core.NonEmptyList", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -302,8 +325,8 @@ fun <A, B, C, D, E, FF, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5).map(arg6)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix()) { a, b, c, d, e, f -> arg6(Tuple6(a, b, c, d, e, f)) }",
+    "arrow.core.NonEmptyList", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -330,8 +353,8 @@ fun <A, B, C, D, E, FF, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6).map(arg7)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix()) { a, b, c, d, e, f, g -> arg7(Tuple7(a, b, c, d, e, f, g)) }",
+    "arrow.core.NonEmptyList", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -359,8 +382,8 @@ fun <A, B, C, D, E, FF, G, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6).map(arg7)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix()) { a, b, c, d, e, f, g -> arg7(Tuple7(a, b, c, d, e, f, g)) }",
+    "arrow.core.NonEmptyList", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -388,8 +411,8 @@ fun <A, B, C, D, E, FF, G, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7).map(arg8)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix()) { a, b, c, d, e, f, g, h -> arg8(Tuple8(a, b, c, d, e, f, g, h)) }",
+    "arrow.core.NonEmptyList", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -418,8 +441,8 @@ fun <A, B, C, D, E, FF, G, H, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7).map(arg8)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix()) { a, b, c, d, e, f, g, h -> arg8(Tuple8(a, b, c, d, e, f, g, h)) }",
+    "arrow.core.NonEmptyList", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -448,8 +471,8 @@ fun <A, B, C, D, E, FF, G, H, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).map(arg9)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix()) { a, b, c, d, e, f, g, h, i -> arg9(Tuple9(a, b, c, d, e, f, g, h, i)) }",
+    "arrow.core.NonEmptyList", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -479,8 +502,8 @@ fun <A, B, C, D, E, FF, G, H, I, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).map(arg9)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix()) { a, b, c, d, e, f, g, h, i -> arg9(Tuple9(a, b, c, d, e, f, g, h, i)) }",
+    "arrow.core.NonEmptyList", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -510,8 +533,8 @@ fun <A, B, C, D, E, FF, G, H, I, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).map(arg10)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix(), arg9.fix()) { a, b, c, d, e, f, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, f, g, h, i, j)) }",
+    "arrow.core.NonEmptyList", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -543,8 +566,8 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).map(arg10)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix(), arg9.fix()) { a, b, c, d, e, f, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, f, g, h, i, j)) }",
+    "arrow.core.NonEmptyList", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -790,8 +813,8 @@ fun <A, B, C, D, E, FF, G, H, I, Z> Kind<ForNonEmptyList, Tuple9<A, B, C, D, E, 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN<A, B, Tuple2<A, B>>(arg0.fix(), arg1.fix()) { a, b -> Tuple2(a, b) }",
+    "arrow.core.NonEmptyList", "arrow.core.Tuple2", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -810,8 +833,8 @@ fun <A, B> tupled(arg0: Kind<ForNonEmptyList, A>, arg1: Kind<ForNonEmptyList, B>
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN<A, B, Tuple2<A, B>>(arg0.fix(), arg1.fix()) { a, b -> Tuple2(a, b) }",
+    "arrow.core.NonEmptyList", "arrow.core.Tuple2", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -830,8 +853,8 @@ fun <A, B> tupledN(arg0: Kind<ForNonEmptyList, A>, arg1: Kind<ForNonEmptyList, B
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN<A, B, C, Tuple3<A, B, C>>(arg0.fix(), arg1.fix(), arg2.fix()) { a, b, c -> Tuple3(a, b, c) }",
+    "arrow.core.NonEmptyList", "arrow.core.Tuple3", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -853,8 +876,8 @@ fun <A, B, C> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN<A, B, C, Tuple3<A, B, C>>(arg0.fix(), arg1.fix(), arg2.fix()) { a, b, c -> Tuple3(a, b, c) }",
+    "arrow.core.NonEmptyList", "arrow.core.Tuple3", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -876,8 +899,8 @@ fun <A, B, C> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN<A, B, C, D, Tuple4<A, B, C, D>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix()) { a, b, c, d -> Tuple4(a, b, c, d) }",
+    "arrow.core.NonEmptyList", "arrow.core.Tuple4", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -901,8 +924,8 @@ fun <A, B, C, D> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN<A, B, C, D, Tuple4<A, B, C, D>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix()) { a, b, c, d -> Tuple4(a, b, c, d) }",
+    "arrow.core.NonEmptyList", "arrow.core.Tuple4", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -926,8 +949,8 @@ fun <A, B, C, D> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN<A, B, C, D, E, Tuple5<A, B, C, D, E>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix()) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }",
+    "arrow.core.NonEmptyList", "arrow.core.Tuple5", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -952,8 +975,8 @@ fun <A, B, C, D, E> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN<A, B, C, D, E, Tuple5<A, B, C, D, E>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix()) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }",
+    "arrow.core.NonEmptyList", "arrow.core.Tuple5", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -978,8 +1001,8 @@ fun <A, B, C, D, E> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN<A, B, C, D, E, FF, Tuple6<A, B, C, D, E, FF>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix()) { a, b, c, d, e, f -> Tuple6(a, b, c, d, e, f) }",
+    "arrow.core.NonEmptyList", "arrow.core.Tuple6", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -1005,8 +1028,8 @@ fun <A, B, C, D, E, FF> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN<A, B, C, D, E, FF, Tuple6<A, B, C, D, E, FF>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix()) { a, b, c, d, e, f -> Tuple6(a, b, c, d, e, f) }",
+    "arrow.core.NonEmptyList", "arrow.core.Tuple6", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -1032,8 +1055,8 @@ fun <A, B, C, D, E, FF> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN<A, B, C, D, E, FF, G, Tuple7<A, B, C, D, E, FF, G>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix()) { a, b, c, d, e, f, g -> Tuple7(a, b, c, d, e, f, g) }",
+    "arrow.core.NonEmptyList", "arrow.core.Tuple7", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -1060,8 +1083,8 @@ fun <A, B, C, D, E, FF, G> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN<A, B, C, D, E, FF, G, Tuple7<A, B, C, D, E, FF, G>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix()) { a, b, c, d, e, f, g -> Tuple7(a, b, c, d, e, f, g) }",
+    "arrow.core.NonEmptyList", "arrow.core.Tuple7", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -1088,8 +1111,8 @@ fun <A, B, C, D, E, FF, G> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN<A, B, C, D, E, FF, G, H, Tuple8<A, B, C, D, E, FF, G, H>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix()) { a, b, c, d, e, f, g, h -> Tuple8(a, b, c, d, e, f, g, h) }",
+    "arrow.core.NonEmptyList", "arrow.core.Tuple8", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -1117,8 +1140,8 @@ fun <A, B, C, D, E, FF, G, H> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN<A, B, C, D, E, FF, G, H, Tuple8<A, B, C, D, E, FF, G, H>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix()) { a, b, c, d, e, f, g, h -> Tuple8(a, b, c, d, e, f, g, h) }",
+    "arrow.core.NonEmptyList", "arrow.core.Tuple8", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -1146,8 +1169,8 @@ fun <A, B, C, D, E, FF, G, H> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN<A, B, C, D, E, FF, G, H, I, Tuple9<A, B, C, D, E, FF, G, H, I>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix()) { a, b, c, d, e, f, g, h, i -> Tuple9(a, b, c, d, e, f, g, h, i) }",
+    "arrow.core.NonEmptyList", "arrow.core.Tuple9", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -1176,8 +1199,8 @@ fun <A, B, C, D, E, FF, G, H, I> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN<A, B, C, D, E, FF, G, H, I, Tuple9<A, B, C, D, E, FF, G, H, I>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix()) { a, b, c, d, e, f, g, h, i -> Tuple9(a, b, c, d, e, f, g, h, i) }",
+    "arrow.core.NonEmptyList", "arrow.core.Tuple9", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -1206,8 +1229,8 @@ fun <A, B, C, D, E, FF, G, H, I> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN<A, B, C, D, E, FF, G, H, I, J, Tuple10<A, B, C, D, E, FF, G, H, I, J>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix(), arg9.fix()) { a, b, c, d, e, f, g, h, i, j -> Tuple10(a, b, c, d, e, f, g, h, i, j) }",
+    "arrow.core.NonEmptyList", "arrow.core.Tuple10", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -1238,8 +1261,8 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "NonEmptyList.tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-    "arrow.core.NonEmptyList"
+    "NonEmptyList.mapN<A, B, C, D, E, FF, G, H, I, J, Tuple10<A, B, C, D, E, FF, G, H, I, J>>(arg0.fix(), arg1.fix(), arg2.fix(), arg3.fix(), arg4.fix(), arg5.fix(), arg6.fix(), arg7.fix(), arg8.fix(), arg9.fix()) { a, b, c, d, e, f, g, h, i, j -> Tuple10(a, b, c, d, e, f, g, h, i, j) }",
+    "arrow.core.NonEmptyList", "arrow.core.Tuple10", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/bimonad/NonEmptyListBimonad.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/bimonad/NonEmptyListBimonad.kt
@@ -16,4 +16,7 @@ internal val bimonad_singleton: NonEmptyListBimonad = object :
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated(
+  "Bimonad typeclass is deprecated. Use concrete methods on NonEmptyList",
+  level = DeprecationLevel.WARNING)
 inline fun Companion.bimonad(): NonEmptyListBimonad = bimonad_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/comonad/NonEmptyListComonad.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/comonad/NonEmptyListComonad.kt
@@ -76,4 +76,7 @@ fun <A> Kind<ForNonEmptyList, A>.duplicate(): NonEmptyList<NonEmptyList<A>> =
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated(
+  "Comonad typeclass is deprecated. Use concrete methods on NonEmptyList",
+  level = DeprecationLevel.WARNING)
 inline fun Companion.comonad(): NonEmptyListComonad = comonad_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/comonad/NonEmptyListComonad.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/comonad/NonEmptyListComonad.kt
@@ -5,11 +5,6 @@ import arrow.core.ForNonEmptyList
 import arrow.core.NonEmptyList
 import arrow.core.NonEmptyList.Companion
 import arrow.core.extensions.NonEmptyListComonad
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -28,8 +23,8 @@ internal val comonad_singleton: NonEmptyListComonad = object :
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "coflatMap(arg1)",
-  "arrow.core.coflatMap"
+  "fix().coflatMap(arg1)",
+  "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -48,8 +43,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.coflatMap(arg1: Function1<Kind<ForNonEmptyLi
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "extract()",
-  "arrow.core.extract"
+  "fix().extract()",
+  "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -67,8 +62,8 @@ fun <A> Kind<ForNonEmptyList, A>.extract(): A = arrow.core.NonEmptyList.comonad(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "duplicate()",
-  "arrow.core.duplicate"
+  "fix().coflatMap<NonEmptyListOf<A>>(::identity)",
+  "arrow.core.fix", "arrow.core.identity"
   ),
   DeprecationLevel.WARNING
 )

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/eq/NonEmptyListEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/eq/NonEmptyListEq.kt
@@ -5,7 +5,6 @@ import arrow.core.NonEmptyList.Companion
 import arrow.core.extensions.NonEmptyListEq
 import arrow.typeclasses.Eq
 import kotlin.Boolean
-import kotlin.Deprecated
 import kotlin.Suppress
 import kotlin.jvm.JvmName
 
@@ -17,13 +16,10 @@ import kotlin.jvm.JvmName
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
+  "@extension projected functions are deprecated",
   ReplaceWith(
-  "neqv(EQ, arg1)",
-  "arrow.core.neqv"
-  ),
-  DeprecationLevel.WARNING
-)
+    "this.neqv<A>(EQ, arg1)",
+    "arrow.core.neqv"))
 fun <A> NonEmptyList<A>.neqv(EQ: Eq<A>, arg1: NonEmptyList<A>): Boolean =
     arrow.core.NonEmptyList.eq<A>(EQ).run {
   this@neqv.neqv(arg1) as kotlin.Boolean
@@ -32,6 +28,14 @@ fun <A> NonEmptyList<A>.neqv(EQ: Eq<A>, arg1: NonEmptyList<A>): Boolean =
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "@extension projected functions are deprecated",
+  ReplaceWith(
+    "Eq.nonEmptyList<A>(EQ)",
+    "arrow.core.NonEmptyList", "arrow.typeclasses.Eq"
+  ),
+  DeprecationLevel.WARNING
 )
 inline fun <A> Companion.eq(EQ: Eq<A>): NonEmptyListEq<A> = object :
     arrow.core.extensions.NonEmptyListEq<A> { override fun EQ(): arrow.typeclasses.Eq<A> = EQ }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/eq/NonEmptyListEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/eq/NonEmptyListEq.kt
@@ -18,7 +18,7 @@ import kotlin.jvm.JvmName
 @Deprecated(
   "@extension projected functions are deprecated",
   ReplaceWith(
-    "this.neqv<A>(EQ, arg1)",
+    "neqv<A>(EQ, arg1)",
     "arrow.core.neqv"))
 fun <A> NonEmptyList<A>.neqv(EQ: Eq<A>, arg1: NonEmptyList<A>): Boolean =
     arrow.core.NonEmptyList.eq<A>(EQ).run {

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/foldable/NonEmptyListFoldable.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/foldable/NonEmptyListFoldable.kt
@@ -86,8 +86,8 @@ fun <A> Kind<ForNonEmptyList, A>.fold(arg1: Monoid<A>): A = arrow.core.NonEmptyL
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Option.fromNullable(reduceNullable(arg1, arg2))",
-    "arrow.core.Option", "arrow.core.reduceNullable"
+    "Option.fromNullable(this.fix().reduceOrNull(arg1, arg2))",
+    "arrow.core.Option", "arrow.core.fix", "arrow.core.reduceOrNull"
   ),
   DeprecationLevel.WARNING
 )
@@ -105,7 +105,14 @@ fun <A, B> Kind<ForNonEmptyList, A>.reduceLeftToOption(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Eval.now(Option.fromNullable(map(arg1).orNull()))", "arrow.core.Option", "arrow.core.Eval"))
+@Deprecated(
+  "@extension kinded projected functions are deprecated",
+  ReplaceWith(
+    "fix().reduceRightEvalOrNull(arg1, arg2).map { Option.fromNullable(it) }",
+    "arrow.core.Option", "arrow.core.fix"
+  ),
+  DeprecationLevel.WARNING
+)
 fun <A, B> Kind<ForNonEmptyList, A>.reduceRightToOption(
   arg1: Function1<A, B>,
   arg2: Function2<A, Eval<B>, Eval<B>>
@@ -121,7 +128,14 @@ fun <A, B> Kind<ForNonEmptyList, A>.reduceRightToOption(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Option.fromNullable(orNull())", "arrow.core.Option"))
+@Deprecated(
+  "@extension kinded projected functions are deprecated",
+  ReplaceWith(
+    "Option.fromNullable<A>(this.fix().reduceOrNull<A, A>(::identity, arg1))",
+    "arrow.core.Option", "arrow.core.fix", "arrow.core.identity", "arrow.core.reduceOrNull"
+  ),
+  DeprecationLevel.WARNING
+)
 fun <A> Kind<ForNonEmptyList, A>.reduceLeftOption(arg1: Function2<A, A, A>): Option<A> =
     arrow.core.NonEmptyList.foldable().run {
   this@reduceLeftOption.reduceLeftOption<A>(arg1) as arrow.core.Option<A>
@@ -134,7 +148,14 @@ fun <A> Kind<ForNonEmptyList, A>.reduceLeftOption(arg1: Function2<A, A, A>): Opt
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Eval.now(Option.fromNullable(orNull()))", "arrow.core.Option", "arrow.core.Eval"))
+@Deprecated(
+  "@extension kinded projected functions are deprecated",
+  ReplaceWith(
+    "fix().reduceRightEvalOrNull<A, A>(::identity, arg1).map<Option<A>> { Option.fromNullable<A>(it) }",
+    "arrow.core.Option", "arrow.core.fix", "arrow.core.identity", "arrow.core.reduceRightEvalOrNull"
+  ),
+  DeprecationLevel.WARNING
+)
 fun <A> Kind<ForNonEmptyList, A>.reduceRightOption(arg1: Function2<A, Eval<A>, Eval<A>>):
     Eval<Option<A>> = arrow.core.NonEmptyList.foldable().run {
   this@reduceRightOption.reduceRightOption<A>(arg1) as arrow.core.Eval<arrow.core.Option<A>>
@@ -207,7 +228,10 @@ fun <A> orEmpty(arg0: Applicative<ForNonEmptyList>, arg1: Monoid<A>): NonEmptyLi
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated. Replace with traverse_ or traverseValidated_ from arrow.core.*")
+@Deprecated(
+  "@extension kinded projected functions are deprecated. Replace with traverseValidated_ or traverseEither_ from arrow.core.*",
+  level = DeprecationLevel.WARNING
+)
 fun <G, A, B> Kind<ForNonEmptyList, A>.traverse_(
   arg1: Applicative<G>,
   arg2: Function1<A, Kind<G, B>>
@@ -222,7 +246,10 @@ fun <G, A, B> Kind<ForNonEmptyList, A>.traverse_(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated. Replace with sequence_ or sequenceValidated_ from arrow.core.*")
+@Deprecated(
+  "@extension kinded projected functions are deprecated. Replace with sequenceValidated_ or sequenceEither_ from arrow.core.*",
+  level = DeprecationLevel.WARNING
+)
 fun <G, A> Kind<ForNonEmptyList, Kind<G, A>>.sequence_(arg1: Applicative<G>): Kind<G, Unit> =
     arrow.core.NonEmptyList.foldable().run {
   this@sequence_.sequence_<G, A>(arg1) as arrow.Kind<G, kotlin.Unit>
@@ -392,7 +419,7 @@ fun <A> Kind<ForNonEmptyList, A>.size(arg1: Monoid<Long>): Long =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("Applicative typeclasses is deprecated. Use concrete methods on NonEmptyList")
+@Deprecated("Applicative typeclass is deprecated. Use concrete methods on NonEmptyList")
 fun <G, A, B, AP : Applicative<G>, MO : Monoid<B>> Kind<ForNonEmptyList, A>.foldMapA(
   arg1: AP,
   arg2: MO,
@@ -408,7 +435,7 @@ fun <G, A, B, AP : Applicative<G>, MO : Monoid<B>> Kind<ForNonEmptyList, A>.fold
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("Applicative typeclasses is deprecated. Use concrete methods on NonEmptyList")
+@Deprecated("Monad typeclass is deprecated. Use concrete methods on NonEmptyList")
 fun <G, A, B, MA : Monad<G>, MO : Monoid<B>> Kind<ForNonEmptyList, A>.foldMapM(
   arg1: MA,
   arg2: MO,
@@ -424,7 +451,7 @@ fun <G, A, B, MA : Monad<G>, MO : Monoid<B>> Kind<ForNonEmptyList, A>.foldMapM(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("Applicative typeclasses is deprecated. Use concrete methods on NonEmptyList")
+@Deprecated("Monad typeclass is deprecated. Use concrete methods on NonEmptyList")
 fun <G, A, B> Kind<ForNonEmptyList, A>.foldM(
   arg1: Monad<G>,
   arg2: B,

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/foldable/NonEmptyListFoldable.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/foldable/NonEmptyListFoldable.kt
@@ -10,15 +10,6 @@ import arrow.core.extensions.NonEmptyListFoldable
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Monad
 import arrow.typeclasses.Monoid
-import kotlin.Boolean
-import kotlin.Function1
-import kotlin.Function2
-import kotlin.Long
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.Unit
-import kotlin.collections.List
-import kotlin.jvm.JvmName
 
 /**
  * cached extension

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/foldable/NonEmptyListFoldable.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/foldable/NonEmptyListFoldable.kt
@@ -581,5 +581,5 @@ fun <A> Kind<ForNonEmptyList, A>.toList(): List<A> = arrow.core.NonEmptyList.fol
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("Foldable typeclasses is deprecated. Use concrete methods on NonEmptyList")
+@Deprecated("Foldable typeclass is deprecated. Use concrete methods on NonEmptyList")
 inline fun Companion.foldable(): NonEmptyListFoldable = foldable_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/foldable/NonEmptyListFoldable.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/foldable/NonEmptyListFoldable.kt
@@ -37,7 +37,7 @@ internal val foldable_singleton: NonEmptyListFoldable = object :
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().foldLeft<B>(arg1, arg2)",
+    "fix().foldLeft<B>(arg1, arg2)",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -57,7 +57,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.foldLeft(arg1: B, arg2: Function2<B, A, B>):
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().foldRight<B>(arg1, arg2)",
+    "fix().foldRight<B>(arg1, arg2)",
     "arrow.core.fix"
   )
 )
@@ -76,7 +76,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.foldRight(arg1: Eval<B>, arg2: Function2<A, 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().combineAll<A>(arg1)",
+    "fix().combineAll<A>(arg1)",
     "arrow.core.combineAll", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -159,7 +159,7 @@ fun <A> Kind<ForNonEmptyList, A>.reduceRightOption(arg1: Function2<A, Eval<A>, E
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().combineAll<A>(arg1)",
+    "fix().combineAll<A>(arg1)",
     "arrow.core.combineAll", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -179,7 +179,7 @@ fun <A> Kind<ForNonEmptyList, A>.combineAll(arg1: Monoid<A>): A =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().foldMap<A, B>(arg1, arg2)",
+    "fix().foldMap<A, B>(arg1, arg2)",
     "arrow.core.fix", "arrow.core.foldMap"
   ),
   DeprecationLevel.WARNING
@@ -267,7 +267,7 @@ fun <A> Kind<ForNonEmptyList, A>.find(arg1: Function1<A, Boolean>): Option<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().any(arg1)",
+    "fix().any(arg1)",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -287,7 +287,7 @@ fun <A> Kind<ForNonEmptyList, A>.exists(arg1: Function1<A, Boolean>): Boolean =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().all(arg1)",
+    "fix().all(arg1)",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -307,7 +307,7 @@ fun <A> Kind<ForNonEmptyList, A>.forAll(arg1: Function1<A, Boolean>): Boolean =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().all(arg1)",
+    "fix().all(arg1)",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -327,7 +327,7 @@ fun <A> Kind<ForNonEmptyList, A>.all(arg1: Function1<A, Boolean>): Boolean =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().isEmpty()",
+    "fix().isEmpty()",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -346,7 +346,7 @@ fun <A> Kind<ForNonEmptyList, A>.isEmpty(): Boolean = arrow.core.NonEmptyList.fo
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().isNotEmpty()",
+    "fix().isNotEmpty()",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -365,7 +365,7 @@ fun <A> Kind<ForNonEmptyList, A>.nonEmpty(): Boolean = arrow.core.NonEmptyList.f
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().isNotEmpty()",
+    "fix().isNotEmpty()",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -384,7 +384,7 @@ fun <A> Kind<ForNonEmptyList, A>.isNotEmpty(): Boolean = arrow.core.NonEmptyList
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().size()",
+    "fix().size()",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -452,7 +452,7 @@ fun <G, A, B> Kind<ForNonEmptyList, A>.foldM(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix()[arg1]",
+    "fix()[arg1]",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -550,7 +550,7 @@ fun <A> Kind<ForNonEmptyList, A>.firstOrNone(arg1: Function1<A, Boolean>): Optio
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().toList()",
+    "fix().toList()",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/foldable/NonEmptyListFoldable.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/foldable/NonEmptyListFoldable.kt
@@ -11,7 +11,6 @@ import arrow.typeclasses.Applicative
 import arrow.typeclasses.Monad
 import arrow.typeclasses.Monoid
 import kotlin.Boolean
-import kotlin.Deprecated
 import kotlin.Function1
 import kotlin.Function2
 import kotlin.Long
@@ -38,8 +37,8 @@ internal val foldable_singleton: NonEmptyListFoldable = object :
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "foldLeft(arg1, arg2)",
-  "arrow.core.foldLeft"
+    "this.fix().foldLeft<B>(arg1, arg2)",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -58,10 +57,9 @@ fun <A, B> Kind<ForNonEmptyList, A>.foldLeft(arg1: B, arg2: Function2<B, A, B>):
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "foldRight(arg1, arg2)",
-  "arrow.core.foldRight"
-  ),
-  DeprecationLevel.WARNING
+    "this.fix().foldRight<B>(arg1, arg2)",
+    "arrow.core.fix"
+  )
 )
 fun <A, B> Kind<ForNonEmptyList, A>.foldRight(arg1: Eval<B>, arg2: Function2<A, Eval<B>, Eval<B>>):
     Eval<B> = arrow.core.NonEmptyList.foldable().run {
@@ -78,8 +76,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.foldRight(arg1: Eval<B>, arg2: Function2<A, 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "fold(arg1)",
-  "arrow.core.fold"
+    "this.fix().combineAll<A>(arg1)",
+    "arrow.core.combineAll", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -97,8 +95,8 @@ fun <A> Kind<ForNonEmptyList, A>.fold(arg1: Monoid<A>): A = arrow.core.NonEmptyL
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "reduceLeftToOption(arg1, arg2)",
-  "arrow.core.reduceLeftToOption"
+    "Option.fromNullable(reduceNullable(arg1, arg2))",
+    "arrow.core.Option", "arrow.core.reduceNullable"
   ),
   DeprecationLevel.WARNING
 )
@@ -116,14 +114,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.reduceLeftToOption(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "reduceRightToOption(arg1, arg2)",
-  "arrow.core.reduceRightToOption"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Eval.now(Option.fromNullable(map(arg1).orNull()))", "arrow.core.Option", "arrow.core.Eval"))
 fun <A, B> Kind<ForNonEmptyList, A>.reduceRightToOption(
   arg1: Function1<A, B>,
   arg2: Function2<A, Eval<B>, Eval<B>>
@@ -139,14 +130,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.reduceRightToOption(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "reduceLeftOption(arg1)",
-  "arrow.core.reduceLeftOption"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Option.fromNullable(orNull())", "arrow.core.Option"))
 fun <A> Kind<ForNonEmptyList, A>.reduceLeftOption(arg1: Function2<A, A, A>): Option<A> =
     arrow.core.NonEmptyList.foldable().run {
   this@reduceLeftOption.reduceLeftOption<A>(arg1) as arrow.core.Option<A>
@@ -159,14 +143,7 @@ fun <A> Kind<ForNonEmptyList, A>.reduceLeftOption(arg1: Function2<A, A, A>): Opt
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "reduceRightOption(arg1)",
-  "arrow.core.reduceRightOption"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Eval.now(Option.fromNullable(orNull()))", "arrow.core.Option", "arrow.core.Eval"))
 fun <A> Kind<ForNonEmptyList, A>.reduceRightOption(arg1: Function2<A, Eval<A>, Eval<A>>):
     Eval<Option<A>> = arrow.core.NonEmptyList.foldable().run {
   this@reduceRightOption.reduceRightOption<A>(arg1) as arrow.core.Eval<arrow.core.Option<A>>
@@ -182,8 +159,8 @@ fun <A> Kind<ForNonEmptyList, A>.reduceRightOption(arg1: Function2<A, Eval<A>, E
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "combineAll(arg1)",
-  "arrow.core.combineAll"
+    "this.fix().combineAll<A>(arg1)",
+    "arrow.core.combineAll", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -202,8 +179,8 @@ fun <A> Kind<ForNonEmptyList, A>.combineAll(arg1: Monoid<A>): A =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "foldMap(arg1, arg2)",
-  "arrow.core.foldMap"
+    "this.fix().foldMap<A, B>(arg1, arg2)",
+    "arrow.core.fix", "arrow.core.foldMap"
   ),
   DeprecationLevel.WARNING
 )
@@ -222,8 +199,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.foldMap(arg1: Monoid<B>, arg2: Function1<A, 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "orEmpty(arg0, arg1)",
-  "arrow.core.NonEmptyList.orEmpty"
+    "NonEmptyList.just(arg1.empty())",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -239,14 +216,7 @@ fun <A> orEmpty(arg0: Applicative<ForNonEmptyList>, arg1: Monoid<A>): NonEmptyLi
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "traverse_(arg1, arg2)",
-  "arrow.core.traverse_"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated("@extension kinded projected functions are deprecated. Replace with traverse_ or traverseValidated_ from arrow.core.*")
 fun <G, A, B> Kind<ForNonEmptyList, A>.traverse_(
   arg1: Applicative<G>,
   arg2: Function1<A, Kind<G, B>>
@@ -261,14 +231,7 @@ fun <G, A, B> Kind<ForNonEmptyList, A>.traverse_(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "sequence_(arg1)",
-  "arrow.core.sequence_"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated("@extension kinded projected functions are deprecated. Replace with sequence_ or sequenceValidated_ from arrow.core.*")
 fun <G, A> Kind<ForNonEmptyList, Kind<G, A>>.sequence_(arg1: Applicative<G>): Kind<G, Unit> =
     arrow.core.NonEmptyList.foldable().run {
   this@sequence_.sequence_<G, A>(arg1) as arrow.Kind<G, kotlin.Unit>
@@ -284,8 +247,8 @@ fun <G, A> Kind<ForNonEmptyList, Kind<G, A>>.sequence_(arg1: Applicative<G>): Ki
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "find(arg1)",
-  "arrow.core.find"
+    "Option.fromNullable(this.fix().firstOrNull(arg1))",
+    "arrow.core.Option", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -304,8 +267,8 @@ fun <A> Kind<ForNonEmptyList, A>.find(arg1: Function1<A, Boolean>): Option<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "exists(arg1)",
-  "arrow.core.exists"
+    "this.fix().any(arg1)",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -324,8 +287,8 @@ fun <A> Kind<ForNonEmptyList, A>.exists(arg1: Function1<A, Boolean>): Boolean =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "forAll(arg1)",
-  "arrow.core.forAll"
+    "this.fix().all(arg1)",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -344,8 +307,8 @@ fun <A> Kind<ForNonEmptyList, A>.forAll(arg1: Function1<A, Boolean>): Boolean =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "all(arg1)",
-  "arrow.core.all"
+    "this.fix().all(arg1)",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -364,8 +327,8 @@ fun <A> Kind<ForNonEmptyList, A>.all(arg1: Function1<A, Boolean>): Boolean =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "isEmpty()",
-  "arrow.core.isEmpty"
+    "this.fix().isEmpty()",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -383,8 +346,8 @@ fun <A> Kind<ForNonEmptyList, A>.isEmpty(): Boolean = arrow.core.NonEmptyList.fo
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "nonEmpty()",
-  "arrow.core.nonEmpty"
+    "this.fix().isNotEmpty()",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -402,8 +365,8 @@ fun <A> Kind<ForNonEmptyList, A>.nonEmpty(): Boolean = arrow.core.NonEmptyList.f
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "isNotEmpty()",
-  "arrow.core.isNotEmpty"
+    "this.fix().isNotEmpty()",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -421,8 +384,8 @@ fun <A> Kind<ForNonEmptyList, A>.isNotEmpty(): Boolean = arrow.core.NonEmptyList
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "size(arg1)",
-  "arrow.core.size"
+    "this.fix().size()",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -438,14 +401,7 @@ fun <A> Kind<ForNonEmptyList, A>.size(arg1: Monoid<Long>): Long =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "foldMapA(arg1, arg2, arg3)",
-  "arrow.core.foldMapA"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated("Applicative typeclasses is deprecated. Use concrete methods on NonEmptyList")
 fun <G, A, B, AP : Applicative<G>, MO : Monoid<B>> Kind<ForNonEmptyList, A>.foldMapA(
   arg1: AP,
   arg2: MO,
@@ -461,14 +417,7 @@ fun <G, A, B, AP : Applicative<G>, MO : Monoid<B>> Kind<ForNonEmptyList, A>.fold
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "foldMapM(arg1, arg2, arg3)",
-  "arrow.core.foldMapM"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated("Applicative typeclasses is deprecated. Use concrete methods on NonEmptyList")
 fun <G, A, B, MA : Monad<G>, MO : Monoid<B>> Kind<ForNonEmptyList, A>.foldMapM(
   arg1: MA,
   arg2: MO,
@@ -484,14 +433,7 @@ fun <G, A, B, MA : Monad<G>, MO : Monoid<B>> Kind<ForNonEmptyList, A>.foldMapM(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "foldM(arg1, arg2, arg3)",
-  "arrow.core.foldM"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated("Applicative typeclasses is deprecated. Use concrete methods on NonEmptyList")
 fun <G, A, B> Kind<ForNonEmptyList, A>.foldM(
   arg1: Monad<G>,
   arg2: B,
@@ -510,8 +452,8 @@ fun <G, A, B> Kind<ForNonEmptyList, A>.foldM(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "get(arg1)",
-  "arrow.core.get"
+    "this.fix()[arg1]",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -530,8 +472,8 @@ fun <A> Kind<ForNonEmptyList, A>.get(arg1: Long): Option<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "firstOption()",
-  "arrow.core.firstOption"
+    "Option.fromNullable(this.fix().firstOrNull())",
+    "arrow.core.Option", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -549,8 +491,8 @@ fun <A> Kind<ForNonEmptyList, A>.firstOption(): Option<A> = arrow.core.NonEmptyL
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "firstOption(arg1)",
-  "arrow.core.firstOption"
+    "Option.fromNullable(this.fix().firstOrNull(arg1))",
+    "arrow.core.Option", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -569,8 +511,8 @@ fun <A> Kind<ForNonEmptyList, A>.firstOption(arg1: Function1<A, Boolean>): Optio
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "firstOrNone()",
-  "arrow.core.firstOrNone"
+    "Option.fromNullable(this.fix().firstOrNull())",
+    "arrow.core.Option", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -588,8 +530,8 @@ fun <A> Kind<ForNonEmptyList, A>.firstOrNone(): Option<A> = arrow.core.NonEmptyL
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "firstOrNone(arg1)",
-  "arrow.core.firstOrNone"
+    "Option.fromNullable(this.fix().firstOrNull(arg1))",
+    "arrow.core.Option", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -608,8 +550,8 @@ fun <A> Kind<ForNonEmptyList, A>.firstOrNone(arg1: Function1<A, Boolean>): Optio
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "toList()",
-  "arrow.core.toList"
+    "this.fix().toList()",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -621,4 +563,5 @@ fun <A> Kind<ForNonEmptyList, A>.toList(): List<A> = arrow.core.NonEmptyList.fol
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("Foldable typeclasses is deprecated. Use concrete methods on NonEmptyList")
 inline fun Companion.foldable(): NonEmptyListFoldable = foldable_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/functor/NonEmptyListFunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/functor/NonEmptyListFunctor.kt
@@ -45,7 +45,7 @@ internal val functor_singleton: NonEmptyListFunctor = object :
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().map<B>(arg1)",
+    "fix().map<B>(arg1)",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -65,7 +65,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.map(arg1: Function1<A, B>): NonEmptyList<B> 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().map<B>(arg1)",
+    "fix().map<B>(arg1)",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -129,7 +129,7 @@ fun <A, B> lift(arg0: Function1<A, B>): Function1<Kind<ForNonEmptyList, A>, Kind
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().void<A>()",
+    "fix().void<A>()",
     "arrow.core.fix", "arrow.core.void"
   ),
   DeprecationLevel.WARNING
@@ -172,7 +172,7 @@ fun <A> Kind<ForNonEmptyList, A>.void(): NonEmptyList<Unit> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().fproduct<A, B>(arg1)",
+    "fix().fproduct<A, B>(arg1)",
     "arrow.core.fix", "arrow.core.fproduct"
   ),
   DeprecationLevel.WARNING
@@ -214,7 +214,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.fproduct(arg1: Function1<A, B>): NonEmptyLis
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().mapConst<A, B>(arg1)",
+    "fix().mapConst<A, B>(arg1)",
     "arrow.core.fix", "arrow.core.mapConst"
   ),
   DeprecationLevel.WARNING
@@ -279,7 +279,7 @@ fun <A, B> A.mapConst(arg1: Kind<ForNonEmptyList, B>): NonEmptyList<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().tupleLeft<A, B>(arg1)",
+    "fix().tupleLeft<A, B>(arg1)",
     "arrow.core.fix", "arrow.core.tupleLeft"
   ),
   DeprecationLevel.WARNING
@@ -321,7 +321,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.tupleLeft(arg1: B): NonEmptyList<Tuple2<B, A
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().tupleRight<A, B>(arg1)",
+    "fix().tupleRight<A, B>(arg1)",
     "arrow.core.fix", "arrow.core.tupleRight"
   ),
   DeprecationLevel.WARNING
@@ -364,7 +364,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.tupleRight(arg1: B): NonEmptyList<Tuple2<A, 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().widen<B, A>()",
+    "fix().widen<B, A>()",
     "arrow.core.fix", "arrow.core.widen"
   ),
   DeprecationLevel.WARNING

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/functor/NonEmptyListFunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/functor/NonEmptyListFunctor.kt
@@ -6,12 +6,6 @@ import arrow.core.NonEmptyList
 import arrow.core.NonEmptyList.Companion
 import arrow.core.Tuple2
 import arrow.core.extensions.NonEmptyListFunctor
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.Unit
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -51,8 +45,8 @@ internal val functor_singleton: NonEmptyListFunctor = object :
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg1)",
-  "arrow.core.map"
+    "this.fix().map<B>(arg1)",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -71,8 +65,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.map(arg1: Function1<A, B>): NonEmptyList<B> 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "imap(arg1, arg2)",
-  "arrow.core.imap"
+    "this.fix().map<B>(arg1)",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -114,8 +108,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.imap(arg1: Function1<A, B>, arg2: Function1<
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "lift(arg0)",
-  "arrow.core.NonEmptyList.lift"
+    "{ nel: NonEmptyList<Int> -> nel.map { arg0 }}",
+    "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -135,8 +129,8 @@ fun <A, B> lift(arg0: Function1<A, B>): Function1<Kind<ForNonEmptyList, A>, Kind
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "void()",
-  "arrow.core.void"
+    "this.fix().void<A>()",
+    "arrow.core.fix", "arrow.core.void"
   ),
   DeprecationLevel.WARNING
 )
@@ -145,6 +139,29 @@ fun <A> Kind<ForNonEmptyList, A>.void(): NonEmptyList<Unit> =
   this@void.void<A>() as arrow.core.NonEmptyList<kotlin.Unit>
 }
 
+/**
+ *  Applies [f] to an [A] inside [F] and returns the [F] structure with a tuple of the [A] value and the
+ *  computed [B] value as result of applying [f]
+ *
+ *  Kind<F, A> -> Kind<F, Tuple2<A, B>>
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.core.*
+ * import arrow.core.extensions.nonemptylist.functor.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.core.extensions.nonemptylist.applicative.just
+ *
+ *  fun main(args: Array<String>) {
+ *   val result =
+ *   //sampleStart
+ *   "Hello".just().fproduct({ "$it World" })
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
 @JvmName("fproduct")
 @Suppress(
   "UNCHECKED_CAST",
@@ -155,8 +172,8 @@ fun <A> Kind<ForNonEmptyList, A>.void(): NonEmptyList<Unit> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "fproduct(arg1)",
-  "arrow.core.fproduct"
+    "this.fix().fproduct<A, B>(arg1)",
+    "arrow.core.fix", "arrow.core.fproduct"
   ),
   DeprecationLevel.WARNING
 )
@@ -165,6 +182,28 @@ fun <A, B> Kind<ForNonEmptyList, A>.fproduct(arg1: Function1<A, B>): NonEmptyLis
   this@fproduct.fproduct<A, B>(arg1) as arrow.core.NonEmptyList<arrow.core.Tuple2<A, B>>
 }
 
+/**
+ *  Replaces [A] inside [F] with [B] resulting in a Kind<F, B>
+ *
+ *  Kind<F, A> -> Kind<F, B>
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.core.*
+ * import arrow.core.extensions.nonemptylist.functor.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.core.extensions.nonemptylist.applicative.just
+ *
+ *  fun main(args: Array<String>) {
+ *   val result =
+ *   //sampleStart
+ *   "Hello World".just().mapConst("...")
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
 @JvmName("mapConst")
 @Suppress(
   "UNCHECKED_CAST",
@@ -175,8 +214,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.fproduct(arg1: Function1<A, B>): NonEmptyLis
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapConst(arg1)",
-  "arrow.core.mapConst"
+    "this.fix().mapConst<A, B>(arg1)",
+    "arrow.core.fix", "arrow.core.mapConst"
   ),
   DeprecationLevel.WARNING
 )
@@ -198,8 +237,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.mapConst(arg1: B): NonEmptyList<B> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapConst(arg1)",
-  "arrow.core.mapConst"
+    "arg1.fix().mapConst<B, A>(this)",
+    "arrow.core.fix", "arrow.core.mapConst"
   ),
   DeprecationLevel.WARNING
 )
@@ -208,6 +247,28 @@ fun <A, B> A.mapConst(arg1: Kind<ForNonEmptyList, B>): NonEmptyList<A> =
   this@mapConst.mapConst<A, B>(arg1) as arrow.core.NonEmptyList<A>
 }
 
+/**
+ *  Pairs [B] with [A] returning a Kind<F, Tuple2<B, A>>
+ *
+ *  Kind<F, A> -> Kind<F, Tuple2<B, A>>
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.core.*
+ * import arrow.core.extensions.nonemptylist.functor.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.core.extensions.nonemptylist.applicative.just
+ *
+ *  fun main(args: Array<String>) {
+ *   val result =
+ *   //sampleStart
+ *   "Hello".just().tupleLeft("World")
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
 @JvmName("tupleLeft")
 @Suppress(
   "UNCHECKED_CAST",
@@ -218,8 +279,8 @@ fun <A, B> A.mapConst(arg1: Kind<ForNonEmptyList, B>): NonEmptyList<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupleLeft(arg1)",
-  "arrow.core.tupleLeft"
+    "this.fix().tupleLeft<A, B>(arg1)",
+    "arrow.core.fix", "arrow.core.tupleLeft"
   ),
   DeprecationLevel.WARNING
 )
@@ -228,6 +289,28 @@ fun <A, B> Kind<ForNonEmptyList, A>.tupleLeft(arg1: B): NonEmptyList<Tuple2<B, A
   this@tupleLeft.tupleLeft<A, B>(arg1) as arrow.core.NonEmptyList<arrow.core.Tuple2<B, A>>
 }
 
+/**
+ *  Pairs [A] with [B] returning a Kind<F, Tuple2<A, B>>
+ *
+ *  Kind<F, A> -> Kind<F, Tuple2<A, B>>
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.core.*
+ * import arrow.core.extensions.nonemptylist.functor.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.core.extensions.nonemptylist.applicative.just
+ *
+ *  fun main(args: Array<String>) {
+ *   val result =
+ *   //sampleStart
+ *   "Hello".just().tupleRight("World")
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
 @JvmName("tupleRight")
 @Suppress(
   "UNCHECKED_CAST",
@@ -238,8 +321,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.tupleLeft(arg1: B): NonEmptyList<Tuple2<B, A
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupleRight(arg1)",
-  "arrow.core.tupleRight"
+    "this.fix().tupleRight<A, B>(arg1)",
+    "arrow.core.fix", "arrow.core.tupleRight"
   ),
   DeprecationLevel.WARNING
 )
@@ -248,6 +331,29 @@ fun <A, B> Kind<ForNonEmptyList, A>.tupleRight(arg1: B): NonEmptyList<Tuple2<A, 
   this@tupleRight.tupleRight<A, B>(arg1) as arrow.core.NonEmptyList<arrow.core.Tuple2<A, B>>
 }
 
+/**
+ *  Given [A] is a sub type of [B], re-type this value from Kind<F, A> to Kind<F, B>
+ *
+ *  Kind<F, A> -> Kind<F, B>
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.core.*
+ * import arrow.core.extensions.nonemptylist.functor.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.core.extensions.nonemptylist.applicative.just
+ *  import arrow.Kind
+ *
+ *  fun main(args: Array<String>) {
+ *   val result: Kind<*, CharSequence> =
+ *   //sampleStart
+ *   "Hello".just().map({ "$it World" }).widen()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
 @JvmName("widen")
 @Suppress(
   "UNCHECKED_CAST",
@@ -258,8 +364,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.tupleRight(arg1: B): NonEmptyList<Tuple2<A, 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "widen()",
-  "arrow.core.widen"
+    "this.fix().widen<B, A>()",
+    "arrow.core.fix", "arrow.core.widen"
   ),
   DeprecationLevel.WARNING
 )
@@ -268,8 +374,73 @@ fun <B, A : B> Kind<ForNonEmptyList, A>.widen(): NonEmptyList<B> =
   this@widen.widen<B, A>() as arrow.core.NonEmptyList<B>
 }
 
+/**
+ *  ank_macro_hierarchy(arrow.typeclasses.Functor)
+ *
+ *  The [Functor] type class abstracts the ability to [map] over the computational context of a type constructor.
+ *  Examples of type constructors that can implement instances of the Functor type class include
+ *  [arrow.core.Option], [arrow.core.NonEmptyList], [List] and many other data types that include a [map] function with the shape
+ *  `fun <F, A, B> Kind<F, A>.map(f: (A) -> B): Kind<F, B>` where `F` refers to any type constructor whose contents can be transformed.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.core.*
+ * import arrow.core.extensions.nonemptylist.functor.*
+ * import arrow.core.*
+ *
+ *
+ *
+ *  fun main(args: Array<String>) {
+ *   val result =
+ *   //sampleStart
+ *   NonEmptyList.functor()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ *
+ *  ### Example
+ *
+ *  Oftentimes we find ourselves in situations where we need to transform the contents of some data type.
+ *  [map] allows us to safely compute over values under the assumption that they'll be there returning the
+ *  transformation encapsulated in the same context.
+ *
+ *  Consider [arrow.core.Option] and [arrow.core.Either]:
+ *
+ *  `Option<A>` allows us to model absence and has two possible states, `Some(a: A)` if the value is not absent and `None` to represent an empty case.
+ *  In a similar fashion `Either<L, R>` may have two possible cases `Left(l: L)` and `Right(r: R)`. By convention, `Left` is used to model the exceptional
+ *  case and `Right` for the successful case.
+ *
+ *  Both [arrow.core.Either] and [arrow.core.Option] are examples of data types that can be computed over transforming their inner results.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.*
+ *  import arrow.core.*
+ *
+ *  suspend fun main(args: Array<String>) {
+ *   val result =
+ *   //sampleStart
+ * 2 }
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.*
+ *  import arrow.core.*
+ *
+ *  fun main(args: Array<String>) {
+ *   val result =
+ *   //sampleStart
+ * 2 }
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-inline fun Companion.functor(): NonEmptyListFunctor = functor_singleton
+@Deprecated("Functor typeclasses is deprecated. Use concrete methods on NonEmptyList")
+inline fun Companion.functor(): NonEmptyListFunctor = functor_singleton as arrow.core.extensions.NonEmptyListFunctor

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/functor/NonEmptyListFunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/functor/NonEmptyListFunctor.kt
@@ -139,29 +139,6 @@ fun <A> Kind<ForNonEmptyList, A>.void(): NonEmptyList<Unit> =
   this@void.void<A>() as arrow.core.NonEmptyList<kotlin.Unit>
 }
 
-/**
- *  Applies [f] to an [A] inside [F] and returns the [F] structure with a tuple of the [A] value and the
- *  computed [B] value as result of applying [f]
- *
- *  Kind<F, A> -> Kind<F, Tuple2<A, B>>
- *
- *  ```kotlin:ank:playground
- *  import arrow.core.*
- * import arrow.core.extensions.nonemptylist.functor.*
- * import arrow.core.*
- *
- *
- *  import arrow.core.extensions.nonemptylist.applicative.just
- *
- *  fun main(args: Array<String>) {
- *   val result =
- *   //sampleStart
- *   "Hello".just().fproduct({ "$it World" })
- *   //sampleEnd
- *   println(result)
- *  }
- *  ```
- */
 @JvmName("fproduct")
 @Suppress(
   "UNCHECKED_CAST",
@@ -182,28 +159,6 @@ fun <A, B> Kind<ForNonEmptyList, A>.fproduct(arg1: Function1<A, B>): NonEmptyLis
   this@fproduct.fproduct<A, B>(arg1) as arrow.core.NonEmptyList<arrow.core.Tuple2<A, B>>
 }
 
-/**
- *  Replaces [A] inside [F] with [B] resulting in a Kind<F, B>
- *
- *  Kind<F, A> -> Kind<F, B>
- *
- *  ```kotlin:ank:playground
- *  import arrow.core.*
- * import arrow.core.extensions.nonemptylist.functor.*
- * import arrow.core.*
- *
- *
- *  import arrow.core.extensions.nonemptylist.applicative.just
- *
- *  fun main(args: Array<String>) {
- *   val result =
- *   //sampleStart
- *   "Hello World".just().mapConst("...")
- *   //sampleEnd
- *   println(result)
- *  }
- *  ```
- */
 @JvmName("mapConst")
 @Suppress(
   "UNCHECKED_CAST",
@@ -247,28 +202,6 @@ fun <A, B> A.mapConst(arg1: Kind<ForNonEmptyList, B>): NonEmptyList<A> =
   this@mapConst.mapConst<A, B>(arg1) as arrow.core.NonEmptyList<A>
 }
 
-/**
- *  Pairs [B] with [A] returning a Kind<F, Tuple2<B, A>>
- *
- *  Kind<F, A> -> Kind<F, Tuple2<B, A>>
- *
- *  ```kotlin:ank:playground
- *  import arrow.core.*
- * import arrow.core.extensions.nonemptylist.functor.*
- * import arrow.core.*
- *
- *
- *  import arrow.core.extensions.nonemptylist.applicative.just
- *
- *  fun main(args: Array<String>) {
- *   val result =
- *   //sampleStart
- *   "Hello".just().tupleLeft("World")
- *   //sampleEnd
- *   println(result)
- *  }
- *  ```
- */
 @JvmName("tupleLeft")
 @Suppress(
   "UNCHECKED_CAST",
@@ -289,28 +222,6 @@ fun <A, B> Kind<ForNonEmptyList, A>.tupleLeft(arg1: B): NonEmptyList<Tuple2<B, A
   this@tupleLeft.tupleLeft<A, B>(arg1) as arrow.core.NonEmptyList<arrow.core.Tuple2<B, A>>
 }
 
-/**
- *  Pairs [A] with [B] returning a Kind<F, Tuple2<A, B>>
- *
- *  Kind<F, A> -> Kind<F, Tuple2<A, B>>
- *
- *  ```kotlin:ank:playground
- *  import arrow.core.*
- * import arrow.core.extensions.nonemptylist.functor.*
- * import arrow.core.*
- *
- *
- *  import arrow.core.extensions.nonemptylist.applicative.just
- *
- *  fun main(args: Array<String>) {
- *   val result =
- *   //sampleStart
- *   "Hello".just().tupleRight("World")
- *   //sampleEnd
- *   println(result)
- *  }
- *  ```
- */
 @JvmName("tupleRight")
 @Suppress(
   "UNCHECKED_CAST",
@@ -331,29 +242,6 @@ fun <A, B> Kind<ForNonEmptyList, A>.tupleRight(arg1: B): NonEmptyList<Tuple2<A, 
   this@tupleRight.tupleRight<A, B>(arg1) as arrow.core.NonEmptyList<arrow.core.Tuple2<A, B>>
 }
 
-/**
- *  Given [A] is a sub type of [B], re-type this value from Kind<F, A> to Kind<F, B>
- *
- *  Kind<F, A> -> Kind<F, B>
- *
- *  ```kotlin:ank:playground
- *  import arrow.core.*
- * import arrow.core.extensions.nonemptylist.functor.*
- * import arrow.core.*
- *
- *
- *  import arrow.core.extensions.nonemptylist.applicative.just
- *  import arrow.Kind
- *
- *  fun main(args: Array<String>) {
- *   val result: Kind<*, CharSequence> =
- *   //sampleStart
- *   "Hello".just().map({ "$it World" }).widen()
- *   //sampleEnd
- *   println(result)
- *  }
- *  ```
- */
 @JvmName("widen")
 @Suppress(
   "UNCHECKED_CAST",
@@ -374,70 +262,6 @@ fun <B, A : B> Kind<ForNonEmptyList, A>.widen(): NonEmptyList<B> =
   this@widen.widen<B, A>() as arrow.core.NonEmptyList<B>
 }
 
-/**
- *  ank_macro_hierarchy(arrow.typeclasses.Functor)
- *
- *  The [Functor] type class abstracts the ability to [map] over the computational context of a type constructor.
- *  Examples of type constructors that can implement instances of the Functor type class include
- *  [arrow.core.Option], [arrow.core.NonEmptyList], [List] and many other data types that include a [map] function with the shape
- *  `fun <F, A, B> Kind<F, A>.map(f: (A) -> B): Kind<F, B>` where `F` refers to any type constructor whose contents can be transformed.
- *
- *  ```kotlin:ank:playground
- *  import arrow.core.*
- * import arrow.core.extensions.nonemptylist.functor.*
- * import arrow.core.*
- *
- *
- *
- *  fun main(args: Array<String>) {
- *   val result =
- *   //sampleStart
- *   NonEmptyList.functor()
- *   //sampleEnd
- *   println(result)
- *  }
- *  ```
- *
- *  ### Example
- *
- *  Oftentimes we find ourselves in situations where we need to transform the contents of some data type.
- *  [map] allows us to safely compute over values under the assumption that they'll be there returning the
- *  transformation encapsulated in the same context.
- *
- *  Consider [arrow.core.Option] and [arrow.core.Either]:
- *
- *  `Option<A>` allows us to model absence and has two possible states, `Some(a: A)` if the value is not absent and `None` to represent an empty case.
- *  In a similar fashion `Either<L, R>` may have two possible cases `Left(l: L)` and `Right(r: R)`. By convention, `Left` is used to model the exceptional
- *  case and `Right` for the successful case.
- *
- *  Both [arrow.core.Either] and [arrow.core.Option] are examples of data types that can be computed over transforming their inner results.
- *
- *  ```kotlin:ank:playground
- *  import arrow.*
- *  import arrow.core.*
- *
- *  suspend fun main(args: Array<String>) {
- *   val result =
- *   //sampleStart
- * 2 }
- *   //sampleEnd
- *   println(result)
- *  }
- *  ```
- *
- *  ```kotlin:ank:playground
- *  import arrow.*
- *  import arrow.core.*
- *
- *  fun main(args: Array<String>) {
- *   val result =
- *   //sampleStart
- * 2 }
- *   //sampleEnd
- *   println(result)
- *  }
- *  ```
- */
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/functor/NonEmptyListFunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/functor/NonEmptyListFunctor.kt
@@ -442,5 +442,5 @@ fun <B, A : B> Kind<ForNonEmptyList, A>.widen(): NonEmptyList<B> =
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("Functor typeclasses is deprecated. Use concrete methods on NonEmptyList")
+@Deprecated("Functor typeclass is deprecated. Use concrete methods on NonEmptyList")
 inline fun Companion.functor(): NonEmptyListFunctor = functor_singleton as arrow.core.extensions.NonEmptyListFunctor

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/hash/NonEmptyListHash.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/hash/NonEmptyListHash.kt
@@ -4,10 +4,6 @@ import arrow.core.NonEmptyList
 import arrow.core.NonEmptyList.Companion
 import arrow.core.extensions.NonEmptyListHash
 import arrow.typeclasses.Hash
-import kotlin.Deprecated
-import kotlin.Int
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 @JvmName("hash")
 @Suppress(
@@ -19,8 +15,8 @@ import kotlin.jvm.JvmName
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "hash(HA)",
-  "arrow.core.hash"
+    "this.hash(HA)",
+    "arrow.core.hash"
   ),
   DeprecationLevel.WARNING
 )
@@ -31,6 +27,14 @@ fun <A> NonEmptyList<A>.hash(HA: Hash<A>): Int = arrow.core.NonEmptyList.hash<A>
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "@extension kinded projected functions are deprecated",
+  ReplaceWith(
+    "Hash.nonEmptyList(HA)",
+    "arrow.core.nonEmptyList", "arrow.typeclasses.Hash"
+  ),
+  DeprecationLevel.WARNING
 )
 inline fun <A> Companion.hash(HA: Hash<A>): NonEmptyListHash<A> = object :
     arrow.core.extensions.NonEmptyListHash<A> { override fun HA(): arrow.typeclasses.Hash<A> = HA }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/hash/NonEmptyListHash.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/hash/NonEmptyListHash.kt
@@ -15,7 +15,7 @@ import arrow.typeclasses.Hash
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.hash(HA)",
+    "hash(HA)",
     "arrow.core.hash"
   ),
   DeprecationLevel.WARNING

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/monad/NonEmptyListMonad.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/monad/NonEmptyListMonad.kt
@@ -405,5 +405,5 @@ fun <A, B> Kind<ForNonEmptyList, Either<A, B>>.select(arg1: Kind<ForNonEmptyList
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("Monad typeclasses is deprecated. Use concrete methods on NonEmptyList")
+@Deprecated("Monad typeclass is deprecated. Use concrete methods on NonEmptyList")
 inline fun Companion.monad(): NonEmptyListMonad = monad_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/monad/NonEmptyListMonad.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/monad/NonEmptyListMonad.kt
@@ -33,7 +33,7 @@ internal val monad_singleton: NonEmptyListMonad = object : arrow.core.extensions
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "this.fix().flatMap<B>(arg1)",
+  "fix().flatMap<B>(arg1)",
     "arrow.core.fix", "arrow.core.flatMap"
   ),
   DeprecationLevel.WARNING
@@ -73,7 +73,7 @@ fun <A, B> tailRecM(arg0: A, arg1: Function1<A, Kind<ForNonEmptyList, Either<A, 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().map<B>(arg1)",
+    "fix().map<B>(arg1)",
     "arrow.core.fix", "arrow.core.map"
   ),
   DeprecationLevel.WARNING
@@ -96,7 +96,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.map(arg1: Function1<A, B>): NonEmptyList<B> 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().ap<B>(arg1)",
+    "fix().ap<B>(arg1)",
     "arrow.core.fix", "arrow.core.ap"
   ),
   DeprecationLevel.WARNING
@@ -116,7 +116,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.ap(arg1: Kind<ForNonEmptyList, Function1<A, 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "this.fix<Kind<ForNonEmptyList, A>>().map<NonEmptyList<A>> { it.fix() }.flatten<A>()",
+  "fix<Kind<ForNonEmptyList, A>>().map<NonEmptyList<A>> { it.fix() }.flatten<A>()",
   "arrow.core.fix", "arrow.core.flatten"
   ),
   DeprecationLevel.WARNING
@@ -136,7 +136,7 @@ fun <A> Kind<ForNonEmptyList, Kind<ForNonEmptyList, A>>.flatten(): NonEmptyList<
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "this.fix().flatMap { arg1 }",
+  "fix().flatMap { arg1 }",
   "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -156,7 +156,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.followedBy(arg1: Kind<ForNonEmptyList, B>): 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().flatMap { a -> arg1.fix().map { a } }",
+    "fix().flatMap { a -> arg1.fix().map { a } }",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -176,7 +176,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.apTap(arg1: Kind<ForNonEmptyList, B>): NonEm
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().flatMap { arg1.value() }",
+    "fix().flatMap { arg1.value() }",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -196,7 +196,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.followedByEval(arg1: Eval<Kind<ForNonEmptyLi
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().flatMap { a -> arg1(a).fix().map { a } }",
+    "fix().flatMap { a -> arg1(a).fix().map { a } }",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -216,7 +216,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.effectM(arg1: Function1<A, Kind<ForNonEmptyL
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().flatMap { a -> arg1(a).fix().map { a } }",
+    "fix().flatMap { a -> arg1(a).fix().map { a } }",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -236,7 +236,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.flatTap(arg1: Function1<A, Kind<ForNonEmptyL
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().flatMap { a -> arg1.fix().map { a } }",
+    "fix().flatMap { a -> arg1.fix().map { a } }",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -256,7 +256,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.productL(arg1: Kind<ForNonEmptyList, B>): No
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().flatMap { a -> arg1.fix().map { a } }",
+    "fix().flatMap { a -> arg1.fix().map { a } }",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -276,7 +276,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.forEffect(arg1: Kind<ForNonEmptyList, B>): N
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().flatMap { a -> arg1.value().fix().map { a } }",
+    "fix().flatMap { a -> arg1.value().fix().map { a } }",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -296,7 +296,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.productLEval(arg1: Eval<Kind<ForNonEmptyList
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().flatMap { a -> arg1.value().fix().map { a } }",
+    "fix().flatMap { a -> arg1.value().fix().map { a } }",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -316,7 +316,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.forEffectEval(arg1: Eval<Kind<ForNonEmptyLis
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix().flatMap<Tuple2<A, B>> { a -> arg1(a).fix<B>().map<Tuple2<A, B>> { Tuple2<A, B>(a, it) } }",
+    "fix().flatMap<Tuple2<A, B>> { a -> arg1(a).fix<B>().map<Tuple2<A, B>> { Tuple2<A, B>(a, it) } }",
     "arrow.core.Tuple2", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -336,7 +336,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.mproduct(arg1: Function1<A, Kind<ForNonEmpty
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "this.fix().ifM<B>(arg1.fix(), arg2.fix())",
+  "fix().ifM<B>(arg1.fix(), arg2.fix())",
   "arrow.core.fix", "arrow.core.ifM"
   ),
   DeprecationLevel.WARNING
@@ -359,7 +359,7 @@ fun <B> Kind<ForNonEmptyList, Boolean>.ifM(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix<Either<A, B>>().selectM<A, B>(arg1.fix<(A) -> B>())",
+    "fix<Either<A, B>>().selectM<A, B>(arg1.fix<(A) -> B>())",
     "arrow.core.fix", "arrow.core.selectM"
   ),
   DeprecationLevel.WARNING
@@ -380,7 +380,7 @@ fun <A, B> Kind<ForNonEmptyList, Either<A, B>>.selectM(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix<Either<A, B>>().selectM<A, B>(arg1.fix<(A) -> B>())",
+    "fix<Either<A, B>>().selectM<A, B>(arg1.fix<(A) -> B>())",
     "arrow.core.fix", "arrow.core.selectM"
   ),
   DeprecationLevel.WARNING

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/monad/NonEmptyListMonad.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/monad/NonEmptyListMonad.kt
@@ -405,5 +405,5 @@ fun <A, B> Kind<ForNonEmptyList, Either<A, B>>.select(arg1: Kind<ForNonEmptyList
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("Monad typeclasses is deprecated. Use concrete methods on List")
+@Deprecated("Monad typeclasses is deprecated. Use concrete methods on NonEmptyList")
 inline fun Companion.monad(): NonEmptyListMonad = monad_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/monad/NonEmptyListMonad.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/monad/NonEmptyListMonad.kt
@@ -33,8 +33,8 @@ internal val monad_singleton: NonEmptyListMonad = object : arrow.core.extensions
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "flatMap(arg1)",
-  "arrow.core.flatMap"
+  "this.fix().flatMap<B>(arg1)",
+    "arrow.core.fix", "arrow.core.flatMap"
   ),
   DeprecationLevel.WARNING
 )
@@ -53,8 +53,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.flatMap(arg1: Function1<A, Kind<ForNonEmptyL
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tailRecM(arg0, arg1)",
-  "arrow.core.NonEmptyList.tailRecM"
+  "NonEmptyList.tailRecM(arg0) { arg1(it) }",
+  "arrow.core.NonEmptyList"
   ),
   DeprecationLevel.WARNING
 )
@@ -73,8 +73,8 @@ fun <A, B> tailRecM(arg0: A, arg1: Function1<A, Kind<ForNonEmptyList, Either<A, 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg1)",
-  "arrow.core.map"
+    "this.fix().map<B>(arg1)",
+    "arrow.core.fix", "arrow.core.map"
   ),
   DeprecationLevel.WARNING
 )
@@ -96,8 +96,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.map(arg1: Function1<A, B>): NonEmptyList<B> 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "ap(arg1)",
-  "arrow.core.ap"
+    "this.fix().ap<B>(arg1)",
+    "arrow.core.fix", "arrow.core.ap"
   ),
   DeprecationLevel.WARNING
 )
@@ -116,8 +116,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.ap(arg1: Kind<ForNonEmptyList, Function1<A, 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "flatten()",
-  "arrow.core.flatten"
+  "this.fix<Kind<ForNonEmptyList, A>>().map<NonEmptyList<A>> { it.fix() }.flatten<A>()",
+  "arrow.core.fix", "arrow.core.flatten"
   ),
   DeprecationLevel.WARNING
 )
@@ -136,8 +136,8 @@ fun <A> Kind<ForNonEmptyList, Kind<ForNonEmptyList, A>>.flatten(): NonEmptyList<
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "followedBy(arg1)",
-  "arrow.core.followedBy"
+  "this.fix().flatMap { arg1 }",
+  "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -156,8 +156,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.followedBy(arg1: Kind<ForNonEmptyList, B>): 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "apTap(arg1)",
-  "arrow.core.apTap"
+    "this.fix().flatMap { a -> arg1.fix().map { a } }",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -176,8 +176,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.apTap(arg1: Kind<ForNonEmptyList, B>): NonEm
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "followedByEval(arg1)",
-  "arrow.core.followedByEval"
+    "this.fix().flatMap { arg1.value() }",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -196,8 +196,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.followedByEval(arg1: Eval<Kind<ForNonEmptyLi
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "effectM(arg1)",
-  "arrow.core.effectM"
+    "this.fix().flatMap { a -> arg1(a).fix().map { a } }",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -216,8 +216,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.effectM(arg1: Function1<A, Kind<ForNonEmptyL
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "flatTap(arg1)",
-  "arrow.core.flatTap"
+    "this.fix().flatMap { a -> arg1(a).fix().map { a } }",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -236,8 +236,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.flatTap(arg1: Function1<A, Kind<ForNonEmptyL
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "productL(arg1)",
-  "arrow.core.productL"
+    "this.fix().flatMap { a -> arg1.fix().map { a } }",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -256,8 +256,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.productL(arg1: Kind<ForNonEmptyList, B>): No
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "forEffect(arg1)",
-  "arrow.core.forEffect"
+    "this.fix().flatMap { a -> arg1.fix().map { a } }",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -276,8 +276,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.forEffect(arg1: Kind<ForNonEmptyList, B>): N
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "productLEval(arg1)",
-  "arrow.core.productLEval"
+    "this.fix().flatMap { a -> arg1.value().fix().map { a } }",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -296,8 +296,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.productLEval(arg1: Eval<Kind<ForNonEmptyList
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "forEffectEval(arg1)",
-  "arrow.core.forEffectEval"
+    "this.fix().flatMap { a -> arg1.value().fix().map { a } }",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -316,8 +316,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.forEffectEval(arg1: Eval<Kind<ForNonEmptyLis
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mproduct(arg1)",
-  "arrow.core.mproduct"
+    "this.fix().flatMap<Tuple2<A, B>> { a -> arg1(a).fix<B>().map<Tuple2<A, B>> { Tuple2<A, B>(a, it) } }",
+    "arrow.core.Tuple2", "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -336,8 +336,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.mproduct(arg1: Function1<A, Kind<ForNonEmpty
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "ifM(arg1, arg2)",
-  "arrow.core.ifM"
+  "this.fix().ifM<B>(arg1.fix(), arg2.fix())",
+  "arrow.core.fix", "arrow.core.ifM"
   ),
   DeprecationLevel.WARNING
 )
@@ -359,8 +359,8 @@ fun <B> Kind<ForNonEmptyList, Boolean>.ifM(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "selectM(arg1)",
-  "arrow.core.selectM"
+    "this.fix<Either<A, B>>().selectM<A, B>(arg1.fix<(A) -> B>())",
+    "arrow.core.fix", "arrow.core.selectM"
   ),
   DeprecationLevel.WARNING
 )
@@ -380,8 +380,8 @@ fun <A, B> Kind<ForNonEmptyList, Either<A, B>>.selectM(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "select(arg1)",
-  "arrow.core.select"
+    "this.fix<Either<A, B>>().selectM<A, B>(arg1.fix<(A) -> B>())",
+    "arrow.core.fix", "arrow.core.selectM"
   ),
   DeprecationLevel.WARNING
 )
@@ -407,4 +407,5 @@ fun <A, B> Kind<ForNonEmptyList, Either<A, B>>.select(arg1: Kind<ForNonEmptyList
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("Monad typeclasses is deprecated. Use concrete methods on List")
 inline fun Companion.monad(): NonEmptyListMonad = monad_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/order/NonEmptyListOrder.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/order/NonEmptyListOrder.kt
@@ -195,6 +195,14 @@ fun <A> NonEmptyList<A>.sort(OA: Order<A>, arg1: NonEmptyList<A>): Tuple2<NonEmp
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated(
+  "@extension projected functions are deprecated",
+  ReplaceWith(
+    "Order.nonEmptyList(OA)",
+    "arrow.core.nonEmptyList", "arrow.core.Order"
+  ),
+  DeprecationLevel.WARNING
+)
 inline fun <A> Companion.order(OA: Order<A>): NonEmptyListOrder<A> = object :
     arrow.core.extensions.NonEmptyListOrder<A> { override fun OA(): arrow.typeclasses.Order<A> = OA
     }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/semialign/NonEmptyListSemialign.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/semialign/NonEmptyListSemialign.kt
@@ -33,8 +33,8 @@ internal val semialign_singleton: NonEmptyListSemialign = object :
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "align(arg0, arg1)",
-  "arrow.core.NonEmptyList.align"
+  "arg0.fix().align(arg1.fix())",
+  "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -53,8 +53,8 @@ fun <A, B> align(arg0: Kind<ForNonEmptyList, A>, arg1: Kind<ForNonEmptyList, B>)
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "alignWith(arg0, arg1, arg2)",
-  "arrow.core.NonEmptyList.alignWith"
+    "arg0.fix().align(arg1.fix()).map(arg2)",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -76,8 +76,8 @@ fun <A, B, C> alignWith(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "salign(arg1, arg2)",
-  "arrow.core.salign"
+  "fix().salign(arg1, arg2.fix())",
+  "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -96,8 +96,8 @@ fun <A> Kind<ForNonEmptyList, A>.salign(arg1: Semigroup<A>, arg2: Kind<ForNonEmp
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "padZip(arg1)",
-  "arrow.core.padZip"
+  "fix().padZip(arg1.fix())",
+  "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -117,8 +117,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.padZip(arg1: Kind<ForNonEmptyList, B>):
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "padZipWith(arg1, arg2)",
-  "arrow.core.padZipWith"
+    "fix().padZip(arg1.fix()).map(arg2)",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -134,4 +134,5 @@ fun <A, B, C> Kind<ForNonEmptyList, A>.padZipWith(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("Semialign typeclasses is deprecated. Use concrete methods on NonEmptyList")
 inline fun Companion.semialign(): NonEmptyListSemialign = semialign_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/semialign/NonEmptyListSemialign.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/semialign/NonEmptyListSemialign.kt
@@ -134,5 +134,5 @@ fun <A, B, C> Kind<ForNonEmptyList, A>.padZipWith(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("Semialign typeclasses is deprecated. Use concrete methods on NonEmptyList")
+@Deprecated("Semialign typeclass is deprecated. Use concrete methods on NonEmptyList")
 inline fun Companion.semialign(): NonEmptyListSemialign = semialign_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/semigroup/NonEmptyListSemigroup.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/semigroup/NonEmptyListSemigroup.kt
@@ -26,7 +26,7 @@ internal val semigroup_singleton: NonEmptyListSemigroup<Any?> = object : NonEmpt
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "plus(arg1)",
+  "this.plus(arg1)",
   "arrow.core.plus"
   ),
   DeprecationLevel.WARNING
@@ -46,8 +46,8 @@ operator fun <A> NonEmptyList<A>.plus(arg1: NonEmptyList<A>): NonEmptyList<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "maybeCombine(arg1)",
-  "arrow.core.maybeCombine"
+  "(arg1?.let { this.plus(it) } ?: this)",
+  "arrow.core.plus"
   ),
   DeprecationLevel.WARNING
 )
@@ -59,6 +59,14 @@ fun <A> NonEmptyList<A>.maybeCombine(arg1: NonEmptyList<A>): NonEmptyList<A> =
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "@extension projected functions are deprecated",
+  ReplaceWith(
+    "Semigroup.nonEmptyList<A>()",
+    "arrow.core.Semigroup", "arrow.core.nonEmptyList"
+  ),
+  DeprecationLevel.WARNING
 )
 inline fun <A> Companion.semigroup(): NonEmptyListSemigroup<A> = semigroup_singleton as
     arrow.core.extensions.NonEmptyListSemigroup<A>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/semigroup/NonEmptyListSemigroup.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/semigroup/NonEmptyListSemigroup.kt
@@ -26,7 +26,7 @@ internal val semigroup_singleton: NonEmptyListSemigroup<Any?> = object : NonEmpt
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "this.plus(arg1)",
+  "plus(arg1)",
   "arrow.core.plus"
   ),
   DeprecationLevel.WARNING

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/semigroupK/NonEmptyListSemigroupK.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/semigroupK/NonEmptyListSemigroupK.kt
@@ -61,4 +61,5 @@ fun <A> algebra(): Semigroup<Kind<ForNonEmptyList, A>> = arrow.core.NonEmptyList
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
 inline fun Companion.semigroupK(): NonEmptyListSemigroupK = semigroupK_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/semigroupK/NonEmptyListSemigroupK.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/semigroupK/NonEmptyListSemigroupK.kt
@@ -28,8 +28,8 @@ internal val semigroupK_singleton: NonEmptyListSemigroupK = object :
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "combineK(arg1)",
-  "arrow.core.combineK"
+  "fix().plus(arg1.fix())",
+  "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -48,8 +48,8 @@ fun <A> Kind<ForNonEmptyList, A>.combineK(arg1: Kind<ForNonEmptyList, A>): NonEm
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "algebra()",
-  "arrow.core.NonEmptyList.algebra"
+  "Semigroup.nonEmptyList<A>()",
+  "arrow.core.nonEmptyList", "arrow.typeclasses.Semigroup"
   ),
   DeprecationLevel.WARNING
 )

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/show/NonEmptyListShow.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/show/NonEmptyListShow.kt
@@ -9,5 +9,13 @@ import kotlin.Suppress
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated(
+  "@extension projected functions are deprecated",
+  ReplaceWith(
+    "Show.nonEmptyList(SA)",
+    "arrow.core.nonEmptyList", "arrow.core.Show"
+  ),
+  DeprecationLevel.WARNING
+)
 inline fun <A> Companion.show(SA: Show<A>): NonEmptyListShow<A> = object :
     arrow.core.extensions.NonEmptyListShow<A> { override fun SA(): arrow.typeclasses.Show<A> = SA }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/traverse/NonEmptyListTraverse.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/traverse/NonEmptyListTraverse.kt
@@ -65,7 +65,7 @@ fun <G, A> Kind<ForNonEmptyList, Kind<G, A>>.sequence(arg1: Applicative<G>): Kin
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "this.fix().map(arg1)",
+  "fix().map(arg1)",
   "arrow.core.fix"
   ),
   DeprecationLevel.WARNING

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/traverse/NonEmptyListTraverse.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/traverse/NonEmptyListTraverse.kt
@@ -99,5 +99,5 @@ fun <G, A, B> Kind<ForNonEmptyList, A>.flatTraverse(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("Traverse typeclasses is deprecated. Use concrete methods on NonEmptyList")
+@Deprecated("Traverse typeclass is deprecated. Use concrete methods on NonEmptyList")
 inline fun Companion.traverse(): NonEmptyListTraverse = traverse_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/traverse/NonEmptyListTraverse.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/traverse/NonEmptyListTraverse.kt
@@ -28,12 +28,8 @@ internal val traverse_singleton: NonEmptyListTraverse = object :
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "traverse(arg1, arg2)",
-  "arrow.core.traverse"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated, Replace with traverseEither or traverseValidated from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <G, A, B> Kind<ForNonEmptyList, A>.traverse(
   arg1: Applicative<G>,
@@ -51,12 +47,8 @@ fun <G, A, B> Kind<ForNonEmptyList, A>.traverse(
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "sequence(arg1)",
-  "arrow.core.sequence"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated. Replace with sequenceEither or sequenceValidated from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <G, A> Kind<ForNonEmptyList, Kind<G, A>>.sequence(arg1: Applicative<G>): Kind<G,
     Kind<ForNonEmptyList, A>> = arrow.core.NonEmptyList.traverse().run {
@@ -73,8 +65,8 @@ fun <G, A> Kind<ForNonEmptyList, Kind<G, A>>.sequence(arg1: Applicative<G>): Kin
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg1)",
-  "arrow.core.map"
+  "this.fix().map(arg1)",
+  "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -91,12 +83,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.map(arg1: Function1<A, B>): NonEmptyList<B> 
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "flatTraverse(arg1, arg2, arg3)",
-  "arrow.core.flatTraverse"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated. Replace with flatTraverseEither or flatTraverseValidated from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <G, A, B> Kind<ForNonEmptyList, A>.flatTraverse(
   arg1: Monad<ForNonEmptyList>,
@@ -111,4 +99,5 @@ fun <G, A, B> Kind<ForNonEmptyList, A>.flatTraverse(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("Traverse typeclasses is deprecated. Use concrete methods on Iterable")
 inline fun Companion.traverse(): NonEmptyListTraverse = traverse_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/traverse/NonEmptyListTraverse.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/traverse/NonEmptyListTraverse.kt
@@ -99,5 +99,5 @@ fun <G, A, B> Kind<ForNonEmptyList, A>.flatTraverse(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("Traverse typeclasses is deprecated. Use concrete methods on Iterable")
+@Deprecated("Traverse typeclasses is deprecated. Use concrete methods on NonEmptyList")
 inline fun Companion.traverse(): NonEmptyListTraverse = traverse_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/unzip/NonEmptyListUnzip.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/unzip/NonEmptyListUnzip.kt
@@ -66,4 +66,7 @@ fun <A, B, C> Kind<ForNonEmptyList, C>.unzipWith(arg1: Function1<C, Tuple2<A, B>
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated(
+  "Unzip typeclass is deprecated. Use concrete methods on NonEmptyList",
+  level = DeprecationLevel.WARNING)
 inline fun Companion.unzip(): NonEmptyListUnzip = unzip_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/unzip/NonEmptyListUnzip.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/unzip/NonEmptyListUnzip.kt
@@ -28,8 +28,8 @@ internal val unzip_singleton: NonEmptyListUnzip = object : arrow.core.extensions
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "unzip()",
-  "arrow.core.unzip"
+  "this.fix<Tuple2<A, B>>().unzip<A, B>()",
+    "arrow.core.Tuple2", "arrow.core.fix", "arrow.core.unzip"
   ),
   DeprecationLevel.WARNING
 )
@@ -49,8 +49,8 @@ fun <A, B> Kind<ForNonEmptyList, Tuple2<A, B>>.unzip(): Tuple2<Kind<ForNonEmptyL
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "unzipWith(arg1)",
-  "arrow.core.unzipWith"
+    "this.fix<C>().unzipWith<A, B, C>(arg1)",
+    "arrow.core.fix", "arrow.core.unzipWith"
   ),
   DeprecationLevel.WARNING
 )

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/unzip/NonEmptyListUnzip.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/unzip/NonEmptyListUnzip.kt
@@ -28,7 +28,7 @@ internal val unzip_singleton: NonEmptyListUnzip = object : arrow.core.extensions
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "this.fix<Tuple2<A, B>>().unzip<A, B>()",
+  "fix<Tuple2<A, B>>().unzip<A, B>()",
     "arrow.core.Tuple2", "arrow.core.fix", "arrow.core.unzip"
   ),
   DeprecationLevel.WARNING
@@ -49,7 +49,7 @@ fun <A, B> Kind<ForNonEmptyList, Tuple2<A, B>>.unzip(): Tuple2<Kind<ForNonEmptyL
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "this.fix<C>().unzipWith<A, B, C>(arg1)",
+    "fix<C>().unzipWith<A, B, C>(arg1)",
     "arrow.core.fix", "arrow.core.unzipWith"
   ),
   DeprecationLevel.WARNING

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/zip/NonEmptyListZip.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/zip/NonEmptyListZip.kt
@@ -64,5 +64,5 @@ fun <A, B, C> Kind<ForNonEmptyList, A>.zipWith(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("Zip typeclasses is deprecated. Use concrete methods on NonEmptyList")
+@Deprecated("Zip typeclass is deprecated. Use concrete methods on NonEmptyList")
 inline fun Companion.zip(): NonEmptyListZip = zip_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/zip/NonEmptyListZip.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/zip/NonEmptyListZip.kt
@@ -28,7 +28,7 @@ internal val zip_singleton: NonEmptyListZip = object : arrow.core.extensions.Non
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "this.fix().zip<B>(arg1.fix())",
+  "fix().zip<B>(arg1.fix())",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
@@ -48,7 +48,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.zip(arg1: Kind<ForNonEmptyList, B>): NonEmpt
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "this.fix().zipWith<B>(arg1.fix(), arg2)",
+  "fix().zipWith<B>(arg1.fix(), arg2)",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/zip/NonEmptyListZip.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/zip/NonEmptyListZip.kt
@@ -48,7 +48,7 @@ fun <A, B> Kind<ForNonEmptyList, A>.zip(arg1: Kind<ForNonEmptyList, B>): NonEmpt
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "fix().zipWith<B>(arg1.fix(), arg2)",
+  "fix().zip<B>(arg1.fix(), arg2)",
     "arrow.core.fix"
   ),
   DeprecationLevel.WARNING

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/zip/NonEmptyListZip.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/zip/NonEmptyListZip.kt
@@ -64,5 +64,5 @@ fun <A, B, C> Kind<ForNonEmptyList, A>.zipWith(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("Zip typeclasses is deprecated. Use concrete methods on Iterable")
+@Deprecated("Zip typeclasses is deprecated. Use concrete methods on NonEmptyList")
 inline fun Companion.zip(): NonEmptyListZip = zip_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/zip/NonEmptyListZip.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/zip/NonEmptyListZip.kt
@@ -28,8 +28,8 @@ internal val zip_singleton: NonEmptyListZip = object : arrow.core.extensions.Non
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "zip(arg1)",
-  "arrow.core.zip"
+  "this.fix().zip<B>(arg1.fix())",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -48,8 +48,8 @@ fun <A, B> Kind<ForNonEmptyList, A>.zip(arg1: Kind<ForNonEmptyList, B>): NonEmpt
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "zipWith(arg1, arg2)",
-  "arrow.core.zipWith"
+  "this.fix().zipWith<B>(arg1.fix(), arg2)",
+    "arrow.core.fix"
   ),
   DeprecationLevel.WARNING
 )
@@ -64,4 +64,5 @@ fun <A, B, C> Kind<ForNonEmptyList, A>.zipWith(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("Zip typeclasses is deprecated. Use concrete methods on Iterable")
 inline fun Companion.zip(): NonEmptyListZip = zip_singleton


### PR DESCRIPTION
- [x] Applicative
- [x] Apply
- [x] Bimonad
- [x] Comonad
- [x] Eq (EqK)
- [x] Foldable
- [x] Functor
- [x] Hash
- [x] Monad
- [x] Order
- [x] Semialign
- [x] Semigroup (SemigroupK)
- [x] Show
- [x] Traverse
- [x] Unzip
- [x] Zip