### PR TITLE
Fix incorrect package new instances

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/boolean.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/boolean.kt
@@ -1,0 +1,45 @@
+package arrow.core
+
+import arrow.typeclasses.Eq
+import arrow.typeclasses.Hash
+import arrow.typeclasses.Monoid
+import arrow.typeclasses.Order
+import arrow.typeclasses.Show
+
+private object BooleanShow : Show<Boolean> {
+  override fun Boolean.show(): String =
+    this.toString()
+}
+
+private object BooleanEq : Eq<Boolean> {
+  override fun Boolean.eqv(b: Boolean): Boolean = this == b
+}
+
+private object BooleanOrder : Order<Boolean> {
+  override fun Boolean.compare(b: Boolean): Ordering = Ordering.fromInt(this.compareTo(b))
+  override fun Boolean.compareTo(b: Boolean): Int = this.compareTo(b)
+}
+
+private object BooleanHash : Hash<Boolean> {
+  override fun Boolean.hash(): Int = this.hashCode()
+}
+
+fun Show.Companion.boolean(): Show<Boolean> =
+  BooleanShow
+
+fun Eq.Companion.boolean(): Eq<Boolean> =
+  BooleanEq
+
+fun Order.Companion.boolean(): Order<Boolean> =
+  BooleanOrder
+
+fun Hash.Companion.boolean(): Hash<Boolean> =
+  BooleanHash
+
+private object AndMonoid : Monoid<Boolean> {
+  override fun Boolean.combine(b: Boolean): Boolean = this && b
+  override fun empty(): Boolean = true
+}
+
+fun Monoid.Companion.boolean(): Monoid<Boolean> =
+  AndMonoid

--- a/arrow-core-data/src/main/kotlin/arrow/core/char.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/char.kt
@@ -1,0 +1,39 @@
+package arrow.core
+
+import arrow.typeclasses.Eq
+import arrow.typeclasses.Hash
+import arrow.typeclasses.Order
+import arrow.typeclasses.Show
+
+private object CharShow : Show<Char> {
+  override fun Char.show(): String =
+    this.toString()
+}
+
+private object CharEq : Eq<Char> {
+  override fun Char.eqv(b: Char): Boolean = this == b
+}
+
+private object CharOrder : Order<Char> {
+  override fun Char.compare(b: Char): Ordering =
+    Ordering.fromInt(this.compareTo(b))
+
+  override fun Char.compareTo(b: Char): Int =
+    this.compareTo(b)
+}
+
+private object CharHash : Hash<Char> {
+  override fun Char.hash(): Int = this.hashCode()
+}
+
+fun Show.Companion.char(): Show<Char> =
+  CharShow
+
+fun Eq.Companion.char(): Eq<Char> =
+  CharEq
+
+fun Order.Companion.char(): Order<Char> =
+  CharOrder
+
+fun Hash.Companion.char(): Hash<Char> =
+  CharHash

--- a/arrow-core-data/src/main/kotlin/arrow/core/number.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/number.kt
@@ -1,0 +1,357 @@
+package arrow.core
+
+import arrow.typeclasses.Eq
+import arrow.typeclasses.Hash
+import arrow.typeclasses.Monoid
+import arrow.typeclasses.Order
+import arrow.typeclasses.Semigroup
+import arrow.typeclasses.Semiring
+import arrow.typeclasses.Show
+
+// ////////
+// Byte
+// ////////
+private object ByteSemigroup : Semigroup<Byte> {
+  override fun Byte.combine(b: Byte): Byte = (this + b).toByte()
+}
+
+private object ByteMonoid : Monoid<Byte> {
+  override fun empty(): Byte = 0
+  override fun Byte.combine(b: Byte): Byte = (this + b).toByte()
+}
+
+private object ByteSemiring : Semiring<Byte> {
+  override fun one(): Byte = 1
+  override fun zero(): Byte = 0
+
+  override fun Byte.combine(b: Byte): Byte = (this + b).toByte()
+  override fun Byte.combineMultiplicate(b: Byte): Byte = (this * b).toByte()
+}
+
+private object ByteOrder : Order<Byte> {
+  override fun Byte.compare(b: Byte): Ordering = Ordering.fromInt(this.compareTo(b))
+  override fun Byte.compareTo(b: Byte): Int = this.compareTo(b)
+}
+
+private object ByteEq : Eq<Byte> {
+  override fun Byte.eqv(b: Byte): Boolean = this == b
+}
+
+private object ByteShow : Show<Byte> {
+  override fun Byte.show(): String = toString()
+}
+
+private object ByteHash : Hash<Byte> {
+  override fun Byte.hash(): Int = hashCode()
+}
+
+fun Hash.Companion.byte(): Hash<Byte> =
+  ByteHash
+
+fun Show.Companion.byte(): Show<Byte> =
+  ByteShow
+
+fun Eq.Companion.byte(): Eq<Byte> =
+  ByteEq
+
+fun Order.Companion.byte(): Order<Byte> =
+  ByteOrder
+
+fun Semigroup.Companion.byte(): Semigroup<Byte> =
+  ByteSemigroup
+
+fun Monoid.Companion.byte(): Monoid<Byte> =
+  ByteMonoid
+
+fun Semiring.Companion.byte(): Semiring<Byte> =
+  ByteSemiring
+
+// ////////
+// Double
+// ////////
+private object DoubleSemigroup : Semigroup<Double> {
+  override fun Double.combine(b: Double): Double = this + b
+}
+
+private object DoubleMonoid : Monoid<Double> {
+  override fun empty(): Double = .0
+  override fun Double.combine(b: Double): Double = this + b
+}
+
+private object DoubleSemiring : Semiring<Double> {
+  override fun one(): Double = 1.0
+  override fun zero(): Double = 0.0
+
+  override fun Double.combine(b: Double): Double = this + b
+  override fun Double.combineMultiplicate(b: Double): Double = this * b
+}
+
+private object DoubleOrder : Order<Double> {
+  override fun Double.compare(b: Double): Ordering = Ordering.fromInt(this.compareTo(b))
+  override fun Double.compareTo(b: Double): Int = this.compareTo(b)
+}
+
+private object DoubleEq : Eq<Double> {
+  override fun Double.eqv(b: Double): Boolean = this == b
+}
+
+private object DoubleShow : Show<Double> {
+  override fun Double.show(): String = toString()
+}
+
+private object DoubleHash : Hash<Double> {
+  override fun Double.hash(): Int = hashCode()
+}
+
+fun Hash.Companion.double(): Hash<Double> =
+  DoubleHash
+
+fun Show.Companion.double(): Show<Double> =
+  DoubleShow
+
+fun Eq.Companion.double(): Eq<Double> =
+  DoubleEq
+
+fun Order.Companion.double(): Order<Double> =
+  DoubleOrder
+
+fun Semigroup.Companion.double(): Semigroup<Double> =
+  DoubleSemigroup
+
+fun Monoid.Companion.double(): Monoid<Double> =
+  DoubleMonoid
+
+fun Semiring.Companion.double(): Semiring<Double> =
+  DoubleSemiring
+
+// ////////
+// Int
+// ////////
+private object IntSemigroup : Semigroup<Int> {
+  override fun Int.combine(b: Int): Int = this + b
+}
+
+private object IntMonoid : Monoid<Int> {
+  override fun empty(): Int = 0
+  override fun Int.combine(b: Int): Int = this + b
+}
+
+private object IntSemiring : Semiring<Int> {
+  override fun one(): Int = 1
+  override fun zero(): Int = 0
+
+  override fun Int.combine(b: Int): Int = this + b
+  override fun Int.combineMultiplicate(b: Int): Int = this * b
+}
+
+private object IntEq : Eq<Int> {
+  override fun Int.eqv(b: Int): Boolean = this == b
+}
+
+private object IntShow : Show<Int> {
+  override fun Int.show(): String = toString()
+}
+
+private object IntOrder : Order<Int> {
+  override fun Int.compare(b: Int): Ordering = Ordering.fromInt(this.compareTo(b))
+  override fun Int.compareTo(b: Int): Int = this.compareTo(b)
+}
+
+private object IntHash : Hash<Int> {
+  override fun Int.hash(): Int = hashCode()
+}
+
+fun Hash.Companion.int(): Hash<Int> =
+  IntHash
+
+fun Show.Companion.int(): Show<Int> =
+  IntShow
+
+fun Eq.Companion.int(): Eq<Int> =
+  IntEq
+
+fun Order.Companion.int(): Order<Int> =
+  IntOrder
+
+fun Semigroup.Companion.int(): Semigroup<Int> =
+  IntSemigroup
+
+fun Monoid.Companion.int(): Monoid<Int> =
+  IntMonoid
+
+fun Semiring.Companion.int(): Semiring<Int> =
+  IntSemiring
+
+// ////////
+// Long
+// ////////
+private object LongSemigroup : Semigroup<Long> {
+  override fun Long.combine(b: Long): Long = this + b
+}
+
+private object LongMonoid : Monoid<Long> {
+  override fun empty(): Long = 0L
+  override fun Long.combine(b: Long): Long = this + b
+}
+
+private object LongSemiring : Semiring<Long> {
+  override fun one(): Long = 1
+  override fun zero(): Long = 0
+
+  override fun Long.combine(b: Long): Long = this + b
+  override fun Long.combineMultiplicate(b: Long): Long = this * b
+}
+
+private object LongOrder : Order<Long> {
+  override fun Long.compare(b: Long): Ordering = Ordering.fromInt(this.compareTo(b))
+  override fun Long.compareTo(b: Long): Int = this.compareTo(b)
+}
+
+private object LongEq : Eq<Long> {
+  override fun Long.eqv(b: Long): Boolean = this == b
+}
+
+private object LongShow : Show<Long> {
+  override fun Long.show(): String = toString()
+}
+
+private object LongHash : Hash<Long> {
+  override fun Long.hash(): Int = hashCode()
+}
+
+fun Hash.Companion.long(): Hash<Long> =
+  LongHash
+
+fun Show.Companion.long(): Show<Long> =
+  LongShow
+
+fun Eq.Companion.long(): Eq<Long> =
+  LongEq
+
+fun Order.Companion.long(): Order<Long> =
+  LongOrder
+
+fun Semigroup.Companion.long(): Semigroup<Long> =
+  LongSemigroup
+
+fun Monoid.Companion.long(): Monoid<Long> =
+  LongMonoid
+
+fun Semiring.Companion.long(): Semiring<Long> =
+  LongSemiring
+
+// ////////
+// Short
+// ////////
+private object ShortSemigroup : Semigroup<Short> {
+  override fun Short.combine(b: Short): Short = (this + b).toShort()
+}
+
+private object ShortMonoid : Monoid<Short> {
+  override fun empty(): Short = 0
+  override fun Short.combine(b: Short): Short = (this + b).toShort()
+}
+
+private object ShortSemiring : Semiring<Short> {
+  override fun one(): Short = 1
+  override fun zero(): Short = 0
+
+  override fun Short.combine(b: Short): Short = (this + b).toShort()
+  override fun Short.combineMultiplicate(b: Short): Short = (this * b).toShort()
+}
+
+private object ShortOrder : Order<Short> {
+  override fun Short.compare(b: Short): Ordering = Ordering.fromInt(this.compareTo(b))
+  override fun Short.compareTo(b: Short): Int = this.compareTo(b)
+}
+
+private object ShortEq : Eq<Short> {
+  override fun Short.eqv(b: Short): Boolean = this == b
+}
+
+private object ShortShow : Show<Short> {
+  override fun Short.show(): String = toString()
+}
+
+private object ShortHash : Hash<Short> {
+  override fun Short.hash(): Int = hashCode()
+}
+
+fun Hash.Companion.short(): Hash<Short> =
+  ShortHash
+
+fun Show.Companion.short(): Show<Short> =
+  ShortShow
+
+fun Eq.Companion.short(): Eq<Short> =
+  ShortEq
+
+fun Order.Companion.short(): Order<Short> =
+  ShortOrder
+
+fun Semigroup.Companion.short(): Semigroup<Short> =
+  ShortSemigroup
+
+fun Monoid.Companion.short(): Monoid<Short> =
+  ShortMonoid
+
+fun Semiring.Companion.short(): Semiring<Short> =
+  ShortSemiring
+
+// ////////
+// Float
+// ////////
+private object FloatSemigroup : Semigroup<Float> {
+  override fun Float.combine(b: Float): Float = this + b
+}
+
+private object FloatMonoid : Monoid<Float> {
+  override fun empty(): Float = 0f
+  override fun Float.combine(b: Float): Float = this + b
+}
+
+private object FloatSemiring : Semiring<Float> {
+  override fun one(): Float = 1f
+  override fun zero(): Float = 0f
+
+  override fun Float.combine(b: Float): Float = this + b
+  override fun Float.combineMultiplicate(b: Float): Float = this * b
+}
+
+private object FloatOrder : Order<Float> {
+  override fun Float.compare(b: Float): Ordering = Ordering.fromInt(this.compareTo(b))
+  override fun Float.compareTo(b: Float): Int = this.compareTo(b)
+}
+
+private object FloatEq : Eq<Float> {
+  override fun Float.eqv(b: Float): Boolean = this == b
+}
+
+private object FloatShow : Show<Float> {
+  override fun Float.show(): String = toString()
+}
+
+private object FloatHash : Hash<Float> {
+  override fun Float.hash(): Int = hashCode()
+}
+
+fun Hash.Companion.float(): Hash<Float> =
+  FloatHash
+
+fun Show.Companion.float(): Show<Float> =
+  FloatShow
+
+fun Eq.Companion.float(): Eq<Float> =
+  FloatEq
+
+fun Order.Companion.float(): Order<Float> =
+  FloatOrder
+
+fun Semigroup.Companion.float(): Semigroup<Float> =
+  FloatSemigroup
+
+fun Monoid.Companion.float(): Monoid<Float> =
+  FloatMonoid
+
+fun Semiring.Companion.float(): Semiring<Float> =
+  FloatSemiring

--- a/arrow-core-data/src/main/kotlin/arrow/core/string.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/string.kt
@@ -1,0 +1,59 @@
+package arrow.core
+
+import arrow.typeclasses.Eq
+import arrow.typeclasses.Hash
+import arrow.typeclasses.Monoid
+import arrow.typeclasses.Order
+import arrow.typeclasses.Semigroup
+import arrow.typeclasses.Show
+
+private object StringSemigroup : Semigroup<String> {
+  override fun String.combine(b: String): String = "${this}$b"
+}
+
+fun Semigroup.Companion.string(): Semigroup<String> =
+  StringSemigroup
+
+private object StringMonoid : Monoid<String> {
+  override fun String.combine(b: String): String = "${this}$b"
+  override fun empty(): String = ""
+}
+
+fun Monoid.Companion.string(): Monoid<String> =
+  StringMonoid
+
+private object StringEq : Eq<String> {
+  override fun String.eqv(b: String): Boolean = this == b
+}
+
+fun Eq.Companion.string(): Eq<String> =
+  StringEq
+
+private object StringShow : Show<String> {
+  override fun String.show(): String = "\"${this.escape()}\""
+
+  private fun String.escape(): String =
+    replace("\n", "\\n").replace("\r", "\\r")
+      .replace("\"", "\\\"").replace("\'", "\\\'")
+      .replace("\t", "\\t").replace("\b", "\\b")
+}
+
+fun Show.Companion.string(): Show<String> =
+  StringShow
+
+private object StringOrder : Order<String> {
+  override fun String.compare(b: String): Ordering =
+    Ordering.fromInt(this.compareTo(b))
+
+  override fun String.compareTo(b: String): Int = this.compareTo(b)
+}
+
+fun Order.Companion.string(): Order<String> =
+  StringOrder
+
+private object StringHash : Hash<String> {
+  override fun String.hash(): Int = hashCode()
+}
+
+fun Hash.Companion.string(): Hash<String> =
+  StringHash

--- a/arrow-core-data/src/test/kotlin/arrow/core/BooleanTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/BooleanTest.kt
@@ -1,6 +1,5 @@
 package arrow.core
 
-import arrow.core.extensions.boolean
 import arrow.core.extensions.eq
 import arrow.core.extensions.hash
 import arrow.core.extensions.order

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/boolean.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/boolean.kt
@@ -33,43 +33,20 @@ interface BooleanHash : Hash<Boolean>, BooleanEq {
 fun Boolean.Companion.show(): Show<Boolean> =
   object : BooleanShow {}
 
-private object BooleanShowInstance : BooleanShow
-
-fun Show.Companion.boolean(): Show<Boolean> =
-  BooleanShowInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Eq.boolean()", "arrow.core.Eq", "arrow.core.boolean"))
 fun Boolean.Companion.eq(): Eq<Boolean> =
   object : BooleanEq {}
-
-private object BooleanEqInstance : BooleanEq
-
-fun Eq.Companion.boolean(): Eq<Boolean> =
-  BooleanEqInstance
 
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Order.boolean()", "arrow.core.Order", "arrow.core.boolean"))
 fun Boolean.Companion.order(): Order<Boolean> =
   object : BooleanOrder {}
 
-private object BooleanOrderInstance : BooleanOrder
-
-fun Order.Companion.boolean(): Order<Boolean> =
-  BooleanOrderInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Hash.boolean()", "arrow.core.Hash", "arrow.core.boolean"))
 fun Boolean.Companion.hash(): Hash<Boolean> =
   object : BooleanHash {}
-
-private object BooleanHashInstance : BooleanHash
-
-fun Hash.Companion.boolean(): Hash<Boolean> =
-  BooleanHashInstance
 
 @Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Monoid.boolean()", "arrow.core.Monoid", "arrow.core.boolean"))
 object AndMonoid : Monoid<Boolean> {
   override fun Boolean.combine(b: Boolean): Boolean = this && b
   override fun empty(): Boolean = true
 }
-
-fun Monoid.Companion.boolean(): Monoid<Boolean> =
-  AndMonoid

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/char.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/char.kt
@@ -35,34 +35,14 @@ interface CharHash : Hash<Char>, CharEq {
 fun Char.Companion.show(): Show<Char> =
   object : CharShow {}
 
-private object CharShowInstance : CharShow
-
-fun Show.Companion.char(): Show<Char> =
-  CharShowInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Eq.char()", "arrow.core.Eq", "arrow.core.char"))
 fun Char.Companion.eq(): Eq<Char> =
   object : CharEq {}
-
-private object CharEqInstance : CharEq
-
-fun Eq.Companion.char(): Eq<Char> =
-  CharEqInstance
 
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Order.char()", "arrow.core.Order", "arrow.core.char"))
 fun Char.Companion.order(): Order<Char> =
   object : CharOrder {}
 
-private object CharOrderInstance : CharOrder
-
-fun Order.Companion.char(): Order<Char> =
-  CharOrderInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Hash.char()", "arrow.core.Hash", "arrow.core.char"))
 fun Char.Companion.hash(): Hash<Char> =
   object : CharHash {}
-
-private object CharHashInstance : CharHash
-
-fun Hash.Companion.char(): Hash<Char> =
-  CharHashInstance

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/number.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/number.kt
@@ -56,64 +56,29 @@ interface ByteHash : Hash<Byte>, ByteEq {
 fun Byte.Companion.hash(): Hash<Byte> =
   object : ByteHash {}
 
-private object ByteHashInstance : ByteHash
-
-fun Hash.Companion.byte(): Hash<Byte> =
-  ByteHashInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Show.byte()", "arrow.core.Show", "arrow.core.byte"))
 fun Byte.Companion.show(): Show<Byte> =
   object : ByteShow {}
-
-private object ByteShowInstance : ByteShow
-
-fun Show.Companion.byte(): Show<Byte> =
-  ByteShowInstance
 
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Eq.byte()", "arrow.core.Eq", "arrow.core.byte"))
 fun Byte.Companion.eq(): Eq<Byte> =
   object : ByteEq {}
 
-private object ByteEqInstance : ByteEq
-
-fun Eq.Companion.byte(): Eq<Byte> =
-  ByteEqInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Order.byte()", "arrow.core.Order", "arrow.core.byte"))
 fun Byte.Companion.order(): Order<Byte> =
   object : ByteOrder {}
-
-private object ByteOrderInstance : ByteOrder
-
-fun Order.Companion.byte(): Order<Byte> =
-  ByteOrderInstance
 
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Semigroup.byte()", "arrow.core.Semigroup", "arrow.core.byte"))
 fun Byte.Companion.semigroup(): Semigroup<Byte> =
   object : ByteSemigroup {}
 
-private object ByteSemigroupInstance : ByteSemigroup
-
-fun Semigroup.Companion.byte(): Semigroup<Byte> =
-  ByteSemigroupInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Monoid.byte()", "arrow.core.Monoid", "arrow.core.byte"))
 fun Byte.Companion.monoid(): Monoid<Byte> =
   object : ByteMonoid {}
 
-private object ByteMonoidInstance : ByteMonoid
-
-fun Monoid.Companion.byte(): Monoid<Byte> =
-  ByteMonoidInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Semiring.byte()", "arrow.core.Semiring", "arrow.core.byte"))
 fun Byte.Companion.semiring(): Semiring<Byte> =
   object : ByteSemiring {}
-
-private object ByteSemiringInstance : ByteSemiring
-
-fun Semiring.Companion.byte(): Semiring<Byte> =
-  ByteSemiringInstance
 
 // ////////
 // Double
@@ -122,10 +87,12 @@ fun Semiring.Companion.byte(): Semiring<Byte> =
 interface DoubleSemigroup : Semigroup<Double> {
   override fun Double.combine(b: Double): Double = this + b
 }
+
 @Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Monoid.double()", "arrow.core.Monoid", "arrow.core.double"))
 interface DoubleMonoid : Monoid<Double>, DoubleSemigroup {
   override fun empty(): Double = .0
 }
+
 @Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Semiring.double()", "arrow.core.Semiring", "arrow.core.double"))
 interface DoubleSemiring : Semiring<Double> {
   override fun one(): Double = 1.0
@@ -134,6 +101,7 @@ interface DoubleSemiring : Semiring<Double> {
   override fun Double.combine(b: Double): Double = this + b
   override fun Double.combineMultiplicate(b: Double): Double = this * b
 }
+
 @Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Order.double()", "arrow.core.Order", "arrow.core.double"))
 interface DoubleOrder : Order<Double> {
   override fun Double.compare(b: Double): Ordering = Ordering.fromInt(this.compareTo(b))
@@ -159,64 +127,29 @@ interface DoubleHash : Hash<Double>, DoubleEq {
 fun Double.Companion.hash(): Hash<Double> =
   object : DoubleHash {}
 
-private object DoubleHashInstance : DoubleHash
-
-fun Hash.Companion.double(): Hash<Double> =
-  DoubleHashInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Show.double()", "arrow.core.Show", "arrow.core.double"))
 fun Double.Companion.show(): Show<Double> =
   object : DoubleShow {}
-
-private object DoubleShowInstance : DoubleShow
-
-fun Show.Companion.double(): Show<Double> =
-  DoubleShowInstance
 
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Eq.double()", "arrow.core.Eq", "arrow.core.double"))
 fun Double.Companion.eq(): Eq<Double> =
   object : DoubleEq {}
 
-private object DoubleEqInstance : DoubleEq
-
-fun Eq.Companion.double(): Eq<Double> =
-  DoubleEqInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Order.double()", "arrow.core.Order", "arrow.core.double"))
 fun Double.Companion.order(): Order<Double> =
   object : DoubleOrder {}
-
-private object DoubleOrderInstance : DoubleOrder
-
-fun Order.Companion.double(): Order<Double> =
-  DoubleOrderInstance
 
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Semigroup.double()", "arrow.core.Semigroup", "arrow.core.double"))
 fun Double.Companion.semigroup(): Semigroup<Double> =
   object : DoubleSemigroup {}
 
-private object DoubleSemigroupInstance : DoubleSemigroup
-
-fun Semigroup.Companion.double(): Semigroup<Double> =
-  DoubleSemigroupInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Monoid.double()", "arrow.core.Monoid", "arrow.core.double"))
 fun Double.Companion.monoid(): Monoid<Double> =
   object : DoubleMonoid {}
 
-private object DoubleMonoidInstance : DoubleMonoid
-
-fun Monoid.Companion.double(): Monoid<Double> =
-  DoubleMonoidInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Semiring.double()", "arrow.core.Semiring", "arrow.core.double"))
 fun Double.Companion.semiring(): Semiring<Double> =
   object : DoubleSemiring {}
-
-private object DoubleSemiringInstance : DoubleSemiring
-
-fun Semiring.Companion.double(): Semiring<Double> =
-  DoubleSemiringInstance
 
 // ////////
 // Int
@@ -264,64 +197,29 @@ interface IntHash : Hash<Int> {
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Hash.int()", "arrow.core.Hash", "arrow.core.int"))
 fun Int.Companion.hash(): Hash<Int> = object : IntHash {}
 
-private object IntHashInstance : IntHash
-
-fun Hash.Companion.int(): Hash<Int> =
-  IntHashInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Show.int()", "arrow.core.Show", "arrow.core.int"))
 fun Int.Companion.show(): Show<Int> =
   object : IntShow {}
-
-private object IntShowInstance : IntShow
-
-fun Show.Companion.int(): Show<Int> =
-  IntShowInstance
 
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Eq.int()", "arrow.core.Eq", "arrow.core.int"))
 fun Int.Companion.eq(): Eq<Int> =
   object : IntEq {}
 
-private object IntEqInstance : IntEq
-
-fun Eq.Companion.int(): Eq<Int> =
-  IntEqInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Order.int()", "arrow.core.Order", "arrow.core.int"))
 fun Int.Companion.order(): Order<Int> =
   object : IntOrder {}
-
-private object IntOrderInstance : IntOrder
-
-fun Order.Companion.int(): Order<Int> =
-  IntOrderInstance
 
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Semigroup.int()", "arrow.core.Semigroup", "arrow.core.int"))
 fun Int.Companion.semigroup(): Semigroup<Int> =
   object : IntSemigroup {}
 
-private object IntSemigroupInstance : IntSemigroup
-
-fun Semigroup.Companion.int(): Semigroup<Int> =
-  IntSemigroupInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Monoid.int()", "arrow.core.Monoid", "arrow.core.int"))
 fun Int.Companion.monoid(): Monoid<Int> =
   object : IntMonoid {}
 
-private object IntMonoidInstance : IntMonoid
-
-fun Monoid.Companion.int(): Monoid<Int> =
-  IntMonoidInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Semiring.int()", "arrow.core.Semiring", "arrow.core.int"))
 fun Int.Companion.semiring(): Semiring<Int> =
   object : IntSemiring {}
-
-private object IntSemiringInstance : IntSemiring
-
-fun Semiring.Companion.int(): Semiring<Int> =
-  IntSemiringInstance
 
 // ////////
 // Long
@@ -370,64 +268,29 @@ interface LongHash : Hash<Long>, LongEq {
 fun Long.Companion.hash(): Hash<Long> =
   object : LongHash {}
 
-private object LongHashInstance : LongHash
-
-fun Hash.Companion.long(): Hash<Long> =
-  LongHashInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Hash.long()", "arrow.core.Show", "arrow.core.long"))
 fun Long.Companion.show(): Show<Long> =
   object : LongShow {}
-
-private object LongShowInstance : LongShow
-
-fun Show.Companion.long(): Show<Long> =
-  LongShowInstance
 
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Eq.long()", "arrow.core.Eq", "arrow.core.long"))
 fun Long.Companion.eq(): Eq<Long> =
   object : LongEq {}
 
-private object LongEqInstance : LongEq
-
-fun Eq.Companion.long(): Eq<Long> =
-  LongEqInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Order.long()", "arrow.core.Order", "arrow.core.long"))
 fun Long.Companion.order(): Order<Long> =
   object : LongOrder {}
-
-private object LongOrderInstance : LongOrder
-
-fun Order.Companion.long(): Order<Long> =
-  LongOrderInstance
 
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Semigroup.long()", "arrow.core.Semigroup", "arrow.core.long"))
 fun Long.Companion.semigroup(): Semigroup<Long> =
   object : LongSemigroup {}
 
-private object LongSemigroupInstance : LongSemigroup
-
-fun Semigroup.Companion.long(): Semigroup<Long> =
-  LongSemigroupInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Monoid.long()", "arrow.core.Monoid", "arrow.core.long"))
 fun Long.Companion.monoid(): Monoid<Long> =
   object : LongMonoid {}
 
-private object LongMonoidInstance : LongMonoid
-
-fun Monoid.Companion.long(): Monoid<Long> =
-  LongMonoidInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Semiring.long()", "arrow.core.Semiring", "arrow.core.long"))
 fun Long.Companion.semiring(): Semiring<Long> =
   object : LongSemiring {}
-
-private object LongSemiringInstance : LongSemiring
-
-fun Semiring.Companion.long(): Semiring<Long> =
-  LongSemiringInstance
 
 // ////////
 // Short
@@ -476,64 +339,29 @@ interface ShortHash : Hash<Short>, ShortEq {
 fun Short.Companion.hash(): Hash<Short> =
   object : ShortHash {}
 
-private object ShortHashInstance : ShortHash
-
-fun Hash.Companion.short(): Hash<Short> =
-  ShortHashInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Show.short()", "arrow.core.Show", "arrow.core.short"))
 fun Short.Companion.show(): Show<Short> =
   object : ShortShow {}
-
-private object ShortShowInstance : ShortShow
-
-fun Show.Companion.short(): Show<Short> =
-  ShortShowInstance
 
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Eq.short()", "arrow.core.Eq", "arrow.core.short"))
 fun Short.Companion.eq(): Eq<Short> =
   object : ShortEq {}
 
-private object ShortEqInstance : ShortEq
-
-fun Eq.Companion.short(): Eq<Short> =
-  ShortEqInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Order.short()", "arrow.core.Order", "arrow.core.short"))
 fun Short.Companion.order(): Order<Short> =
   object : ShortOrder {}
-
-private object ShortOrderInstance : ShortOrder
-
-fun Order.Companion.short(): Order<Short> =
-  ShortOrderInstance
 
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Semigroup.short()", "arrow.core.Semigroup", "arrow.core.short"))
 fun Short.Companion.semigroup(): Semigroup<Short> =
   object : ShortSemigroup {}
 
-private object ShortSemigroupInstance : ShortSemigroup
-
-fun Semigroup.Companion.short(): Semigroup<Short> =
-  ShortSemigroupInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Monoid.short()", "arrow.core.Monoid", "arrow.core.short"))
 fun Short.Companion.monoid(): Monoid<Short> =
   object : ShortMonoid {}
 
-private object ShortMonoidInstance : ShortMonoid
-
-fun Monoid.Companion.short(): Monoid<Short> =
-  ShortMonoidInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Semiring.short()", "arrow.core.Semiring", "arrow.core.short"))
 fun Short.Companion.semiring(): Semiring<Short> =
   object : ShortSemiring {}
-
-private object ShortSemiringInstance : ShortSemiring
-
-fun Semiring.Companion.short(): Semiring<Short> =
-  ShortSemiringInstance
 
 // ////////
 // Float
@@ -582,61 +410,26 @@ interface FloatHash : Hash<Float>, FloatEq {
 fun Float.Companion.hash(): Hash<Float> =
   object : FloatHash {}
 
-private object FloatHashInstance : FloatHash
-
-fun Hash.Companion.float(): Hash<Float> =
-  FloatHashInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Show.float()", "arrow.core.Show", "arrow.core.float"))
 fun Float.Companion.show(): Show<Float> =
   object : FloatShow {}
-
-private object FloatShowInstance : FloatShow
-
-fun Show.Companion.float(): Show<Float> =
-  FloatShowInstance
 
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Eq.float()", "arrow.core.Eq", "arrow.core.float"))
 fun Float.Companion.eq(): Eq<Float> =
   object : FloatEq {}
 
-private object FloatEqInstance : FloatEq
-
-fun Eq.Companion.float(): Eq<Float> =
-  FloatEqInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Order.float()", "arrow.core.Order", "arrow.core.float"))
 fun Float.Companion.order(): Order<Float> =
   object : FloatOrder {}
-
-private object FloatOrderInstance : FloatOrder
-
-fun Order.Companion.float(): Order<Float> =
-  FloatOrderInstance
 
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Semigroup.float()", "arrow.core.Semigroup", "arrow.core.float"))
 fun Float.Companion.semigroup(): Semigroup<Float> =
   object : FloatSemigroup {}
 
-private object FloatSemigroupInstance : FloatSemigroup
-
-fun Semigroup.Companion.float(): Semigroup<Float> =
-  FloatSemigroupInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Monoid.float()", "arrow.core.Monoid", "arrow.core.float"))
 fun Float.Companion.monoid(): Monoid<Float> =
   object : FloatMonoid {}
 
-private object FloatMonoidInstance : FloatMonoid
-
-fun Monoid.Companion.float(): Monoid<Float> =
-  FloatMonoidInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Semiring.float()", "arrow.core.Semiring", "arrow.core.float"))
 fun Float.Companion.semiring(): Semiring<Float> =
   object : FloatSemiring {}
-
-private object FloatSemiringInstance : FloatSemiring
-
-fun Semiring.Companion.float(): Semiring<Float> =
-  FloatSemiringInstance

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/string.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/string.kt
@@ -17,11 +17,6 @@ interface StringSemigroup : Semigroup<String> {
 fun String.Companion.semigroup(): Semigroup<String> =
   object : StringSemigroup {}
 
-private object StringSemigroupInstance : StringSemigroup
-
-fun Semigroup.Companion.string(): Semigroup<String> =
-  StringSemigroupInstance
-
 @Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Hash.string()", "arrow.core.Hash", "arrow.core.string"))
 interface StringMonoid : Monoid<String>, StringSemigroup {
   override fun empty(): String = ""
@@ -30,11 +25,6 @@ interface StringMonoid : Monoid<String>, StringSemigroup {
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Show.string()", "arrow.core.Show", "arrow.core.string"))
 fun String.Companion.monoid(): Monoid<String> =
   object : StringMonoid {}
-
-private object StringMonoidInstance : StringMonoid
-
-fun Monoid.Companion.string(): Monoid<String> =
-  StringMonoidInstance
 
 @Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Hash.string()", "arrow.core.Hash", "arrow.core.string"))
 interface StringEq : Eq<String> {
@@ -45,12 +35,7 @@ interface StringEq : Eq<String> {
 fun String.Companion.eq(): Eq<String> =
   object : StringEq {}
 
-private object StringEqInstance : StringEq
-
-fun Eq.Companion.string(): Eq<String> =
-  StringEqInstance
-
-@Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Hash.string()", "arrow.core.Hash", "arrow.core.string"))
+@Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Show.string()", "arrow.core.Show", "arrow.core.string"))
 interface StringShow : Show<String> {
   override fun String.show(): String = "\"${this.escape()}\""
 
@@ -64,11 +49,7 @@ interface StringShow : Show<String> {
 fun String.Companion.show(): Show<String> =
   object : StringShow {}
 
-private object StringShowInstance : StringShow
-
-fun Show.Companion.string(): Show<String> =
-  StringShowInstance
-
+@Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Order.string()", "arrow.core.Order", "arrow.core.string"))
 interface StringOrder : Order<String> {
   override fun String.compare(b: String): Ordering =
     Ordering.fromInt(this.compareTo(b))
@@ -76,15 +57,11 @@ interface StringOrder : Order<String> {
   override fun String.compareTo(b: String): Int = this.compareTo(b)
 }
 
-private object StringOrderInstance : StringOrder
-
-fun Order.Companion.string(): Order<String> =
-  StringOrderInstance
-
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Order.string()", "arrow.core.Order", "arrow.core.string"))
 fun String.Companion.order(): Order<String> =
   object : StringOrder {}
 
+@Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Hash.string()", "arrow.core.Hash", "arrow.core.string"))
 interface StringHash : Hash<String>, StringEq {
   override fun String.hash(): Int = hashCode()
 }
@@ -93,11 +70,8 @@ interface StringHash : Hash<String>, StringEq {
 fun String.Companion.hash(): Hash<String> =
   object : StringHash {}
 
-private object StringHashInstance : StringHash
 
-fun Hash.Companion.string(): Hash<String> =
-  StringHashInstance
-
+@Deprecated("ForString extensions has been deprecated. Use concrete methods on String")
 object StringContext : StringShow, StringOrder, StringMonoid
 
 @Deprecated("ForString extensions has been deprecated. Use concrete methods on String")

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/string.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/string.kt
@@ -70,7 +70,6 @@ interface StringHash : Hash<String>, StringEq {
 fun String.Companion.hash(): Hash<String> =
   object : StringHash {}
 
-
 @Deprecated("ForString extensions has been deprecated. Use concrete methods on String")
 object StringContext : StringShow, StringOrder, StringMonoid
 


### PR DESCRIPTION
The instances for `Boolean`, `Char`, String` and `Number`s where still in `arrow.core.extensions`, this PR moves them to `arrow.core` instead.