### PR TITLE
CU-cn24b4 Remove extension and higherkind annotations for Const

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
@@ -50,11 +50,177 @@ data class Const<A, out T>(private val value: A) : ConstOf<A, T> {
   fun value(): A =
     value
 
+  fun <U> map(f: (T) -> U): Const<A, U> =
+    retag()
+
+  inline fun <A, B, C, T> mapN(
+    SG: Semigroup<A>,
+    b: Const<A, B>,
+    c: Const<A, C>,
+    map: (A, B) -> T
+  ): Const<A, T> =
+    b.retag<T>()
+      .combine(SG, c.retag())
+
+  inline fun <A, B, C, D, T> mapN(
+    SG: Semigroup<A>,
+    b: Const<A, B>,
+    c: Const<A, C>,
+    d: Const<A, D>,
+    map: (A, B, C) -> T
+  ): Const<A, T> =
+    b.retag<T>()
+      .combine(SG, c.retag())
+      .combine(SG, d.retag())
+
+  inline fun <A, B, C, D, E, T> mapN(
+    SG: Semigroup<A>,
+    b: Const<A, B>,
+    c: Const<A, C>,
+    d: Const<A, D>,
+    e: Const<A, E>,
+    map: (A, B, C, D) -> T
+  ): Const<A, T> =
+    b.retag<T>()
+      .combine(SG, c.retag())
+      .combine(SG, d.retag())
+      .combine(SG, e.retag())
+
+  inline fun <A, B, C, D, E, F, T> mapN(
+    SG: Semigroup<A>,
+    b: Const<A, B>,
+    c: Const<A, C>,
+    d: Const<A, D>,
+    e: Const<A, E>,
+    f: Const<A, F>,
+    map: (A, B, C, D, E) -> T
+  ): Const<A, T> =
+    b.retag<T>()
+      .combine(SG, c.retag())
+      .combine(SG, d.retag())
+      .combine(SG, e.retag())
+      .combine(SG, f.retag())
+
+  inline fun <A, B, C, D, E, F, G, T> mapN(
+    SG: Semigroup<A>,
+    b: Const<A, B>,
+    c: Const<A, C>,
+    d: Const<A, D>,
+    e: Const<A, E>,
+    f: Const<A, F>,
+    g: Const<A, G>,
+    map: (A, B, C, D, E, F) -> T
+  ): Const<A, T> =
+    b.retag<T>()
+      .combine(SG, c.retag())
+      .combine(SG, d.retag())
+      .combine(SG, e.retag())
+      .combine(SG, f.retag())
+      .combine(SG, g.retag())
+
+  inline fun <A, B, C, D, E, F, G, H, T> mapN(
+    SG: Semigroup<A>,
+    b: Const<A, B>,
+    c: Const<A, C>,
+    d: Const<A, D>,
+    e: Const<A, E>,
+    f: Const<A, F>,
+    g: Const<A, G>,
+    h: Const<A, H>,
+    map: (A, B, C, D, E, F, G) -> T
+  ): Const<A, T> =
+    b.retag<T>()
+      .combine(SG, c.retag())
+      .combine(SG, d.retag())
+      .combine(SG, e.retag())
+      .combine(SG, f.retag())
+      .combine(SG, g.retag())
+      .combine(SG, h.retag())
+
+  inline fun <A, B, C, D, E, F, G, H, I, T> mapN(
+    SG: Semigroup<A>,
+    b: Const<A, B>,
+    c: Const<A, C>,
+    d: Const<A, D>,
+    e: Const<A, E>,
+    f: Const<A, F>,
+    g: Const<A, G>,
+    h: Const<A, H>,
+    i: Const<A, I>,
+    map: (A, B, C, D, E, F, G, H) -> T
+  ): Const<A, T> =
+    b.retag<T>()
+      .combine(SG, c.retag())
+      .combine(SG, d.retag())
+      .combine(SG, e.retag())
+      .combine(SG, f.retag())
+      .combine(SG, g.retag())
+      .combine(SG, h.retag())
+      .combine(SG, i.retag())
+
+  inline fun <A, B, C, D, E, F, G, H, I, J, T> mapN(
+    SG: Semigroup<A>,
+    b: Const<A, B>,
+    c: Const<A, C>,
+    d: Const<A, D>,
+    e: Const<A, E>,
+    f: Const<A, F>,
+    g: Const<A, G>,
+    h: Const<A, H>,
+    i: Const<A, I>,
+    j: Const<A, J>,
+    map: (A, B, C, D, E, F, G, H, I) -> T
+  ): Const<A, T> =
+    b.retag<T>()
+      .combine(SG, c.retag())
+      .combine(SG, d.retag())
+      .combine(SG, e.retag())
+      .combine(SG, f.retag())
+      .combine(SG, g.retag())
+      .combine(SG, h.retag())
+      .combine(SG, i.retag())
+      .combine(SG, j.retag())
+
+  inline fun <A, B, C, D, E, F, G, H, I, J, K, T> mapN(
+    SG: Semigroup<A>,
+    b: Const<A, B>,
+    c: Const<A, C>,
+    d: Const<A, D>,
+    e: Const<A, E>,
+    f: Const<A, F>,
+    g: Const<A, G>,
+    h: Const<A, H>,
+    i: Const<A, I>,
+    j: Const<A, J>,
+    k: Const<A, K>,
+    map: (A, B, C, D, E, F, G, H, I, J) -> T
+  ): Const<A, T> =
+    b.retag<T>()
+      .combine(SG, c.retag())
+      .combine(SG, d.retag())
+      .combine(SG, e.retag())
+      .combine(SG, f.retag())
+      .combine(SG, g.retag())
+      .combine(SG, h.retag())
+      .combine(SG, i.retag())
+      .combine(SG, j.retag())
+      .combine(SG, k.retag())
+
   fun show(SA: Show<A>): String =
     "$Const(${SA.run { value.show() }})"
 
   override fun toString(): String =
     show(Show.any())
+
+
+
+  fun <A, B, C, D> tupled(
+    SG: Semigroup<A>,
+    b: Const<A, B>,
+    c: Const<A, C>,
+    d: Const<A, D>,
+  ): Const<A, Tuple3<A, B, C>> =
+    mapN(SG, b, c,d) { b, c, d -> Tuple3(b, c, d) }
 }
 
 @Deprecated(
@@ -69,13 +235,14 @@ fun <A, T> Const<A, T>.combine(SG: Semigroup<A>, that: Const<A, T>): Const<A, T>
 
 @Deprecated(
   "Kind is deprecated, and will be removed in 0.13.0. Please use the ap method defined for Const instead",
-  level = DeprecationLevel.WARNING
+  ReplaceWith(
+    "mapN(MA, this, arg1)",
+    "arrow.core.mapN"
+  ),
+  DeprecationLevel.WARNING
 )
 fun <A, T, U> ConstOf<A, T>.ap(SG: Semigroup<A>, ff: ConstOf<A, (T) -> U>): Const<A, U> =
   fix().retag<U>().combine(SG, ff.fix().retag())
-
-fun <A, T, U> Const<A, T>.ap(SG: Semigroup<A>, ff: Const<A, (T) -> U>): Const<A, U> =
-  retag<U>().combine(SG, ff.retag())
 
 @Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
 fun <T, A, G> ConstOf<A, Kind<G, T>>.sequence(GA: Applicative<G>): Kind<G, Const<A, T>> =
@@ -84,33 +251,18 @@ fun <T, A, G> ConstOf<A, Kind<G, T>>.sequence(GA: Applicative<G>): Kind<G, Const
 inline fun <A> A.const(): Const<A, Nothing> =
   Const(this)
 
-fun <A, T, U> Const<A, T>.map(f: (T) -> U): Const<A, U> =
-  retag()
-
 fun <A, T, U> Const<A, T>.contramap(f: (U) -> T): Const<A, U> =
   retag()
 
-fun <A, T> Const<A, T>.eqv(EQ: Eq<Const<A, T>>, b: Const<A, T>): Boolean =
+fun <A, T> Const<A, T>.eqv(EQ: Eq<A>, b: Const<A, T>): Boolean =
   EQ.run {
-    eqv(b)
+    value().eqv(b.value())
   }
 
-fun <A, T> Eq.Companion.const(EQ: Eq<Const<A, T>>): Eq<Const<A, T>> = object : Eq<Const<A, T>> {
+fun <A, T> Eq.Companion.const(EQ: Eq<A>): Eq<Const<A, T>> = object : Eq<Const<A, T>> {
   override fun Const<A, T>.eqv(b: Const<A, T>): Boolean =
     eqv(EQ, b)
 }
-
-fun <A, T, U> Const<A, T>.foldLeft(b: U, f: (U, T) -> U): U =
-  b
-
-fun <A, T, U> Const<A, T>.foldRight(lb: Eval<U>, f: (T, Eval<U>) -> Eval<U>): Eval<U> =
-  lb
-
-fun <A, B, T> Const<A, T>.reduceOrNull(initial: (A) -> B, operation: (acc: B, A) -> B): B? =
-  initial(value())
-
-fun <A, B, T> Const<A, T>.reduceRightNull(initial: (A) -> B, operation: (A, acc: B) -> B): B? =
-  initial(value())
 
 fun <A, T> Const<A, T>.hashWithSalt(HA: Hash<A>, salt: Int): Int =
   HA.run {
@@ -154,3 +306,9 @@ fun <A, T> Order.Companion.const(OA: Order<A>): Order<Const<A, T>> =
     override fun Const<A, T>.compare(b: Const<A, T>): Ordering =
       compare(OA, b)
   }
+
+//
+//fun <A, B, T> Const<T, A>.divide(MO: Monoid<A>, b: Const<T, B>, f: (T) -> Tuple2<A, B>): Const<A, B> =
+//  Const(
+//    MO.run { value() + b.value() }
+//  )

--- a/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
@@ -296,8 +296,3 @@ fun <A, T> Order.Companion.const(OA: Order<A>): Order<Const<A, T>> =
     override fun Const<A, T>.compare(b: Const<A, T>): Ordering =
       compare(OA, b)
   }
-
-//fun <A, B, T> divide(SG: Semigroup<A>, a: Const<T, A>, b: Const<T, B>, f: (T) -> Tuple2<A, B>): Const<A, B> =
-//  Const(
-//    SG.run { a.value() + b.value() }
-//  )

--- a/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
@@ -1,14 +1,25 @@
 package arrow.core
 
 import arrow.Kind
-import arrow.higherkind
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
 
+@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
+class ForConst private constructor() { companion object }
+@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
+typealias ConstOf<A, T> = arrow.Kind2<ForConst, A, T>
+@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
+typealias ConstPartialOf<A> = arrow.Kind<ForConst, A>
+
+@Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
+@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
+inline fun <A, T> ConstOf<A, T>.fix(): Const<A, T> =
+  this as Const<A, T>
+
+
 fun <A, T> ConstOf<A, T>.value(): A = this.fix().value()
 
-@higherkind
 data class Const<A, out T>(private val value: A) : ConstOf<A, T> {
 
   @Suppress("UNCHECKED_CAST")

--- a/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
@@ -48,12 +48,30 @@ data class Const<A, out T>(private val value: A) : ConstOf<A, T> {
     show(Show.any())
 }
 
+@Deprecated(
+  "Kind is deprecated, and will be removed in 0.13.0. Please use the combine method defined for Const instead",
+  level = DeprecationLevel.WARNING
+)
 fun <A, T> ConstOf<A, T>.combine(SG: Semigroup<A>, that: ConstOf<A, T>): Const<A, T> =
   Const(SG.run { value().combine(that.value()) })
 
+fun <A, T> Const<A, T>.combine(SG: Semigroup<A>, that: Const<A, T>): Const<A, T> =
+  Const(SG.run { value().combine(that.value()) })
+
+@Deprecated(
+  "Kind is deprecated, and will be removed in 0.13.0. Please use the ap method defined for Const instead",
+  level = DeprecationLevel.WARNING
+)
 fun <A, T, U> ConstOf<A, T>.ap(SG: Semigroup<A>, ff: ConstOf<A, (T) -> U>): Const<A, U> =
   fix().retag<U>().combine(SG, ff.fix().retag())
 
+fun <A, T, U> Const<A, T>.ap(SG: Semigroup<A>, ff: Const<A, (T) -> U>): Const<A, U> =
+  retag<U>().combine(SG, ff.retag())
+
+@Deprecated(
+  "Kind is deprecated, and will be removed in 0.13.0. Replace with sequence or sequenceValidated from arrow.core.*",
+  level = DeprecationLevel.WARNING
+)
 fun <T, A, G> ConstOf<A, Kind<G, T>>.sequence(GA: Applicative<G>): Kind<G, Const<A, T>> =
   fix().traverse(GA, ::identity)
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
@@ -4,6 +4,7 @@ import arrow.Kind
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
+import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
@@ -119,4 +120,37 @@ fun <A, T> Const<A, T>.hashWithSalt(HA: Hash<A>, salt: Int): Int =
 fun <A, T> Const<A, T>.compare(ORD: Order<A>, b: Const<A, T>): Ordering =
   ORD.run {
     value().compare(b.value())
+  }
+
+fun <A, T> Semigroup.Companion.const(SA: Semigroup<A>): Semigroup<Const<A, T>> =
+  object : Semigroup<Const<A, T>> {
+    override fun Const<A, T>.combine(b: Const<A, T>): Const<A, T> =
+      this.combine(SA, b)
+  }
+
+fun <A, T> Monoid.Companion.const(MA: Monoid<A>): Monoid<Const<A, T>> =
+  object : Monoid<Const<A, T>> {
+    override fun empty(): Const<A, T> =
+      Const(MA.empty())
+
+    override fun Const<A, T>.combine(b: Const<A, T>): Const<A, T> =
+      this.combine(MA, b)
+  }
+
+fun <A, T> Hash.Companion.const(HA: Hash<A>): Hash<Const<A, T>> =
+  object : Hash<Const<A, T>> {
+    override fun Const<A, T>.hashWithSalt(salt: Int): Int =
+      hashWithSalt(HA, salt)
+  }
+
+fun <A, T> Show.Companion.const(SA: Show<A>): Show<Const<A, T>> =
+  object : Show<Const<A, T>> {
+    override fun Const<A, T>.show(): String =
+      show(SA)
+  }
+
+fun <A, T> Order.Companion.const(OA: Order<A>): Order<Const<A, T>> =
+  object : Order<Const<A, T>> {
+    override fun Const<A, T>.compare(b: Const<A, T>): Ordering =
+      compare(OA, b)
   }

--- a/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
@@ -2,6 +2,7 @@ package arrow.core
 
 import arrow.Kind
 import arrow.typeclasses.Applicative
+import arrow.typeclasses.Divide
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
@@ -211,16 +212,6 @@ data class Const<A, out T>(private val value: A) : ConstOf<A, T> {
 
   override fun toString(): String =
     show(Show.any())
-
-
-
-  fun <A, B, C, D> tupled(
-    SG: Semigroup<A>,
-    b: Const<A, B>,
-    c: Const<A, C>,
-    d: Const<A, D>,
-  ): Const<A, Tuple3<A, B, C>> =
-    mapN(SG, b, c,d) { b, c, d -> Tuple3(b, c, d) }
 }
 
 @Deprecated(
@@ -307,8 +298,7 @@ fun <A, T> Order.Companion.const(OA: Order<A>): Order<Const<A, T>> =
       compare(OA, b)
   }
 
-//
-//fun <A, B, T> Const<T, A>.divide(MO: Monoid<A>, b: Const<T, B>, f: (T) -> Tuple2<A, B>): Const<A, B> =
+//fun <A, B, T> divide(SG: Semigroup<A>, a: Const<T, A>, b: Const<T, B>, f: (T) -> Tuple2<A, B>): Const<A, B> =
 //  Const(
-//    MO.run { value() + b.value() }
+//    SG.run { a.value() + b.value() }
 //  )

--- a/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
@@ -2,7 +2,6 @@ package arrow.core
 
 import arrow.Kind
 import arrow.typeclasses.Applicative
-import arrow.typeclasses.Divide
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid

--- a/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
@@ -17,7 +17,6 @@ typealias ConstPartialOf<A> = arrow.Kind<ForConst, A>
 inline fun <A, T> ConstOf<A, T>.fix(): Const<A, T> =
   this as Const<A, T>
 
-
 fun <A, T> ConstOf<A, T>.value(): A = this.fix().value()
 
 data class Const<A, out T>(private val value: A) : ConstOf<A, T> {

--- a/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
@@ -3,6 +3,7 @@ package arrow.core
 import arrow.Kind
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Eq
+import arrow.typeclasses.Hash
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
 
@@ -81,12 +82,16 @@ fun <T, A, G> ConstOf<A, Kind<G, T>>.sequence(GA: Applicative<G>): Kind<G, Const
 inline fun <A> A.const(): Const<A, Nothing> =
   Const(this)
 
-fun <A, T, U> Const<A, T>.map(f: (T) -> U): Const<A, U> = retag()
+fun <A, T, U> Const<A, T>.map(f: (T) -> U): Const<A, U> =
+  retag()
 
-fun <A, T, U> Const<A, T>.contramap(f: (U) -> T): Const<A, U> = retag()
+fun <A, T, U> Const<A, T>.contramap(f: (U) -> T): Const<A, U> =
+  retag()
 
 fun <A, T> Const<A, T>.eqv(EQ: Eq<Const<A, T>>, b: Const<A, T>): Boolean =
-  EQ.run { eqv(b) }
+  EQ.run {
+    eqv(b)
+  }
 
 fun <A, T> Eq.Companion.const(EQ: Eq<Const<A, T>>): Eq<Const<A, T>> = object : Eq<Const<A, T>> {
   override fun Const<A, T>.eqv(b: Const<A, T>): Boolean =
@@ -104,3 +109,8 @@ fun <A, B, T> Const<A, T>.reduceOrNull(initial: (A) -> B, operation: (acc: B, A)
 
 fun <A, B, T> Const<A, T>.reduceRightNull(initial: (A) -> B, operation: (A, acc: B) -> B): B? =
   initial(value())
+
+fun <A, T> Const<A, T>.hashWithSalt(HA: Hash<A>, salt: Int): Int =
+  HA.run {
+    value().hashWithSalt(salt)
+  }

--- a/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
@@ -45,6 +45,159 @@ data class Const<A, out T>(private val value: A) : ConstOf<A, T> {
   companion object {
     fun <A, T> just(a: A): Const<A, T> =
       Const(a)
+
+    inline fun <A, B, C, T> mapN(
+      SG: Semigroup<A>,
+      b: Const<A, B>,
+      c: Const<A, C>,
+      map: (A, B) -> T
+    ): Const<A, T> =
+      b.retag<T>()
+        .combine(SG, c.retag())
+
+    inline fun <A, B, C, D, T> mapN(
+      SG: Semigroup<A>,
+      b: Const<A, B>,
+      c: Const<A, C>,
+      d: Const<A, D>,
+      map: (A, B, C) -> T
+    ): Const<A, T> =
+      b.retag<T>()
+        .combine(SG, c.retag())
+        .combine(SG, d.retag())
+
+    inline fun <A, B, C, D, E, T> mapN(
+      SG: Semigroup<A>,
+      b: Const<A, B>,
+      c: Const<A, C>,
+      d: Const<A, D>,
+      e: Const<A, E>,
+      map: (A, B, C, D) -> T
+    ): Const<A, T> =
+      b.retag<T>()
+        .combine(SG, c.retag())
+        .combine(SG, d.retag())
+        .combine(SG, e.retag())
+
+    inline fun <A, B, C, D, E, F, T> mapN(
+      SG: Semigroup<A>,
+      b: Const<A, B>,
+      c: Const<A, C>,
+      d: Const<A, D>,
+      e: Const<A, E>,
+      f: Const<A, F>,
+      map: (A, B, C, D, E) -> T
+    ): Const<A, T> =
+      b.retag<T>()
+        .combine(SG, c.retag())
+        .combine(SG, d.retag())
+        .combine(SG, e.retag())
+        .combine(SG, f.retag())
+
+    inline fun <A, B, C, D, E, F, G, T> mapN(
+      SG: Semigroup<A>,
+      b: Const<A, B>,
+      c: Const<A, C>,
+      d: Const<A, D>,
+      e: Const<A, E>,
+      f: Const<A, F>,
+      g: Const<A, G>,
+      map: (A, B, C, D, E, F) -> T
+    ): Const<A, T> =
+      b.retag<T>()
+        .combine(SG, c.retag())
+        .combine(SG, d.retag())
+        .combine(SG, e.retag())
+        .combine(SG, f.retag())
+        .combine(SG, g.retag())
+
+    inline fun <A, B, C, D, E, F, G, H, T> mapN(
+      SG: Semigroup<A>,
+      b: Const<A, B>,
+      c: Const<A, C>,
+      d: Const<A, D>,
+      e: Const<A, E>,
+      f: Const<A, F>,
+      g: Const<A, G>,
+      h: Const<A, H>,
+      map: (A, B, C, D, E, F, G) -> T
+    ): Const<A, T> =
+      b.retag<T>()
+        .combine(SG, c.retag())
+        .combine(SG, d.retag())
+        .combine(SG, e.retag())
+        .combine(SG, f.retag())
+        .combine(SG, g.retag())
+        .combine(SG, h.retag())
+
+    inline fun <A, B, C, D, E, F, G, H, I, T> mapN(
+      SG: Semigroup<A>,
+      b: Const<A, B>,
+      c: Const<A, C>,
+      d: Const<A, D>,
+      e: Const<A, E>,
+      f: Const<A, F>,
+      g: Const<A, G>,
+      h: Const<A, H>,
+      i: Const<A, I>,
+      map: (A, B, C, D, E, F, G, H) -> T
+    ): Const<A, T> =
+      b.retag<T>()
+        .combine(SG, c.retag())
+        .combine(SG, d.retag())
+        .combine(SG, e.retag())
+        .combine(SG, f.retag())
+        .combine(SG, g.retag())
+        .combine(SG, h.retag())
+        .combine(SG, i.retag())
+
+    inline fun <A, B, C, D, E, F, G, H, I, J, T> mapN(
+      SG: Semigroup<A>,
+      b: Const<A, B>,
+      c: Const<A, C>,
+      d: Const<A, D>,
+      e: Const<A, E>,
+      f: Const<A, F>,
+      g: Const<A, G>,
+      h: Const<A, H>,
+      i: Const<A, I>,
+      j: Const<A, J>,
+      map: (A, B, C, D, E, F, G, H, I) -> T
+    ): Const<A, T> =
+      b.retag<T>()
+        .combine(SG, c.retag())
+        .combine(SG, d.retag())
+        .combine(SG, e.retag())
+        .combine(SG, f.retag())
+        .combine(SG, g.retag())
+        .combine(SG, h.retag())
+        .combine(SG, i.retag())
+        .combine(SG, j.retag())
+
+    inline fun <A, B, C, D, E, F, G, H, I, J, K, T> mapN(
+      SG: Semigroup<A>,
+      b: Const<A, B>,
+      c: Const<A, C>,
+      d: Const<A, D>,
+      e: Const<A, E>,
+      f: Const<A, F>,
+      g: Const<A, G>,
+      h: Const<A, H>,
+      i: Const<A, I>,
+      j: Const<A, J>,
+      k: Const<A, K>,
+      map: (A, B, C, D, E, F, G, H, I, J) -> T
+    ): Const<A, T> =
+      b.retag<T>()
+        .combine(SG, c.retag())
+        .combine(SG, d.retag())
+        .combine(SG, e.retag())
+        .combine(SG, f.retag())
+        .combine(SG, g.retag())
+        .combine(SG, h.retag())
+        .combine(SG, i.retag())
+        .combine(SG, j.retag())
+        .combine(SG, k.retag())
   }
 
   fun value(): A =
@@ -52,159 +205,6 @@ data class Const<A, out T>(private val value: A) : ConstOf<A, T> {
 
   fun <U> map(f: (T) -> U): Const<A, U> =
     retag()
-
-  inline fun <A, B, C, T> mapN(
-    SG: Semigroup<A>,
-    b: Const<A, B>,
-    c: Const<A, C>,
-    map: (A, B) -> T
-  ): Const<A, T> =
-    b.retag<T>()
-      .combine(SG, c.retag())
-
-  inline fun <A, B, C, D, T> mapN(
-    SG: Semigroup<A>,
-    b: Const<A, B>,
-    c: Const<A, C>,
-    d: Const<A, D>,
-    map: (A, B, C) -> T
-  ): Const<A, T> =
-    b.retag<T>()
-      .combine(SG, c.retag())
-      .combine(SG, d.retag())
-
-  inline fun <A, B, C, D, E, T> mapN(
-    SG: Semigroup<A>,
-    b: Const<A, B>,
-    c: Const<A, C>,
-    d: Const<A, D>,
-    e: Const<A, E>,
-    map: (A, B, C, D) -> T
-  ): Const<A, T> =
-    b.retag<T>()
-      .combine(SG, c.retag())
-      .combine(SG, d.retag())
-      .combine(SG, e.retag())
-
-  inline fun <A, B, C, D, E, F, T> mapN(
-    SG: Semigroup<A>,
-    b: Const<A, B>,
-    c: Const<A, C>,
-    d: Const<A, D>,
-    e: Const<A, E>,
-    f: Const<A, F>,
-    map: (A, B, C, D, E) -> T
-  ): Const<A, T> =
-    b.retag<T>()
-      .combine(SG, c.retag())
-      .combine(SG, d.retag())
-      .combine(SG, e.retag())
-      .combine(SG, f.retag())
-
-  inline fun <A, B, C, D, E, F, G, T> mapN(
-    SG: Semigroup<A>,
-    b: Const<A, B>,
-    c: Const<A, C>,
-    d: Const<A, D>,
-    e: Const<A, E>,
-    f: Const<A, F>,
-    g: Const<A, G>,
-    map: (A, B, C, D, E, F) -> T
-  ): Const<A, T> =
-    b.retag<T>()
-      .combine(SG, c.retag())
-      .combine(SG, d.retag())
-      .combine(SG, e.retag())
-      .combine(SG, f.retag())
-      .combine(SG, g.retag())
-
-  inline fun <A, B, C, D, E, F, G, H, T> mapN(
-    SG: Semigroup<A>,
-    b: Const<A, B>,
-    c: Const<A, C>,
-    d: Const<A, D>,
-    e: Const<A, E>,
-    f: Const<A, F>,
-    g: Const<A, G>,
-    h: Const<A, H>,
-    map: (A, B, C, D, E, F, G) -> T
-  ): Const<A, T> =
-    b.retag<T>()
-      .combine(SG, c.retag())
-      .combine(SG, d.retag())
-      .combine(SG, e.retag())
-      .combine(SG, f.retag())
-      .combine(SG, g.retag())
-      .combine(SG, h.retag())
-
-  inline fun <A, B, C, D, E, F, G, H, I, T> mapN(
-    SG: Semigroup<A>,
-    b: Const<A, B>,
-    c: Const<A, C>,
-    d: Const<A, D>,
-    e: Const<A, E>,
-    f: Const<A, F>,
-    g: Const<A, G>,
-    h: Const<A, H>,
-    i: Const<A, I>,
-    map: (A, B, C, D, E, F, G, H) -> T
-  ): Const<A, T> =
-    b.retag<T>()
-      .combine(SG, c.retag())
-      .combine(SG, d.retag())
-      .combine(SG, e.retag())
-      .combine(SG, f.retag())
-      .combine(SG, g.retag())
-      .combine(SG, h.retag())
-      .combine(SG, i.retag())
-
-  inline fun <A, B, C, D, E, F, G, H, I, J, T> mapN(
-    SG: Semigroup<A>,
-    b: Const<A, B>,
-    c: Const<A, C>,
-    d: Const<A, D>,
-    e: Const<A, E>,
-    f: Const<A, F>,
-    g: Const<A, G>,
-    h: Const<A, H>,
-    i: Const<A, I>,
-    j: Const<A, J>,
-    map: (A, B, C, D, E, F, G, H, I) -> T
-  ): Const<A, T> =
-    b.retag<T>()
-      .combine(SG, c.retag())
-      .combine(SG, d.retag())
-      .combine(SG, e.retag())
-      .combine(SG, f.retag())
-      .combine(SG, g.retag())
-      .combine(SG, h.retag())
-      .combine(SG, i.retag())
-      .combine(SG, j.retag())
-
-  inline fun <A, B, C, D, E, F, G, H, I, J, K, T> mapN(
-    SG: Semigroup<A>,
-    b: Const<A, B>,
-    c: Const<A, C>,
-    d: Const<A, D>,
-    e: Const<A, E>,
-    f: Const<A, F>,
-    g: Const<A, G>,
-    h: Const<A, H>,
-    i: Const<A, I>,
-    j: Const<A, J>,
-    k: Const<A, K>,
-    map: (A, B, C, D, E, F, G, H, I, J) -> T
-  ): Const<A, T> =
-    b.retag<T>()
-      .combine(SG, c.retag())
-      .combine(SG, d.retag())
-      .combine(SG, e.retag())
-      .combine(SG, f.retag())
-      .combine(SG, g.retag())
-      .combine(SG, h.retag())
-      .combine(SG, i.retag())
-      .combine(SG, j.retag())
-      .combine(SG, k.retag())
 
   fun show(SA: Show<A>): String =
     "$Const(${SA.run { value.show() }})"
@@ -226,8 +226,8 @@ fun <A, T> Const<A, T>.combine(SG: Semigroup<A>, that: Const<A, T>): Const<A, T>
 @Deprecated(
   "Kind is deprecated, and will be removed in 0.13.0. Please use the ap method defined for Const instead",
   ReplaceWith(
-    "mapN(MA, this, arg1)",
-    "arrow.core.mapN"
+    "Const.mapN(MA, this, arg1)",
+    "arrow.core.Const"
   ),
   DeprecationLevel.WARNING
 )

--- a/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
@@ -256,11 +256,21 @@ fun <A, T> Eq.Companion.const(EQ: Eq<A>): Eq<Const<A, T>> = object : Eq<Const<A,
     eqv(EQ, b)
 }
 
+@Deprecated(
+  "Hash is going to be removed, please use hashCode() instead",
+  ReplaceWith("hashCode()"),
+  level = DeprecationLevel.WARNING
+)
 fun <A, T> Const<A, T>.hashWithSalt(HA: Hash<A>, salt: Int): Int =
   HA.run {
     value().hashWithSalt(salt)
   }
 
+@Deprecated(
+  "Order is going to be removed, please use compareTo() instead",
+  ReplaceWith("compareTo(b)"),
+  level = DeprecationLevel.WARNING
+)
 fun <A, T> Const<A, T>.compare(ORD: Order<A>, b: Const<A, T>): Ordering =
   ORD.run {
     value().compare(b.value())
@@ -279,22 +289,4 @@ fun <A, T> Monoid.Companion.const(MA: Monoid<A>): Monoid<Const<A, T>> =
 
     override fun Const<A, T>.combine(b: Const<A, T>): Const<A, T> =
       this.combine(MA, b)
-  }
-
-fun <A, T> Hash.Companion.const(HA: Hash<A>): Hash<Const<A, T>> =
-  object : Hash<Const<A, T>> {
-    override fun Const<A, T>.hashWithSalt(salt: Int): Int =
-      hashWithSalt(HA, salt)
-  }
-
-fun <A, T> Show.Companion.const(SA: Show<A>): Show<Const<A, T>> =
-  object : Show<Const<A, T>> {
-    override fun Const<A, T>.show(): String =
-      show(SA)
-  }
-
-fun <A, T> Order.Companion.const(OA: Order<A>): Order<Const<A, T>> =
-  object : Order<Const<A, T>> {
-    override fun Const<A, T>.compare(b: Const<A, T>): Ordering =
-      compare(OA, b)
   }

--- a/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
@@ -20,6 +20,7 @@ typealias ConstPartialOf<A> = arrow.Kind<ForConst, A>
 inline fun <A, T> ConstOf<A, T>.fix(): Const<A, T> =
   this as Const<A, T>
 
+@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
 fun <A, T> ConstOf<A, T>.value(): A = this.fix().value()
 
 data class Const<A, out T>(private val value: A) : ConstOf<A, T> {
@@ -29,10 +30,12 @@ data class Const<A, out T>(private val value: A) : ConstOf<A, T> {
     this as Const<A, U>
 
   @Suppress("UNUSED_PARAMETER")
+  @Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
   fun <G, U> traverse(GA: Applicative<G>, f: (T) -> Kind<G, U>): Kind<G, Const<A, U>> =
     GA.just(retag())
 
   @Suppress("UNUSED_PARAMETER")
+  @Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
   fun <G, U> traverseFilter(GA: Applicative<G>, f: (T) -> Kind<G, Option<U>>): Kind<G, Const<A, U>> =
     GA.just(retag())
 
@@ -71,10 +74,7 @@ fun <A, T, U> ConstOf<A, T>.ap(SG: Semigroup<A>, ff: ConstOf<A, (T) -> U>): Cons
 fun <A, T, U> Const<A, T>.ap(SG: Semigroup<A>, ff: Const<A, (T) -> U>): Const<A, U> =
   retag<U>().combine(SG, ff.retag())
 
-@Deprecated(
-  "Kind is deprecated, and will be removed in 0.13.0. Replace with sequence or sequenceValidated from arrow.core.*",
-  level = DeprecationLevel.WARNING
-)
+@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
 fun <T, A, G> ConstOf<A, Kind<G, T>>.sequence(GA: Applicative<G>): Kind<G, Const<A, T>> =
   fix().traverse(GA, ::identity)
 
@@ -98,3 +98,9 @@ fun <A, T, U> Const<A, T>.foldLeft(b: U, f: (U, T) -> U): U =
 
 fun <A, T, U> Const<A, T>.foldRight(lb: Eval<U>, f: (T, Eval<U>) -> Eval<U>): Eval<U> =
   lb
+
+fun <A, B, T> Const<A, T>.reduceOrNull(initial: (A) -> B, operation: (acc: B, A) -> B): B? =
+  initial(value())
+
+fun <A, B, T> Const<A, T>.reduceRightNull(initial: (A) -> B, operation: (A, acc: B) -> B): B? =
+  initial(value())

--- a/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
@@ -2,11 +2,14 @@ package arrow.core
 
 import arrow.Kind
 import arrow.typeclasses.Applicative
+import arrow.typeclasses.Eq
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
 
 @Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-class ForConst private constructor() { companion object }
+class ForConst private constructor() {
+  companion object
+}
 @Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
 typealias ConstOf<A, T> = arrow.Kind2<ForConst, A, T>
 @Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
@@ -77,3 +80,21 @@ fun <T, A, G> ConstOf<A, Kind<G, T>>.sequence(GA: Applicative<G>): Kind<G, Const
 
 inline fun <A> A.const(): Const<A, Nothing> =
   Const(this)
+
+fun <A, T, U> Const<A, T>.map(f: (T) -> U): Const<A, U> = retag()
+
+fun <A, T, U> Const<A, T>.contramap(f: (U) -> T): Const<A, U> = retag()
+
+fun <A, T> Const<A, T>.eqv(EQ: Eq<Const<A, T>>, b: Const<A, T>): Boolean =
+  EQ.run { eqv(b) }
+
+fun <A, T> Eq.Companion.const(EQ: Eq<Const<A, T>>): Eq<Const<A, T>> = object : Eq<Const<A, T>> {
+  override fun Const<A, T>.eqv(b: Const<A, T>): Boolean =
+    eqv(EQ, b)
+}
+
+fun <A, T, U> Const<A, T>.foldLeft(b: U, f: (U, T) -> U): U =
+  b
+
+fun <A, T, U> Const<A, T>.foldRight(lb: Eval<U>, f: (T, Eval<U>) -> Eval<U>): Eval<U> =
+  lb

--- a/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
@@ -4,6 +4,7 @@ import arrow.Kind
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
+import arrow.typeclasses.Order
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
 
@@ -113,4 +114,9 @@ fun <A, B, T> Const<A, T>.reduceRightNull(initial: (A) -> B, operation: (A, acc:
 fun <A, T> Const<A, T>.hashWithSalt(HA: Hash<A>, salt: Int): Int =
   HA.run {
     value().hashWithSalt(salt)
+  }
+
+fun <A, T> Const<A, T>.compare(ORD: Order<A>, b: Const<A, T>): Ordering =
+  ORD.run {
+    value().compare(b.value())
   }

--- a/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
@@ -220,7 +220,7 @@ class NonEmptyList<out A>(
 
   @JvmName("flatMapKind")
   @Deprecated(
-    "Kind is deprecated, and will be removed in 0.13.0. Please the flatMap method defined for NonEmptyList instead",
+    "Kind is deprecated, and will be removed in 0.13.0. Please use the flatMap method defined for NonEmptyList instead",
     level = DeprecationLevel.WARNING
   )
   inline fun <B> flatMap(f: (A) -> NonEmptyListOf<B>): NonEmptyList<B> =

--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Traverse.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Traverse.kt
@@ -226,34 +226,6 @@ import arrow.typeclasses.internal.idApplicative
  *
  * For brevity and demonstration purposes we’ll implement an isomorphic [foldMap] method in terms of [traverse] by using [Const]. You can then implement [foldRight] in terms of [foldMap], and [foldLeft] can then be implemented in terms of [foldRight], though the resulting implementations may be slow.
  *
- * ```kotlin:ank:playground
- * import arrow.Kind
- * import arrow.core.Const
- * import arrow.core.ListK
- * import arrow.core.extensions.const.applicative.applicative
- * import arrow.core.extensions.listk.traverse.traverse
- * import arrow.core.extensions.monoid
- * import arrow.core.fix
- * import arrow.core.identity
- * import arrow.core.k
- * import arrow.typeclasses.Monoid
- * import arrow.typeclasses.Traverse
- *
- * //sampleStart
- * fun <F, B, A> Kind<F, A>.foldMap(f: (A) -> B, M: Monoid<B>, TF: Traverse<F>): B =
- *   TF.run {
- *     M.run {
- *       traverse(Const.applicative(M)) { a: A -> Const<B, Nothing>(f(a)) }.fix().value()
- *     }
- *   }
- *
- * val sing = listOf("Hello", " from ", "the", " other ", "side!").k().foldMap(::identity, String.monoid(), ListK.traverse())
- * //sampleEnd
- * fun main() {
- *   println("Sing=$sing")
- * }
- * ```
- *
  * ### Choose your implementation
  *
  * The type signature of [Traverse] appears highly abstract, although it's easier if you think about it as executing operations over collections - what [traverse] does as it walks the `Kind<F, A>` depending on the context `F` of the function. Let's see some examples where `F` is taken to be `List`.

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const.kt
@@ -31,16 +31,28 @@ import arrow.typeclasses.TraverseFilter
 import arrow.core.ap as constAp
 import arrow.core.combine as combineAp
 
+@Deprecated(
+  message = "Invariant typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
+)
 interface ConstInvariant<A> : Invariant<ConstPartialOf<A>> {
   override fun <T, U> ConstOf<A, T>.imap(f: (T) -> U, g: (U) -> T): Const<A, U> =
     fix().retag()
 }
 
+@Deprecated(
+  message = "Contravariant typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
+)
 interface ConstContravariant<A> : Contravariant<ConstPartialOf<A>> {
   override fun <T, U> ConstOf<A, T>.contramap(f: (U) -> T): Const<A, U> =
     fix().retag()
 }
 
+@Deprecated(
+  message = "Divide typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
+)
 interface ConstDivideInstance<O> : Divide<ConstPartialOf<O>>, ConstContravariant<O> {
   fun MO(): Monoid<O>
   override fun <A, B, Z> divide(fa: Kind<ConstPartialOf<O>, A>, fb: Kind<ConstPartialOf<O>, B>, f: (Z) -> Tuple2<A, B>): Kind<ConstPartialOf<O>, Z> =
@@ -49,6 +61,10 @@ interface ConstDivideInstance<O> : Divide<ConstPartialOf<O>>, ConstContravariant
     )
 }
 
+@Deprecated(
+  message = "Divisible typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
+)
 interface ConstDivisibleInstance<O> : Divisible<ConstPartialOf<O>>, ConstDivideInstance<O> {
   fun MOO(): Monoid<O>
   override fun MO(): Monoid<O> = MOO()
@@ -57,11 +73,19 @@ interface ConstDivisibleInstance<O> : Divisible<ConstPartialOf<O>>, ConstDivideI
     Const(MOO().empty())
 }
 
+@Deprecated(
+  message = "Functor typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
+)
 interface ConstFunctor<A> : Functor<ConstPartialOf<A>> {
   override fun <T, U> ConstOf<A, T>.map(f: (T) -> U): Const<A, U> =
     fix().retag()
 }
 
+@Deprecated(
+  message = "Apply typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
+)
 interface ConstApply<A> : Apply<ConstPartialOf<A>> {
 
   fun MA(): Monoid<A>
@@ -72,6 +96,10 @@ interface ConstApply<A> : Apply<ConstPartialOf<A>> {
     constAp(MA(), ff)
 }
 
+@Deprecated(
+  message = "Applicative typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
+)
 interface ConstApplicative<A> : Applicative<ConstPartialOf<A>> {
 
   fun MA(): Monoid<A>
@@ -87,6 +115,10 @@ interface ConstApplicative<A> : Applicative<ConstPartialOf<A>> {
     constAp(MA(), ff)
 }
 
+@Deprecated(
+  message = "Foldable typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
+)
 interface ConstFoldable<A> : Foldable<ConstPartialOf<A>> {
 
   override fun <T, U> ConstOf<A, T>.foldLeft(b: U, f: (U, T) -> U): U = b
@@ -94,6 +126,10 @@ interface ConstFoldable<A> : Foldable<ConstPartialOf<A>> {
   override fun <T, U> ConstOf<A, T>.foldRight(lb: Eval<U>, f: (T, Eval<U>) -> Eval<U>): Eval<U> = lb
 }
 
+@Deprecated(
+  message = "Traverse typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
+)
 interface ConstTraverse<X> : Traverse<ConstPartialOf<X>>, ConstFoldable<X> {
 
   override fun <T, U> ConstOf<X, T>.map(f: (T) -> U): Const<X, U> = fix().retag()
@@ -102,6 +138,10 @@ interface ConstTraverse<X> : Traverse<ConstPartialOf<X>>, ConstFoldable<X> {
     fix().traverse(AP, f)
 }
 
+@Deprecated(
+  message = "TraverseFilter typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
+)
 interface ConstTraverseFilter<X> : TraverseFilter<ConstPartialOf<X>>, ConstTraverse<X> {
 
   override fun <T, U> Kind<ConstPartialOf<X>, T>.map(f: (T) -> U): Const<X, U> = fix().retag()
@@ -110,6 +150,11 @@ interface ConstTraverseFilter<X> : TraverseFilter<ConstPartialOf<X>>, ConstTrave
     fix().traverseFilter(AP, f)
 }
 
+@Deprecated(
+  "Typeclass instance have been moved to the companion object of the typeclass.",
+  ReplaceWith("Semigroup.const()", "arrow.core.const", "arrow.typeclasses.Semigroup"),
+  DeprecationLevel.WARNING
+)
 interface ConstSemigroup<A, T> : Semigroup<ConstOf<A, T>> {
 
   fun SA(): Semigroup<A>
@@ -118,6 +163,11 @@ interface ConstSemigroup<A, T> : Semigroup<ConstOf<A, T>> {
     combineAp(SA(), b)
 }
 
+@Deprecated(
+  "Typeclass instance have been moved to the companion object of the typeclass.",
+  ReplaceWith("Monoid.const()", "arrow.core.const", "arrow.typeclasses.Monoid"),
+  DeprecationLevel.WARNING
+)
 interface ConstMonoid<A, T> : Monoid<ConstOf<A, T>>, ConstSemigroup<A, T> {
 
   fun MA(): Monoid<A>
@@ -127,6 +177,11 @@ interface ConstMonoid<A, T> : Monoid<ConstOf<A, T>>, ConstSemigroup<A, T> {
   override fun empty(): Const<A, T> = Const(MA().empty())
 }
 
+@Deprecated(
+  "Typeclass instance have been moved to the companion object of the typeclass.",
+  ReplaceWith("Eq.const()", "arrow.core.const", "arrow.typeclasses.Eq"),
+  DeprecationLevel.WARNING
+)
 interface ConstEq<A, T> : Eq<Const<A, T>> {
 
   fun EQ(): Eq<A>
@@ -135,12 +190,20 @@ interface ConstEq<A, T> : Eq<Const<A, T>> {
     EQ().run { value().eqv(b.value()) }
 }
 
+@Deprecated(
+  message = "Order typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
+)
 interface ConstOrder<A, T> : Order<Const<A, T>> {
   fun ORD(): Order<A>
   override fun Const<A, T>.compare(b: Const<A, T>): Ordering =
     ORD().run { value().compare(b.value()) }
 }
 
+@Deprecated(
+  message = "EqK typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
+)
 interface ConstEqK<A> : EqK<ConstPartialOf<A>> {
 
   fun EQA(): Eq<A>
@@ -154,11 +217,21 @@ interface ConstEqK<A> : EqK<ConstPartialOf<A>> {
     }
 }
 
+@Deprecated(
+  "Typeclass instance have been moved to the companion object of the typeclass.",
+  ReplaceWith("Show.const()", "arrow.core.const", "arrow.typeclasses.Show"),
+  DeprecationLevel.WARNING
+)
 interface ConstShow<A, T> : Show<Const<A, T>> {
   fun SA(): Show<A>
   override fun Const<A, T>.show(): String = show(SA())
 }
 
+@Deprecated(
+  "Typeclass instance have been moved to the companion object of the typeclass.",
+  ReplaceWith("Hash.const()", "arrow.core.const", "arrow.typeclasses.Hash"),
+  DeprecationLevel.WARNING
+)
 interface ConstHash<A, T> : Hash<Const<A, T>> {
   fun HA(): Hash<A>
 

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const.kt
@@ -32,19 +32,16 @@ import arrow.typeclasses.TraverseFilter
 import arrow.core.ap as constAp
 import arrow.core.combine as combineAp
 
-@extension
 interface ConstInvariant<A> : Invariant<ConstPartialOf<A>> {
   override fun <T, U> ConstOf<A, T>.imap(f: (T) -> U, g: (U) -> T): Const<A, U> =
     fix().retag()
 }
 
-@extension
 interface ConstContravariant<A> : Contravariant<ConstPartialOf<A>> {
   override fun <T, U> ConstOf<A, T>.contramap(f: (U) -> T): Const<A, U> =
     fix().retag()
 }
 
-@extension
 interface ConstDivideInstance<O> : Divide<ConstPartialOf<O>>, ConstContravariant<O> {
   fun MO(): Monoid<O>
   override fun <A, B, Z> divide(fa: Kind<ConstPartialOf<O>, A>, fb: Kind<ConstPartialOf<O>, B>, f: (Z) -> Tuple2<A, B>): Kind<ConstPartialOf<O>, Z> =
@@ -53,7 +50,6 @@ interface ConstDivideInstance<O> : Divide<ConstPartialOf<O>>, ConstContravariant
     )
 }
 
-@extension
 interface ConstDivisibleInstance<O> : Divisible<ConstPartialOf<O>>, ConstDivideInstance<O> {
   fun MOO(): Monoid<O>
   override fun MO(): Monoid<O> = MOO()
@@ -62,13 +58,11 @@ interface ConstDivisibleInstance<O> : Divisible<ConstPartialOf<O>>, ConstDivideI
     Const(MOO().empty())
 }
 
-@extension
 interface ConstFunctor<A> : Functor<ConstPartialOf<A>> {
   override fun <T, U> ConstOf<A, T>.map(f: (T) -> U): Const<A, U> =
     fix().retag()
 }
 
-@extension
 interface ConstApply<A> : Apply<ConstPartialOf<A>> {
 
   fun MA(): Monoid<A>
@@ -79,7 +73,6 @@ interface ConstApply<A> : Apply<ConstPartialOf<A>> {
     constAp(MA(), ff)
 }
 
-@extension
 interface ConstApplicative<A> : Applicative<ConstPartialOf<A>> {
 
   fun MA(): Monoid<A>
@@ -95,7 +88,6 @@ interface ConstApplicative<A> : Applicative<ConstPartialOf<A>> {
     constAp(MA(), ff)
 }
 
-@extension
 interface ConstFoldable<A> : Foldable<ConstPartialOf<A>> {
 
   override fun <T, U> ConstOf<A, T>.foldLeft(b: U, f: (U, T) -> U): U = b
@@ -103,7 +95,6 @@ interface ConstFoldable<A> : Foldable<ConstPartialOf<A>> {
   override fun <T, U> ConstOf<A, T>.foldRight(lb: Eval<U>, f: (T, Eval<U>) -> Eval<U>): Eval<U> = lb
 }
 
-@extension
 interface ConstTraverse<X> : Traverse<ConstPartialOf<X>>, ConstFoldable<X> {
 
   override fun <T, U> ConstOf<X, T>.map(f: (T) -> U): Const<X, U> = fix().retag()
@@ -112,7 +103,6 @@ interface ConstTraverse<X> : Traverse<ConstPartialOf<X>>, ConstFoldable<X> {
     fix().traverse(AP, f)
 }
 
-@extension
 interface ConstTraverseFilter<X> : TraverseFilter<ConstPartialOf<X>>, ConstTraverse<X> {
 
   override fun <T, U> Kind<ConstPartialOf<X>, T>.map(f: (T) -> U): Const<X, U> = fix().retag()
@@ -121,7 +111,6 @@ interface ConstTraverseFilter<X> : TraverseFilter<ConstPartialOf<X>>, ConstTrave
     fix().traverseFilter(AP, f)
 }
 
-@extension
 interface ConstSemigroup<A, T> : Semigroup<ConstOf<A, T>> {
 
   fun SA(): Semigroup<A>
@@ -130,7 +119,6 @@ interface ConstSemigroup<A, T> : Semigroup<ConstOf<A, T>> {
     combineAp(SA(), b)
 }
 
-@extension
 interface ConstMonoid<A, T> : Monoid<ConstOf<A, T>>, ConstSemigroup<A, T> {
 
   fun MA(): Monoid<A>
@@ -140,7 +128,6 @@ interface ConstMonoid<A, T> : Monoid<ConstOf<A, T>>, ConstSemigroup<A, T> {
   override fun empty(): Const<A, T> = Const(MA().empty())
 }
 
-@extension
 interface ConstEq<A, T> : Eq<Const<A, T>> {
 
   fun EQ(): Eq<A>
@@ -149,14 +136,12 @@ interface ConstEq<A, T> : Eq<Const<A, T>> {
     EQ().run { value().eqv(b.value()) }
 }
 
-@extension
 interface ConstOrder<A, T> : Order<Const<A, T>> {
   fun ORD(): Order<A>
   override fun Const<A, T>.compare(b: Const<A, T>): Ordering =
     ORD().run { value().compare(b.value()) }
 }
 
-@extension
 interface ConstEqK<A> : EqK<ConstPartialOf<A>> {
 
   fun EQA(): Eq<A>
@@ -170,13 +155,11 @@ interface ConstEqK<A> : EqK<ConstPartialOf<A>> {
     }
 }
 
-@extension
 interface ConstShow<A, T> : Show<Const<A, T>> {
   fun SA(): Show<A>
   override fun Const<A, T>.show(): String = show(SA())
 }
 
-@extension
 interface ConstHash<A, T> : Hash<Const<A, T>> {
   fun HA(): Hash<A>
 

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const.kt
@@ -11,7 +11,6 @@ import arrow.core.Tuple2
 import arrow.core.extensions.const.eq.eq
 import arrow.core.fix
 import arrow.core.value
-import arrow.extension
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Apply
 import arrow.typeclasses.Contravariant

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/applicative/ConstApplicative.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/applicative/ConstApplicative.kt
@@ -25,7 +25,7 @@ import kotlin.jvm.JvmName
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
     "just(a)",
-    "arrow.core.Const.just"
+    "arrow.core.just"
   ),
   DeprecationLevel.WARNING
 )
@@ -45,7 +45,7 @@ fun <A> A.just(MA: Monoid<A>): Const<A, A> =
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
     "unit(MA)",
-    "arrow.core.Const.unit"
+    "arrow.core.unit"
   ),
   DeprecationLevel.WARNING
 )

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/applicative/ConstApplicative.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/applicative/ConstApplicative.kt
@@ -24,14 +24,15 @@ import kotlin.jvm.JvmName
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "just(MA)",
-  "arrow.core.just"
+    "just(a)",
+    "arrow.core.Const.just"
   ),
   DeprecationLevel.WARNING
 )
-fun <A> A.just(MA: Monoid<A>): Const<A, A> = arrow.core.Const.applicative<A>(MA).run {
-  this@just.just<A>() as arrow.core.Const<A, A>
-}
+fun <A> A.just(MA: Monoid<A>): Const<A, A> =
+  arrow.core.Const.applicative<A>(MA).run {
+    this@just.just<A>() as arrow.core.Const<A, A>
+  }
 
 @JvmName("unit")
 @Suppress(
@@ -43,14 +44,14 @@ fun <A> A.just(MA: Monoid<A>): Const<A, A> = arrow.core.Const.applicative<A>(MA)
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "unit(MA)",
-  "arrow.core.Const.unit"
+    "unit(MA)",
+    "arrow.core.Const.unit"
   ),
   DeprecationLevel.WARNING
 )
 fun <A> unit(MA: Monoid<A>): Const<A, Unit> = arrow.core.Const
-   .applicative<A>(MA)
-   .unit() as arrow.core.Const<A, kotlin.Unit>
+  .applicative<A>(MA)
+  .unit() as arrow.core.Const<A, kotlin.Unit>
 
 @JvmName("map")
 @Suppress(
@@ -62,15 +63,15 @@ fun <A> unit(MA: Monoid<A>): Const<A, Unit> = arrow.core.Const
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(MA, arg1)",
-  "arrow.core.map"
+    "map(MA, arg1)",
+    "arrow.core.map"
   ),
   DeprecationLevel.WARNING
 )
 fun <A, B> Kind<Kind<ForConst, A>, A>.map(MA: Monoid<A>, arg1: Function1<A, B>): Const<A, B> =
-    arrow.core.Const.applicative<A>(MA).run {
-  this@map.map<A, B>(arg1) as arrow.core.Const<A, B>
-}
+  arrow.core.Const.applicative<A>(MA).run {
+    this@map.map<A, B>(arg1) as arrow.core.Const<A, B>
+  }
 
 @JvmName("replicate")
 @Suppress(
@@ -82,15 +83,15 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.map(MA: Monoid<A>, arg1: Function1<A, B>):
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "replicate(MA, arg1)",
-  "arrow.core.replicate"
+    "replicate(MA, arg1)",
+    "arrow.core.replicate"
   ),
   DeprecationLevel.WARNING
 )
 fun <A> Kind<Kind<ForConst, A>, A>.replicate(MA: Monoid<A>, arg1: Int): Const<A, List<A>> =
-    arrow.core.Const.applicative<A>(MA).run {
-  this@replicate.replicate<A>(arg1) as arrow.core.Const<A, kotlin.collections.List<A>>
-}
+  arrow.core.Const.applicative<A>(MA).run {
+    this@replicate.replicate<A>(arg1) as arrow.core.Const<A, kotlin.collections.List<A>>
+  }
 
 @JvmName("replicate")
 @Suppress(
@@ -102,8 +103,8 @@ fun <A> Kind<Kind<ForConst, A>, A>.replicate(MA: Monoid<A>, arg1: Int): Const<A,
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "replicate(MA, arg1, arg2)",
-  "arrow.core.replicate"
+    "replicate(MA, arg1, arg2)",
+    "arrow.core.replicate"
   ),
   DeprecationLevel.WARNING
 )
@@ -119,6 +120,11 @@ fun <A> Kind<Kind<ForConst, A>, A>.replicate(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated(
+  "Applicative typeclass is deprecated. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
+)
 inline fun <A> Companion.applicative(MA: Monoid<A>): ConstApplicative<A> = object :
-    arrow.core.extensions.ConstApplicative<A> { override fun MA(): arrow.typeclasses.Monoid<A> = MA
-    }
+  arrow.core.extensions.ConstApplicative<A> {
+  override fun MA(): arrow.typeclasses.Monoid<A> = MA
+}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/apply/ConstApply.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/apply/ConstApply.kt
@@ -100,8 +100,8 @@ fun <A, B, Z> Kind<Kind<ForConst, A>, A>.map2Eval(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, arg0, arg1, arg2)",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, arg0, arg1, arg2)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -124,8 +124,8 @@ fun <A, B, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, arg0, arg1, arg2)",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, arg0, arg1, arg2)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -148,8 +148,8 @@ fun <A, B, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, arg0, arg1, arg2, arg3)",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -173,8 +173,8 @@ fun <A, B, C, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, arg0, arg1, arg2, arg3)",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -198,7 +198,7 @@ fun <A, B, C, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, arg0, arg1, arg2, arg3, arg4)",
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4)",
     "arrow.core.map"
   ),
   DeprecationLevel.WARNING
@@ -224,8 +224,8 @@ fun <A, B, C, D, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, arg0, arg1, arg2, arg3, arg4)",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -250,8 +250,8 @@ fun <A, B, C, D, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5)",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -277,8 +277,8 @@ fun <A, B, C, D, E, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5)",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -304,8 +304,8 @@ fun <A, B, C, D, E, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -332,8 +332,8 @@ fun <A, B, C, D, E, FF, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -360,8 +360,8 @@ fun <A, B, C, D, E, FF, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -390,8 +390,8 @@ fun <A, B, C, D, E, FF, G, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -420,8 +420,8 @@ fun <A, B, C, D, E, FF, G, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -451,8 +451,8 @@ fun <A, B, C, D, E, FF, G, H, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -482,8 +482,8 @@ fun <A, B, C, D, E, FF, G, H, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -514,8 +514,8 @@ fun <A, B, C, D, E, FF, G, H, I, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -546,8 +546,8 @@ fun <A, B, C, D, E, FF, G, H, I, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -579,8 +579,8 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -611,8 +611,8 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, this, arg1).map(arg2)",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, this, arg1).map(arg2)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -634,8 +634,8 @@ fun <A, B, Z> Kind<Kind<ForConst, A>, A>.map2(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, this, arg1) { a, b -> Tuple2(a, b) }",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, this, arg1) { a, b -> Tuple2(a, b) }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -654,8 +654,8 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.product(MA: Monoid<A>, arg1: Kind<Kind<For
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, this, arg1).map { (ab, c) -> Tuple3(ab.a, ab.b, c) }",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, this, arg1).map { (ab, c) -> Tuple3(ab.a, ab.b, c) }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -676,8 +676,8 @@ fun <A, B, Z> Kind<Kind<ForConst, A>, Tuple2<A, B>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, this, arg1).map { (abc, d) -> Tuple4(abc.a, abc.b, abc.c, d) }",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, this, arg1).map { (abc, d) -> Tuple4(abc.a, abc.b, abc.c, d) }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -699,8 +699,8 @@ fun <A, B, C, Z> Kind<Kind<ForConst, A>, Tuple3<A, B, C>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, this, arg1).map { (abcd, e) -> Tuple5(abcd.a, abcd.b, abcd.c, abcd.d, e) }",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, this, arg1).map { (abcd, e) -> Tuple5(abcd.a, abcd.b, abcd.c, abcd.d, e) }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -722,8 +722,8 @@ fun <A, B, C, D, Z> Kind<Kind<ForConst, A>, Tuple4<A, B, C, D>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, this, arg1).map { (abcde, f) -> Tuple6(abcde.a, abcde.b, abcde.c, abcde.d, abcde.e, f) }",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, this, arg1).map { (abcde, f) -> Tuple6(abcde.a, abcde.b, abcde.c, abcde.d, abcde.e, f) }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -745,9 +745,9 @@ fun <A, B, C, D, E, Z> Kind<Kind<ForConst, A>, Tuple5<A, B, C, D, E>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, this, arg1)\n" +
+    "Cons.mapN(MA, this, arg1)\n" +
       ".map { (abcdef, g) -> Tuple7(abcdef.a, abcdef.b, abcdef.c, abcdef.d, abcdef.e, abcdef.f, g) }",
-    "arrow.core.mapN"
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -769,9 +769,9 @@ fun <A, B, C, D, E, FF, Z> Kind<Kind<ForConst, A>, Tuple6<A, B, C, D, E, FF>>.pr
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, this, arg1)\n" +
+    "Cons.mapN(MA, this, arg1)\n" +
       ".map { (abcdefg, h) -> Tuple8(abcdefg.a, abcdefg.b, abcdefg.c, abcdefg.d, abcdefg.e, abcdefg.f, abcdefg.g, h) }",
-    "arrow.core.mapN"
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -794,9 +794,9 @@ fun <A, B, C, D, E, FF, G, Z> Kind<Kind<ForConst, A>, Tuple7<A, B, C, D, E, FF, 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, this, arg1)\n" +
+    "Cons.mapN(MA, this, arg1)\n" +
       ".map { (abcdefgh, i) -> Tuple9(abcdefgh.a, abcdefgh.b, abcdefgh.c, abcdefgh.d, abcdefgh.e, abcdefgh.f, abcdefgh.g, abcdefgh.h, i) }",
-    "arrow.core.mapN"
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -819,9 +819,9 @@ fun <A, B, C, D, E, FF, G, H, Z> Kind<Kind<ForConst, A>, Tuple8<A, B, C, D, E, F
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, this, arg1)\n" +
+    "Cons.mapN(MA, this, arg1)\n" +
       ".map { (abcdefghi, j) -> Tuple10(abcdefghi.a, abcdefghi.b, abcdefghi.c, abcdefghi.d, abcdefghi.e, abcdefghi.f, abcdefghi.g, abcdefghi.h, abcdefghi.i, j) }",
-    "arrow.core.mapN"
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -844,8 +844,8 @@ fun <A, B, C, D, E, FF, G, H, I, Z> Kind<Kind<ForConst, A>, Tuple9<A, B, C, D, E
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(SG, arg0, arg1) { a, b -> Tuple2(a, b) }",
-    "arrow.core.mapN"
+    "Cons.mapN(SG, arg0, arg1) { a, b -> Tuple2(a, b) }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -867,8 +867,8 @@ fun <A, B> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(SG, arg0, arg1) { a, b -> Tuple2(a, b) }",
-    "arrow.core.mapN"
+    "Cons.mapN(SG, arg0, arg1) { a, b -> Tuple2(a, b) }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -890,8 +890,8 @@ fun <A, B> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(SG, arg0, arg1, arg2) { a, b, c -> Tuple3(a, b, c) }",
-    "arrow.core.mapN"
+    "Cons.mapN(SG, arg0, arg1, arg2) { a, b, c -> Tuple3(a, b, c) }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -914,8 +914,8 @@ fun <A, B, C> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(SG, arg0, arg1, arg2) { a, b, c -> Tuple3(a, b, c) }",
-    "arrow.core.mapN"
+    "Cons.mapN(SG, arg0, arg1, arg2) { a, b, c -> Tuple3(a, b, c) }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -938,8 +938,8 @@ fun <A, B, C> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(SG, arg0, arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }",
-    "arrow.core.mapN"
+    "Cons.mapN(SG, arg0, arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -963,8 +963,8 @@ fun <A, B, C, D> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(SG, arg0, arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }",
-    "arrow.core.mapN"
+    "Cons.mapN(SG, arg0, arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -988,8 +988,8 @@ fun <A, B, C, D> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(SG, arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }",
-    "arrow.core.mapN"
+    "Cons.mapN(SG, arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -1015,8 +1015,8 @@ fun <A, B, C, D, E> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(SG, arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }",
-    "arrow.core.mapN"
+    "Cons.mapN(SG, arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -1042,8 +1042,8 @@ fun <A, B, C, D, E> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, ff -> Tuple6(a, b, c, d, e, ff) }",
-    "arrow.core.mapN"
+    "Cons.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, ff -> Tuple6(a, b, c, d, e, ff) }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -1070,8 +1070,8 @@ fun <A, B, C, D, E, FF> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, ff -> Tuple6(a, b, c, d, e, ff) }",
-    "arrow.core.mapN"
+    "Cons.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, ff -> Tuple6(a, b, c, d, e, ff) }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -1099,8 +1099,8 @@ fun <A, B, C, D, E, FF> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, ff, g -> Tuple7(a, b, c, d, e, ff, g) }",
-    "arrow.core.mapN"
+    "Cons.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, ff, g -> Tuple7(a, b, c, d, e, ff, g) }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -1128,8 +1128,8 @@ fun <A, B, C, D, E, FF, G> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, ff, g -> Tuple7(a, b, c, d, e, ff, g) }",
-    "arrow.core.mapN"
+    "Cons.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, ff, g -> Tuple7(a, b, c, d, e, ff, g) }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -1157,8 +1157,8 @@ fun <A, B, C, D, E, FF, G> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, ff, g, h -> Tuple8(a, b, c, d, e, ff, g, h) }",
-    "arrow.core.mapN"
+    "Cons.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, ff, g, h -> Tuple8(a, b, c, d, e, ff, g, h) }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -1187,8 +1187,8 @@ fun <A, B, C, D, E, FF, G, H> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, ff, g, h -> Tuple8(a, b, c, d, e, ff, g, h) }",
-    "arrow.core.mapN"
+    "Cons.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, ff, g, h -> Tuple8(a, b, c, d, e, ff, g, h) }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -1217,9 +1217,9 @@ fun <A, B, C, D, E, FF, G, H> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, ff, g, h, i -> \n" +
+    "Cons.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, ff, g, h, i -> \n" +
       "Tuple9(a, b, c, d, e, ff, g, h, i) }",
-    "arrow.core.mapN"
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -1249,9 +1249,9 @@ fun <A, B, C, D, E, FF, G, H, I> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, ff, g, h, i -> \n" +
+    "Cons.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, ff, g, h, i -> \n" +
       "Tuple9(a, b, c, d, e, ff, g, h, i) }",
-    "arrow.core.mapN"
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -1281,9 +1281,9 @@ fun <A, B, C, D, E, FF, G, H, I> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, ff, g, h, i, j -> \n" +
+    "Cons.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, ff, g, h, i, j -> \n" +
       "Tuple10(a, b, c, d, e, ff, g, h, i, j) }",
-    "arrow.core.mapN"
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -1315,9 +1315,9 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, ff, g, h, i, j -> \n" +
+    "Cons.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, ff, g, h, i, j -> \n" +
       "Tuple10(a, b, c, d, e, ff, g, h, i, j) }",
-    "arrow.core.mapN"
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -1349,8 +1349,8 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(SG, this, arg1) { (_, right) -> right }",
-    "arrow.core.mapN"
+    "Cons.mapN(SG, this, arg1) { (_, right) -> right }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -1372,8 +1372,8 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.followedBy(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(SG, this, arg1) { (left, _) -> left }",
-    "arrow.core.mapN"
+    "Cons.mapN(SG, this, arg1) { (left, _) -> left }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/apply/ConstApply.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/apply/ConstApply.kt
@@ -31,8 +31,8 @@ import kotlin.jvm.JvmName
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "ap(MA, arg1)",
-  "arrow.core.ap"
+    "ap(MA, arg1)",
+    "arrow.core.Const.ap"
   ),
   DeprecationLevel.WARNING
 )
@@ -53,8 +53,8 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.ap(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "apEval(MA, arg1)",
-  "arrow.core.apEval"
+    "apEval(MA, arg1)",
+    "arrow.core.apEval"
   ),
   DeprecationLevel.WARNING
 )
@@ -76,8 +76,8 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.apEval(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map2Eval(MA, arg1, arg2)",
-  "arrow.core.map2Eval"
+    "map2Eval(MA, arg1, arg2)",
+    "arrow.core.map2Eval"
   ),
   DeprecationLevel.WARNING
 )
@@ -100,8 +100,8 @@ fun <A, B, Z> Kind<Kind<ForConst, A>, A>.map2Eval(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(MA, arg0, arg1, arg2)",
-  "arrow.core.Const.map"
+    "map(MA, arg0, arg1, arg2)",
+    "arrow.core.Const.map"
   ),
   DeprecationLevel.WARNING
 )
@@ -111,8 +111,8 @@ fun <A, B, Z> map(
   arg1: Kind<Kind<ForConst, A>, B>,
   arg2: Function1<Tuple2<A, B>, Z>
 ): Const<A, Z> = arrow.core.Const
-   .apply<A>(MA)
-   .map<A, B, Z>(arg0, arg1, arg2) as arrow.core.Const<A, Z>
+  .apply<A>(MA)
+  .map<A, B, Z>(arg0, arg1, arg2) as arrow.core.Const<A, Z>
 
 @JvmName("mapN")
 @Suppress(
@@ -124,8 +124,8 @@ fun <A, B, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(MA, arg0, arg1, arg2)",
-  "arrow.core.Const.mapN"
+    "mapN(MA, arg0, arg1, arg2)",
+    "arrow.core.Const.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -135,8 +135,8 @@ fun <A, B, Z> mapN(
   arg1: Kind<Kind<ForConst, A>, B>,
   arg2: Function1<Tuple2<A, B>, Z>
 ): Const<A, Z> = arrow.core.Const
-   .apply<A>(MA)
-   .mapN<A, B, Z>(arg0, arg1, arg2) as arrow.core.Const<A, Z>
+  .apply<A>(MA)
+  .mapN<A, B, Z>(arg0, arg1, arg2) as arrow.core.Const<A, Z>
 
 @JvmName("map")
 @Suppress(
@@ -148,8 +148,8 @@ fun <A, B, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(MA, arg0, arg1, arg2, arg3)",
-  "arrow.core.Const.map"
+    "map(MA, arg0, arg1, arg2, arg3)",
+    "arrow.core.Const.map"
   ),
   DeprecationLevel.WARNING
 )
@@ -160,8 +160,8 @@ fun <A, B, C, Z> map(
   arg2: Kind<Kind<ForConst, A>, C>,
   arg3: Function1<Tuple3<A, B, C>, Z>
 ): Const<A, Z> = arrow.core.Const
-   .apply<A>(MA)
-   .map<A, B, C, Z>(arg0, arg1, arg2, arg3) as arrow.core.Const<A, Z>
+  .apply<A>(MA)
+  .map<A, B, C, Z>(arg0, arg1, arg2, arg3) as arrow.core.Const<A, Z>
 
 @JvmName("mapN")
 @Suppress(
@@ -173,8 +173,8 @@ fun <A, B, C, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(MA, arg0, arg1, arg2, arg3)",
-  "arrow.core.Const.mapN"
+    "mapN(MA, arg0, arg1, arg2, arg3)",
+    "arrow.core.Const.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -185,8 +185,8 @@ fun <A, B, C, Z> mapN(
   arg2: Kind<Kind<ForConst, A>, C>,
   arg3: Function1<Tuple3<A, B, C>, Z>
 ): Const<A, Z> = arrow.core.Const
-   .apply<A>(MA)
-   .mapN<A, B, C, Z>(arg0, arg1, arg2, arg3) as arrow.core.Const<A, Z>
+  .apply<A>(MA)
+  .mapN<A, B, C, Z>(arg0, arg1, arg2, arg3) as arrow.core.Const<A, Z>
 
 @JvmName("map")
 @Suppress(
@@ -198,8 +198,8 @@ fun <A, B, C, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(MA, arg0, arg1, arg2, arg3, arg4)",
-  "arrow.core.Const.map"
+    "map(MA, arg0, arg1, arg2, arg3, arg4)",
+    "arrow.core.Const.map"
   ),
   DeprecationLevel.WARNING
 )
@@ -211,8 +211,8 @@ fun <A, B, C, D, Z> map(
   arg3: Kind<Kind<ForConst, A>, D>,
   arg4: Function1<Tuple4<A, B, C, D>, Z>
 ): Const<A, Z> = arrow.core.Const
-   .apply<A>(MA)
-   .map<A, B, C, D, Z>(arg0, arg1, arg2, arg3, arg4) as arrow.core.Const<A, Z>
+  .apply<A>(MA)
+  .map<A, B, C, D, Z>(arg0, arg1, arg2, arg3, arg4) as arrow.core.Const<A, Z>
 
 @JvmName("mapN")
 @Suppress(
@@ -224,8 +224,8 @@ fun <A, B, C, D, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(MA, arg0, arg1, arg2, arg3, arg4)",
-  "arrow.core.Const.mapN"
+    "mapN(MA, arg0, arg1, arg2, arg3, arg4)",
+    "arrow.core.Const.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -237,8 +237,8 @@ fun <A, B, C, D, Z> mapN(
   arg3: Kind<Kind<ForConst, A>, D>,
   arg4: Function1<Tuple4<A, B, C, D>, Z>
 ): Const<A, Z> = arrow.core.Const
-   .apply<A>(MA)
-   .mapN<A, B, C, D, Z>(arg0, arg1, arg2, arg3, arg4) as arrow.core.Const<A, Z>
+  .apply<A>(MA)
+  .mapN<A, B, C, D, Z>(arg0, arg1, arg2, arg3, arg4) as arrow.core.Const<A, Z>
 
 @JvmName("map")
 @Suppress(
@@ -250,8 +250,8 @@ fun <A, B, C, D, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(MA, arg0, arg1, arg2, arg3, arg4, arg5)",
-  "arrow.core.Const.map"
+    "map(MA, arg0, arg1, arg2, arg3, arg4, arg5)",
+    "arrow.core.Const.map"
   ),
   DeprecationLevel.WARNING
 )
@@ -264,8 +264,8 @@ fun <A, B, C, D, E, Z> map(
   arg4: Kind<Kind<ForConst, A>, E>,
   arg5: Function1<Tuple5<A, B, C, D, E>, Z>
 ): Const<A, Z> = arrow.core.Const
-   .apply<A>(MA)
-   .map<A, B, C, D, E, Z>(arg0, arg1, arg2, arg3, arg4, arg5) as arrow.core.Const<A, Z>
+  .apply<A>(MA)
+  .map<A, B, C, D, E, Z>(arg0, arg1, arg2, arg3, arg4, arg5) as arrow.core.Const<A, Z>
 
 @JvmName("mapN")
 @Suppress(
@@ -277,8 +277,8 @@ fun <A, B, C, D, E, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5)",
-  "arrow.core.Const.mapN"
+    "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5)",
+    "arrow.core.Const.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -291,8 +291,8 @@ fun <A, B, C, D, E, Z> mapN(
   arg4: Kind<Kind<ForConst, A>, E>,
   arg5: Function1<Tuple5<A, B, C, D, E>, Z>
 ): Const<A, Z> = arrow.core.Const
-   .apply<A>(MA)
-   .mapN<A, B, C, D, E, Z>(arg0, arg1, arg2, arg3, arg4, arg5) as arrow.core.Const<A, Z>
+  .apply<A>(MA)
+  .mapN<A, B, C, D, E, Z>(arg0, arg1, arg2, arg3, arg4, arg5) as arrow.core.Const<A, Z>
 
 @JvmName("map")
 @Suppress(
@@ -304,8 +304,8 @@ fun <A, B, C, D, E, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-  "arrow.core.Const.map"
+    "map(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
+    "arrow.core.Const.map"
   ),
   DeprecationLevel.WARNING
 )
@@ -319,8 +319,8 @@ fun <A, B, C, D, E, FF, Z> map(
   arg5: Kind<Kind<ForConst, A>, FF>,
   arg6: Function1<Tuple6<A, B, C, D, E, FF>, Z>
 ): Const<A, Z> = arrow.core.Const
-   .apply<A>(MA)
-   .map<A, B, C, D, E, FF, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as arrow.core.Const<A, Z>
+  .apply<A>(MA)
+  .map<A, B, C, D, E, FF, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as arrow.core.Const<A, Z>
 
 @JvmName("mapN")
 @Suppress(
@@ -332,8 +332,8 @@ fun <A, B, C, D, E, FF, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-  "arrow.core.Const.mapN"
+    "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
+    "arrow.core.Const.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -347,8 +347,8 @@ fun <A, B, C, D, E, FF, Z> mapN(
   arg5: Kind<Kind<ForConst, A>, FF>,
   arg6: Function1<Tuple6<A, B, C, D, E, FF>, Z>
 ): Const<A, Z> = arrow.core.Const
-   .apply<A>(MA)
-   .mapN<A, B, C, D, E, FF, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as arrow.core.Const<A, Z>
+  .apply<A>(MA)
+  .mapN<A, B, C, D, E, FF, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as arrow.core.Const<A, Z>
 
 @JvmName("map")
 @Suppress(
@@ -360,8 +360,8 @@ fun <A, B, C, D, E, FF, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-  "arrow.core.Const.map"
+    "map(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
+    "arrow.core.Const.map"
   ),
   DeprecationLevel.WARNING
 )
@@ -376,9 +376,9 @@ fun <A, B, C, D, E, FF, G, Z> map(
   arg6: Kind<Kind<ForConst, A>, G>,
   arg7: Function1<Tuple7<A, B, C, D, E, FF, G>, Z>
 ): Const<A, Z> = arrow.core.Const
-   .apply<A>(MA)
-   .map<A, B, C, D, E, FF, G, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as
-    arrow.core.Const<A, Z>
+  .apply<A>(MA)
+  .map<A, B, C, D, E, FF, G, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as
+  arrow.core.Const<A, Z>
 
 @JvmName("mapN")
 @Suppress(
@@ -390,8 +390,8 @@ fun <A, B, C, D, E, FF, G, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-  "arrow.core.Const.mapN"
+    "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
+    "arrow.core.Const.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -406,9 +406,9 @@ fun <A, B, C, D, E, FF, G, Z> mapN(
   arg6: Kind<Kind<ForConst, A>, G>,
   arg7: Function1<Tuple7<A, B, C, D, E, FF, G>, Z>
 ): Const<A, Z> = arrow.core.Const
-   .apply<A>(MA)
-   .mapN<A, B, C, D, E, FF, G, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as
-    arrow.core.Const<A, Z>
+  .apply<A>(MA)
+  .mapN<A, B, C, D, E, FF, G, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as
+  arrow.core.Const<A, Z>
 
 @JvmName("map")
 @Suppress(
@@ -420,8 +420,8 @@ fun <A, B, C, D, E, FF, G, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-  "arrow.core.Const.map"
+    "map(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
+    "arrow.core.Const.map"
   ),
   DeprecationLevel.WARNING
 )
@@ -437,9 +437,9 @@ fun <A, B, C, D, E, FF, G, H, Z> map(
   arg7: Kind<Kind<ForConst, A>, H>,
   arg8: Function1<Tuple8<A, B, C, D, E, FF, G, H>, Z>
 ): Const<A, Z> = arrow.core.Const
-   .apply<A>(MA)
-   .map<A, B, C, D, E, FF, G, H, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
-    arrow.core.Const<A, Z>
+  .apply<A>(MA)
+  .map<A, B, C, D, E, FF, G, H, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
+  arrow.core.Const<A, Z>
 
 @JvmName("mapN")
 @Suppress(
@@ -451,8 +451,8 @@ fun <A, B, C, D, E, FF, G, H, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-  "arrow.core.Const.mapN"
+    "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
+    "arrow.core.Const.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -468,9 +468,9 @@ fun <A, B, C, D, E, FF, G, H, Z> mapN(
   arg7: Kind<Kind<ForConst, A>, H>,
   arg8: Function1<Tuple8<A, B, C, D, E, FF, G, H>, Z>
 ): Const<A, Z> = arrow.core.Const
-   .apply<A>(MA)
-   .mapN<A, B, C, D, E, FF, G, H, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
-    arrow.core.Const<A, Z>
+  .apply<A>(MA)
+  .mapN<A, B, C, D, E, FF, G, H, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
+  arrow.core.Const<A, Z>
 
 @JvmName("map")
 @Suppress(
@@ -482,8 +482,8 @@ fun <A, B, C, D, E, FF, G, H, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-  "arrow.core.Const.map"
+    "map(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
+    "arrow.core.Const.map"
   ),
   DeprecationLevel.WARNING
 )
@@ -500,9 +500,9 @@ fun <A, B, C, D, E, FF, G, H, I, Z> map(
   arg8: Kind<Kind<ForConst, A>, I>,
   arg9: Function1<Tuple9<A, B, C, D, E, FF, G, H, I>, Z>
 ): Const<A, Z> = arrow.core.Const
-   .apply<A>(MA)
-   .map<A, B, C, D, E, FF, G, H, I, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
-    as arrow.core.Const<A, Z>
+  .apply<A>(MA)
+  .map<A, B, C, D, E, FF, G, H, I, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+  as arrow.core.Const<A, Z>
 
 @JvmName("mapN")
 @Suppress(
@@ -514,8 +514,8 @@ fun <A, B, C, D, E, FF, G, H, I, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-  "arrow.core.Const.mapN"
+    "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
+    "arrow.core.Const.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -532,9 +532,9 @@ fun <A, B, C, D, E, FF, G, H, I, Z> mapN(
   arg8: Kind<Kind<ForConst, A>, I>,
   arg9: Function1<Tuple9<A, B, C, D, E, FF, G, H, I>, Z>
 ): Const<A, Z> = arrow.core.Const
-   .apply<A>(MA)
-   .mapN<A, B, C, D, E, FF, G, H, I, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
-    as arrow.core.Const<A, Z>
+  .apply<A>(MA)
+  .mapN<A, B, C, D, E, FF, G, H, I, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+  as arrow.core.Const<A, Z>
 
 @JvmName("map")
 @Suppress(
@@ -546,8 +546,8 @@ fun <A, B, C, D, E, FF, G, H, I, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)",
-  "arrow.core.Const.map"
+    "map(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)",
+    "arrow.core.Const.map"
   ),
   DeprecationLevel.WARNING
 )
@@ -565,8 +565,8 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> map(
   arg9: Kind<Kind<ForConst, A>, J>,
   arg10: Function1<Tuple10<A, B, C, D, E, FF, G, H, I, J>, Z>
 ): Const<A, Z> = arrow.core.Const
-   .apply<A>(MA)
-   .map<A, B, C, D, E, FF, G, H, I, J,
+  .apply<A>(MA)
+  .map<A, B, C, D, E, FF, G, H, I, J,
     Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) as arrow.core.Const<A, Z>
 
 @JvmName("mapN")
@@ -579,8 +579,8 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)",
-  "arrow.core.Const.mapN"
+    "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)",
+    "arrow.core.Const.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -598,8 +598,8 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> mapN(
   arg9: Kind<Kind<ForConst, A>, J>,
   arg10: Function1<Tuple10<A, B, C, D, E, FF, G, H, I, J>, Z>
 ): Const<A, Z> = arrow.core.Const
-   .apply<A>(MA)
-   .mapN<A, B, C, D, E, FF, G, H, I, J,
+  .apply<A>(MA)
+  .mapN<A, B, C, D, E, FF, G, H, I, J,
     Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) as arrow.core.Const<A, Z>
 
 @JvmName("map2")
@@ -612,8 +612,8 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map2(MA, arg1, arg2)",
-  "arrow.core.map2"
+    "map2(MA, arg1, arg2)",
+    "arrow.core.map2"
   ),
   DeprecationLevel.WARNING
 )
@@ -635,13 +635,13 @@ fun <A, B, Z> Kind<Kind<ForConst, A>, A>.map2(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(MA, arg1)",
-  "arrow.core.product"
+    "product(MA, arg1)",
+    "arrow.core.product"
   ),
   DeprecationLevel.WARNING
 )
 fun <A, B> Kind<Kind<ForConst, A>, A>.product(MA: Monoid<A>, arg1: Kind<Kind<ForConst, A>, B>):
-    Const<A, Tuple2<A, B>> = arrow.core.Const.apply<A>(MA).run {
+  Const<A, Tuple2<A, B>> = arrow.core.Const.apply<A>(MA).run {
   this@product.product<A, B>(arg1) as arrow.core.Const<A, arrow.core.Tuple2<A, B>>
 }
 
@@ -655,8 +655,8 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.product(MA: Monoid<A>, arg1: Kind<Kind<For
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(MA, arg1)",
-  "arrow.core.product"
+    "product(MA, arg1)",
+    "arrow.core.product"
   ),
   DeprecationLevel.WARNING
 )
@@ -677,8 +677,8 @@ fun <A, B, Z> Kind<Kind<ForConst, A>, Tuple2<A, B>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(MA, arg1)",
-  "arrow.core.product"
+    "product(MA, arg1)",
+    "arrow.core.product"
   ),
   DeprecationLevel.WARNING
 )
@@ -686,9 +686,9 @@ fun <A, B, C, Z> Kind<Kind<ForConst, A>, Tuple3<A, B, C>>.product(
   MA: Monoid<A>,
   arg1: Kind<Kind<ForConst, A>, Z>
 ): Const<A, Tuple4<A, B, C, Z>> =
-    arrow.core.Const.apply<A>(MA).run {
-  this@product.product<A, B, C, Z>(arg1) as arrow.core.Const<A, arrow.core.Tuple4<A, B, C, Z>>
-}
+  arrow.core.Const.apply<A>(MA).run {
+    this@product.product<A, B, C, Z>(arg1) as arrow.core.Const<A, arrow.core.Tuple4<A, B, C, Z>>
+  }
 
 @JvmName("product3")
 @Suppress(
@@ -700,8 +700,8 @@ fun <A, B, C, Z> Kind<Kind<ForConst, A>, Tuple3<A, B, C>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(MA, arg1)",
-  "arrow.core.product"
+    "product(MA, arg1)",
+    "arrow.core.product"
   ),
   DeprecationLevel.WARNING
 )
@@ -709,9 +709,9 @@ fun <A, B, C, D, Z> Kind<Kind<ForConst, A>, Tuple4<A, B, C, D>>.product(
   MA: Monoid<A>,
   arg1: Kind<Kind<ForConst, A>, Z>
 ): Const<A, Tuple5<A, B, C, D, Z>> =
-    arrow.core.Const.apply<A>(MA).run {
-  this@product.product<A, B, C, D, Z>(arg1) as arrow.core.Const<A, arrow.core.Tuple5<A, B, C, D, Z>>
-}
+  arrow.core.Const.apply<A>(MA).run {
+    this@product.product<A, B, C, D, Z>(arg1) as arrow.core.Const<A, arrow.core.Tuple5<A, B, C, D, Z>>
+  }
 
 @JvmName("product4")
 @Suppress(
@@ -723,8 +723,8 @@ fun <A, B, C, D, Z> Kind<Kind<ForConst, A>, Tuple4<A, B, C, D>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(MA, arg1)",
-  "arrow.core.product"
+    "product(MA, arg1)",
+    "arrow.core.product"
   ),
   DeprecationLevel.WARNING
 )
@@ -732,10 +732,10 @@ fun <A, B, C, D, E, Z> Kind<Kind<ForConst, A>, Tuple5<A, B, C, D, E>>.product(
   MA: Monoid<A>,
   arg1: Kind<Kind<ForConst, A>, Z>
 ): Const<A, Tuple6<A, B, C, D, E, Z>> =
-    arrow.core.Const.apply<A>(MA).run {
-  this@product.product<A, B, C, D, E, Z>(arg1) as arrow.core.Const<A, arrow.core.Tuple6<A, B, C, D,
-    E, Z>>
-}
+  arrow.core.Const.apply<A>(MA).run {
+    this@product.product<A, B, C, D, E, Z>(arg1) as arrow.core.Const<A, arrow.core.Tuple6<A, B, C, D,
+      E, Z>>
+  }
 
 @JvmName("product5")
 @Suppress(
@@ -747,8 +747,8 @@ fun <A, B, C, D, E, Z> Kind<Kind<ForConst, A>, Tuple5<A, B, C, D, E>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(MA, arg1)",
-  "arrow.core.product"
+    "product(MA, arg1)",
+    "arrow.core.product"
   ),
   DeprecationLevel.WARNING
 )
@@ -756,10 +756,10 @@ fun <A, B, C, D, E, FF, Z> Kind<Kind<ForConst, A>, Tuple6<A, B, C, D, E, FF>>.pr
   MA: Monoid<A>,
   arg1: Kind<Kind<ForConst, A>, Z>
 ): Const<A, Tuple7<A, B, C, D, E, FF, Z>> =
-    arrow.core.Const.apply<A>(MA).run {
-  this@product.product<A, B, C, D, E, FF, Z>(arg1) as arrow.core.Const<A, arrow.core.Tuple7<A, B, C,
-    D, E, FF, Z>>
-}
+  arrow.core.Const.apply<A>(MA).run {
+    this@product.product<A, B, C, D, E, FF, Z>(arg1) as arrow.core.Const<A, arrow.core.Tuple7<A, B, C,
+      D, E, FF, Z>>
+  }
 
 @JvmName("product6")
 @Suppress(
@@ -771,14 +771,14 @@ fun <A, B, C, D, E, FF, Z> Kind<Kind<ForConst, A>, Tuple6<A, B, C, D, E, FF>>.pr
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(MA, arg1)",
-  "arrow.core.product"
+    "product(MA, arg1)",
+    "arrow.core.product"
   ),
   DeprecationLevel.WARNING
 )
 fun <A, B, C, D, E, FF, G, Z> Kind<Kind<ForConst, A>, Tuple7<A, B, C, D, E, FF,
-    G>>.product(MA: Monoid<A>, arg1: Kind<Kind<ForConst, A>, Z>): Const<A, Tuple8<A, B, C, D, E, FF,
-    G, Z>> = arrow.core.Const.apply<A>(MA).run {
+  G>>.product(MA: Monoid<A>, arg1: Kind<Kind<ForConst, A>, Z>): Const<A, Tuple8<A, B, C, D, E, FF,
+  G, Z>> = arrow.core.Const.apply<A>(MA).run {
   this@product.product<A, B, C, D, E, FF, G, Z>(arg1) as arrow.core.Const<A, arrow.core.Tuple8<A, B,
     C, D, E, FF, G, Z>>
 }
@@ -793,14 +793,14 @@ fun <A, B, C, D, E, FF, G, Z> Kind<Kind<ForConst, A>, Tuple7<A, B, C, D, E, FF,
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(MA, arg1)",
-  "arrow.core.product"
+    "product(MA, arg1)",
+    "arrow.core.product"
   ),
   DeprecationLevel.WARNING
 )
 fun <A, B, C, D, E, FF, G, H, Z> Kind<Kind<ForConst, A>, Tuple8<A, B, C, D, E, FF, G,
-    H>>.product(MA: Monoid<A>, arg1: Kind<Kind<ForConst, A>, Z>): Const<A, Tuple9<A, B, C, D, E, FF,
-    G, H, Z>> = arrow.core.Const.apply<A>(MA).run {
+  H>>.product(MA: Monoid<A>, arg1: Kind<Kind<ForConst, A>, Z>): Const<A, Tuple9<A, B, C, D, E, FF,
+  G, H, Z>> = arrow.core.Const.apply<A>(MA).run {
   this@product.product<A, B, C, D, E, FF, G, H, Z>(arg1) as arrow.core.Const<A, arrow.core.Tuple9<A,
     B, C, D, E, FF, G, H, Z>>
 }
@@ -815,14 +815,14 @@ fun <A, B, C, D, E, FF, G, H, Z> Kind<Kind<ForConst, A>, Tuple8<A, B, C, D, E, F
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(MA, arg1)",
-  "arrow.core.product"
+    "product(MA, arg1)",
+    "arrow.core.product"
   ),
   DeprecationLevel.WARNING
 )
 fun <A, B, C, D, E, FF, G, H, I, Z> Kind<Kind<ForConst, A>, Tuple9<A, B, C, D, E, FF, G, H,
-    I>>.product(MA: Monoid<A>, arg1: Kind<Kind<ForConst, A>, Z>): Const<A, Tuple10<A, B, C, D, E,
-    FF, G, H, I, Z>> = arrow.core.Const.apply<A>(MA).run {
+  I>>.product(MA: Monoid<A>, arg1: Kind<Kind<ForConst, A>, Z>): Const<A, Tuple10<A, B, C, D, E,
+  FF, G, H, I, Z>> = arrow.core.Const.apply<A>(MA).run {
   this@product.product<A, B, C, D, E, FF, G, H, I, Z>(arg1) as arrow.core.Const<A,
     arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, Z>>
 }
@@ -837,8 +837,8 @@ fun <A, B, C, D, E, FF, G, H, I, Z> Kind<Kind<ForConst, A>, Tuple9<A, B, C, D, E
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(MA, arg0, arg1)",
-  "arrow.core.Const.tupled"
+    "tupled(MA, arg0, arg1)",
+    "arrow.core.Const.tupled"
   ),
   DeprecationLevel.WARNING
 )
@@ -847,8 +847,8 @@ fun <A, B> tupled(
   arg0: Kind<Kind<ForConst, A>, A>,
   arg1: Kind<Kind<ForConst, A>, B>
 ): Const<A, Tuple2<A, B>> = arrow.core.Const
-   .apply<A>(MA)
-   .tupled<A, B>(arg0, arg1) as arrow.core.Const<A, arrow.core.Tuple2<A, B>>
+  .apply<A>(MA)
+  .tupled<A, B>(arg0, arg1) as arrow.core.Const<A, arrow.core.Tuple2<A, B>>
 
 @JvmName("tupledN")
 @Suppress(
@@ -860,8 +860,8 @@ fun <A, B> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(MA, arg0, arg1)",
-  "arrow.core.Const.tupledN"
+    "tupledN(MA, arg0, arg1)",
+    "arrow.core.Const.tupledN"
   ),
   DeprecationLevel.WARNING
 )
@@ -870,8 +870,8 @@ fun <A, B> tupledN(
   arg0: Kind<Kind<ForConst, A>, A>,
   arg1: Kind<Kind<ForConst, A>, B>
 ): Const<A, Tuple2<A, B>> = arrow.core.Const
-   .apply<A>(MA)
-   .tupledN<A, B>(arg0, arg1) as arrow.core.Const<A, arrow.core.Tuple2<A, B>>
+  .apply<A>(MA)
+  .tupledN<A, B>(arg0, arg1) as arrow.core.Const<A, arrow.core.Tuple2<A, B>>
 
 @JvmName("tupled")
 @Suppress(
@@ -883,8 +883,8 @@ fun <A, B> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(MA, arg0, arg1, arg2)",
-  "arrow.core.Const.tupled"
+    "tupled(MA, arg0, arg1, arg2)",
+    "arrow.core.Const.tupled"
   ),
   DeprecationLevel.WARNING
 )
@@ -894,8 +894,8 @@ fun <A, B, C> tupled(
   arg1: Kind<Kind<ForConst, A>, B>,
   arg2: Kind<Kind<ForConst, A>, C>
 ): Const<A, Tuple3<A, B, C>> = arrow.core.Const
-   .apply<A>(MA)
-   .tupled<A, B, C>(arg0, arg1, arg2) as arrow.core.Const<A, arrow.core.Tuple3<A, B, C>>
+  .apply<A>(MA)
+  .tupled<A, B, C>(arg0, arg1, arg2) as arrow.core.Const<A, arrow.core.Tuple3<A, B, C>>
 
 @JvmName("tupledN")
 @Suppress(
@@ -907,8 +907,8 @@ fun <A, B, C> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(MA, arg0, arg1, arg2)",
-  "arrow.core.Const.tupledN"
+    "tupledN(MA, arg0, arg1, arg2)",
+    "arrow.core.Const.tupledN"
   ),
   DeprecationLevel.WARNING
 )
@@ -918,8 +918,8 @@ fun <A, B, C> tupledN(
   arg1: Kind<Kind<ForConst, A>, B>,
   arg2: Kind<Kind<ForConst, A>, C>
 ): Const<A, Tuple3<A, B, C>> = arrow.core.Const
-   .apply<A>(MA)
-   .tupledN<A, B, C>(arg0, arg1, arg2) as arrow.core.Const<A, arrow.core.Tuple3<A, B, C>>
+  .apply<A>(MA)
+  .tupledN<A, B, C>(arg0, arg1, arg2) as arrow.core.Const<A, arrow.core.Tuple3<A, B, C>>
 
 @JvmName("tupled")
 @Suppress(
@@ -931,8 +931,8 @@ fun <A, B, C> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(MA, arg0, arg1, arg2, arg3)",
-  "arrow.core.Const.tupled"
+    "tupled(MA, arg0, arg1, arg2, arg3)",
+    "arrow.core.Const.tupled"
   ),
   DeprecationLevel.WARNING
 )
@@ -943,8 +943,8 @@ fun <A, B, C, D> tupled(
   arg2: Kind<Kind<ForConst, A>, C>,
   arg3: Kind<Kind<ForConst, A>, D>
 ): Const<A, Tuple4<A, B, C, D>> = arrow.core.Const
-   .apply<A>(MA)
-   .tupled<A, B, C, D>(arg0, arg1, arg2, arg3) as arrow.core.Const<A, arrow.core.Tuple4<A, B, C, D>>
+  .apply<A>(MA)
+  .tupled<A, B, C, D>(arg0, arg1, arg2, arg3) as arrow.core.Const<A, arrow.core.Tuple4<A, B, C, D>>
 
 @JvmName("tupledN")
 @Suppress(
@@ -956,8 +956,8 @@ fun <A, B, C, D> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(MA, arg0, arg1, arg2, arg3)",
-  "arrow.core.Const.tupledN"
+    "tupledN(MA, arg0, arg1, arg2, arg3)",
+    "arrow.core.Const.tupledN"
   ),
   DeprecationLevel.WARNING
 )
@@ -968,9 +968,9 @@ fun <A, B, C, D> tupledN(
   arg2: Kind<Kind<ForConst, A>, C>,
   arg3: Kind<Kind<ForConst, A>, D>
 ): Const<A, Tuple4<A, B, C, D>> = arrow.core.Const
-   .apply<A>(MA)
-   .tupledN<A, B, C, D>(arg0, arg1, arg2, arg3) as arrow.core.Const<A, arrow.core.Tuple4<A, B, C,
-    D>>
+  .apply<A>(MA)
+  .tupledN<A, B, C, D>(arg0, arg1, arg2, arg3) as arrow.core.Const<A, arrow.core.Tuple4<A, B, C,
+  D>>
 
 @JvmName("tupled")
 @Suppress(
@@ -982,8 +982,8 @@ fun <A, B, C, D> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(MA, arg0, arg1, arg2, arg3, arg4)",
-  "arrow.core.Const.tupled"
+    "tupled(MA, arg0, arg1, arg2, arg3, arg4)",
+    "arrow.core.Const.tupled"
   ),
   DeprecationLevel.WARNING
 )
@@ -995,9 +995,9 @@ fun <A, B, C, D, E> tupled(
   arg3: Kind<Kind<ForConst, A>, D>,
   arg4: Kind<Kind<ForConst, A>, E>
 ): Const<A, Tuple5<A, B, C, D, E>> = arrow.core.Const
-   .apply<A>(MA)
-   .tupled<A, B, C, D, E>(arg0, arg1, arg2, arg3, arg4) as arrow.core.Const<A, arrow.core.Tuple5<A,
-    B, C, D, E>>
+  .apply<A>(MA)
+  .tupled<A, B, C, D, E>(arg0, arg1, arg2, arg3, arg4) as arrow.core.Const<A, arrow.core.Tuple5<A,
+  B, C, D, E>>
 
 @JvmName("tupledN")
 @Suppress(
@@ -1009,8 +1009,8 @@ fun <A, B, C, D, E> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(MA, arg0, arg1, arg2, arg3, arg4)",
-  "arrow.core.Const.tupledN"
+    "tupledN(MA, arg0, arg1, arg2, arg3, arg4)",
+    "arrow.core.Const.tupledN"
   ),
   DeprecationLevel.WARNING
 )
@@ -1022,9 +1022,9 @@ fun <A, B, C, D, E> tupledN(
   arg3: Kind<Kind<ForConst, A>, D>,
   arg4: Kind<Kind<ForConst, A>, E>
 ): Const<A, Tuple5<A, B, C, D, E>> = arrow.core.Const
-   .apply<A>(MA)
-   .tupledN<A, B, C, D, E>(arg0, arg1, arg2, arg3, arg4) as arrow.core.Const<A, arrow.core.Tuple5<A,
-    B, C, D, E>>
+  .apply<A>(MA)
+  .tupledN<A, B, C, D, E>(arg0, arg1, arg2, arg3, arg4) as arrow.core.Const<A, arrow.core.Tuple5<A,
+  B, C, D, E>>
 
 @JvmName("tupled")
 @Suppress(
@@ -1036,8 +1036,8 @@ fun <A, B, C, D, E> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(MA, arg0, arg1, arg2, arg3, arg4, arg5)",
-  "arrow.core.Const.tupled"
+    "tupled(MA, arg0, arg1, arg2, arg3, arg4, arg5)",
+    "arrow.core.Const.tupled"
   ),
   DeprecationLevel.WARNING
 )
@@ -1050,9 +1050,9 @@ fun <A, B, C, D, E, FF> tupled(
   arg4: Kind<Kind<ForConst, A>, E>,
   arg5: Kind<Kind<ForConst, A>, FF>
 ): Const<A, Tuple6<A, B, C, D, E, FF>> = arrow.core.Const
-   .apply<A>(MA)
-   .tupled<A, B, C, D, E, FF>(arg0, arg1, arg2, arg3, arg4, arg5) as arrow.core.Const<A,
-    arrow.core.Tuple6<A, B, C, D, E, FF>>
+  .apply<A>(MA)
+  .tupled<A, B, C, D, E, FF>(arg0, arg1, arg2, arg3, arg4, arg5) as arrow.core.Const<A,
+  arrow.core.Tuple6<A, B, C, D, E, FF>>
 
 @JvmName("tupledN")
 @Suppress(
@@ -1064,8 +1064,8 @@ fun <A, B, C, D, E, FF> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(MA, arg0, arg1, arg2, arg3, arg4, arg5)",
-  "arrow.core.Const.tupledN"
+    "tupledN(MA, arg0, arg1, arg2, arg3, arg4, arg5)",
+    "arrow.core.Const.tupledN"
   ),
   DeprecationLevel.WARNING
 )
@@ -1078,9 +1078,9 @@ fun <A, B, C, D, E, FF> tupledN(
   arg4: Kind<Kind<ForConst, A>, E>,
   arg5: Kind<Kind<ForConst, A>, FF>
 ): Const<A, Tuple6<A, B, C, D, E, FF>> = arrow.core.Const
-   .apply<A>(MA)
-   .tupledN<A, B, C, D, E, FF>(arg0, arg1, arg2, arg3, arg4, arg5) as arrow.core.Const<A,
-    arrow.core.Tuple6<A, B, C, D, E, FF>>
+  .apply<A>(MA)
+  .tupledN<A, B, C, D, E, FF>(arg0, arg1, arg2, arg3, arg4, arg5) as arrow.core.Const<A,
+  arrow.core.Tuple6<A, B, C, D, E, FF>>
 
 @JvmName("tupled")
 @Suppress(
@@ -1092,8 +1092,8 @@ fun <A, B, C, D, E, FF> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-  "arrow.core.Const.tupled"
+    "tupled(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
+    "arrow.core.Const.tupled"
   ),
   DeprecationLevel.WARNING
 )
@@ -1107,9 +1107,9 @@ fun <A, B, C, D, E, FF, G> tupled(
   arg5: Kind<Kind<ForConst, A>, FF>,
   arg6: Kind<Kind<ForConst, A>, G>
 ): Const<A, Tuple7<A, B, C, D, E, FF, G>> = arrow.core.Const
-   .apply<A>(MA)
-   .tupled<A, B, C, D, E, FF, G>(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as arrow.core.Const<A,
-    arrow.core.Tuple7<A, B, C, D, E, FF, G>>
+  .apply<A>(MA)
+  .tupled<A, B, C, D, E, FF, G>(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as arrow.core.Const<A,
+  arrow.core.Tuple7<A, B, C, D, E, FF, G>>
 
 @JvmName("tupledN")
 @Suppress(
@@ -1121,8 +1121,8 @@ fun <A, B, C, D, E, FF, G> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-  "arrow.core.Const.tupledN"
+    "tupledN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
+    "arrow.core.Const.tupledN"
   ),
   DeprecationLevel.WARNING
 )
@@ -1136,9 +1136,9 @@ fun <A, B, C, D, E, FF, G> tupledN(
   arg5: Kind<Kind<ForConst, A>, FF>,
   arg6: Kind<Kind<ForConst, A>, G>
 ): Const<A, Tuple7<A, B, C, D, E, FF, G>> = arrow.core.Const
-   .apply<A>(MA)
-   .tupledN<A, B, C, D, E, FF, G>(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as arrow.core.Const<A,
-    arrow.core.Tuple7<A, B, C, D, E, FF, G>>
+  .apply<A>(MA)
+  .tupledN<A, B, C, D, E, FF, G>(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as arrow.core.Const<A,
+  arrow.core.Tuple7<A, B, C, D, E, FF, G>>
 
 @JvmName("tupled")
 @Suppress(
@@ -1150,8 +1150,8 @@ fun <A, B, C, D, E, FF, G> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-  "arrow.core.Const.tupled"
+    "tupled(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
+    "arrow.core.Const.tupled"
   ),
   DeprecationLevel.WARNING
 )
@@ -1166,9 +1166,9 @@ fun <A, B, C, D, E, FF, G, H> tupled(
   arg6: Kind<Kind<ForConst, A>, G>,
   arg7: Kind<Kind<ForConst, A>, H>
 ): Const<A, Tuple8<A, B, C, D, E, FF, G, H>> = arrow.core.Const
-   .apply<A>(MA)
-   .tupled<A, B, C, D, E, FF, G, H>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as
-    arrow.core.Const<A, arrow.core.Tuple8<A, B, C, D, E, FF, G, H>>
+  .apply<A>(MA)
+  .tupled<A, B, C, D, E, FF, G, H>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as
+  arrow.core.Const<A, arrow.core.Tuple8<A, B, C, D, E, FF, G, H>>
 
 @JvmName("tupledN")
 @Suppress(
@@ -1180,8 +1180,8 @@ fun <A, B, C, D, E, FF, G, H> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-  "arrow.core.Const.tupledN"
+    "tupledN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
+    "arrow.core.Const.tupledN"
   ),
   DeprecationLevel.WARNING
 )
@@ -1196,9 +1196,9 @@ fun <A, B, C, D, E, FF, G, H> tupledN(
   arg6: Kind<Kind<ForConst, A>, G>,
   arg7: Kind<Kind<ForConst, A>, H>
 ): Const<A, Tuple8<A, B, C, D, E, FF, G, H>> = arrow.core.Const
-   .apply<A>(MA)
-   .tupledN<A, B, C, D, E, FF, G, H>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as
-    arrow.core.Const<A, arrow.core.Tuple8<A, B, C, D, E, FF, G, H>>
+  .apply<A>(MA)
+  .tupledN<A, B, C, D, E, FF, G, H>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as
+  arrow.core.Const<A, arrow.core.Tuple8<A, B, C, D, E, FF, G, H>>
 
 @JvmName("tupled")
 @Suppress(
@@ -1210,8 +1210,8 @@ fun <A, B, C, D, E, FF, G, H> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-  "arrow.core.Const.tupled"
+    "tupled(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
+    "arrow.core.Const.tupled"
   ),
   DeprecationLevel.WARNING
 )
@@ -1227,9 +1227,9 @@ fun <A, B, C, D, E, FF, G, H, I> tupled(
   arg7: Kind<Kind<ForConst, A>, H>,
   arg8: Kind<Kind<ForConst, A>, I>
 ): Const<A, Tuple9<A, B, C, D, E, FF, G, H, I>> = arrow.core.Const
-   .apply<A>(MA)
-   .tupled<A, B, C, D, E, FF, G, H, I>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
-    arrow.core.Const<A, arrow.core.Tuple9<A, B, C, D, E, FF, G, H, I>>
+  .apply<A>(MA)
+  .tupled<A, B, C, D, E, FF, G, H, I>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
+  arrow.core.Const<A, arrow.core.Tuple9<A, B, C, D, E, FF, G, H, I>>
 
 @JvmName("tupledN")
 @Suppress(
@@ -1241,8 +1241,8 @@ fun <A, B, C, D, E, FF, G, H, I> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-  "arrow.core.Const.tupledN"
+    "tupledN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
+    "arrow.core.Const.tupledN"
   ),
   DeprecationLevel.WARNING
 )
@@ -1258,9 +1258,9 @@ fun <A, B, C, D, E, FF, G, H, I> tupledN(
   arg7: Kind<Kind<ForConst, A>, H>,
   arg8: Kind<Kind<ForConst, A>, I>
 ): Const<A, Tuple9<A, B, C, D, E, FF, G, H, I>> = arrow.core.Const
-   .apply<A>(MA)
-   .tupledN<A, B, C, D, E, FF, G, H, I>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
-    arrow.core.Const<A, arrow.core.Tuple9<A, B, C, D, E, FF, G, H, I>>
+  .apply<A>(MA)
+  .tupledN<A, B, C, D, E, FF, G, H, I>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
+  arrow.core.Const<A, arrow.core.Tuple9<A, B, C, D, E, FF, G, H, I>>
 
 @JvmName("tupled")
 @Suppress(
@@ -1272,8 +1272,8 @@ fun <A, B, C, D, E, FF, G, H, I> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-  "arrow.core.Const.tupled"
+    "tupled(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
+    "arrow.core.Const.tupled"
   ),
   DeprecationLevel.WARNING
 )
@@ -1290,10 +1290,10 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupled(
   arg8: Kind<Kind<ForConst, A>, I>,
   arg9: Kind<Kind<ForConst, A>, J>
 ): Const<A, Tuple10<A, B, C, D, E, FF, G, H, I, J>> = arrow.core.Const
-   .apply<A>(MA)
-   .tupled<A, B, C, D, E, FF, G, H, I,
+  .apply<A>(MA)
+  .tupled<A, B, C, D, E, FF, G, H, I,
     J>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) as arrow.core.Const<A,
-    arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, J>>
+  arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, J>>
 
 @JvmName("tupledN")
 @Suppress(
@@ -1305,8 +1305,8 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-  "arrow.core.Const.tupledN"
+    "tupledN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
+    "arrow.core.Const.tupledN"
   ),
   DeprecationLevel.WARNING
 )
@@ -1323,10 +1323,10 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupledN(
   arg8: Kind<Kind<ForConst, A>, I>,
   arg9: Kind<Kind<ForConst, A>, J>
 ): Const<A, Tuple10<A, B, C, D, E, FF, G, H, I, J>> = arrow.core.Const
-   .apply<A>(MA)
-   .tupledN<A, B, C, D, E, FF, G, H, I,
+  .apply<A>(MA)
+  .tupledN<A, B, C, D, E, FF, G, H, I,
     J>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) as arrow.core.Const<A,
-    arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, J>>
+  arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, J>>
 
 @JvmName("followedBy")
 @Suppress(
@@ -1338,13 +1338,13 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "followedBy(MA, arg1)",
-  "arrow.core.followedBy"
+    "followedBy(MA, arg1)",
+    "arrow.core.followedBy"
   ),
   DeprecationLevel.WARNING
 )
 fun <A, B> Kind<Kind<ForConst, A>, A>.followedBy(MA: Monoid<A>, arg1: Kind<Kind<ForConst, A>, B>):
-    Const<A, B> = arrow.core.Const.apply<A>(MA).run {
+  Const<A, B> = arrow.core.Const.apply<A>(MA).run {
   this@followedBy.followedBy<A, B>(arg1) as arrow.core.Const<A, B>
 }
 
@@ -1358,13 +1358,13 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.followedBy(MA: Monoid<A>, arg1: Kind<Kind<
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "apTap(MA, arg1)",
-  "arrow.core.apTap"
+    "apTap(MA, arg1)",
+    "arrow.core.apTap"
   ),
   DeprecationLevel.WARNING
 )
 fun <A, B> Kind<Kind<ForConst, A>, A>.apTap(MA: Monoid<A>, arg1: Kind<Kind<ForConst, A>, B>):
-    Const<A, A> = arrow.core.Const.apply<A>(MA).run {
+  Const<A, A> = arrow.core.Const.apply<A>(MA).run {
   this@apTap.apTap<A, B>(arg1) as arrow.core.Const<A, A>
 }
 
@@ -1372,5 +1372,11 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.apTap(MA: Monoid<A>, arg1: Kind<Kind<ForCo
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated(
+  "Apply typeclass is deprecated. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
+)
 inline fun <A> Companion.apply(MA: Monoid<A>): ConstApply<A> = object :
-    arrow.core.extensions.ConstApply<A> { override fun MA(): arrow.typeclasses.Monoid<A> = MA }
+  arrow.core.extensions.ConstApply<A> {
+  override fun MA(): arrow.typeclasses.Monoid<A> = MA
+}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/apply/ConstApply.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/apply/ConstApply.kt
@@ -53,18 +53,18 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.ap(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "apEval(MA, arg1)",
-    "arrow.core.apEval"
+    "arg1.map { retag<Z>().combine(MA, it.retag()) }",
+    "arrow.core.combine"
   ),
   DeprecationLevel.WARNING
 )
 fun <A, B> Kind<Kind<ForConst, A>, A>.apEval(
   MA: Monoid<A>,
   arg1: Eval<Kind<Kind<ForConst, A>, Function1<A, B>>>
-): Eval<Kind<Kind<ForConst, A>, B>> = arrow.core.Const.apply<A>(MA).run {
-  this@apEval.apEval<A, B>(arg1) as arrow.core.Eval<arrow.Kind<arrow.Kind<arrow.core.ForConst, A>,
-    B>>
-}
+): Eval<Kind<Kind<ForConst, A>, B>> =
+  arrow.core.Const.apply<A>(MA).run {
+    this@apEval.apEval<A, B>(arg1) as arrow.core.Eval<arrow.Kind<arrow.Kind<arrow.core.ForConst, A>, B>>
+  }
 
 @JvmName("map2Eval")
 @Suppress(
@@ -76,8 +76,8 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.apEval(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "map2Eval(MA, arg1, arg2)",
-    "arrow.core.map2Eval"
+    "arg1.map { retag<Z>().combine(MA, it.retag()) }",
+    "arrow.core.combine"
   ),
   DeprecationLevel.WARNING
 )
@@ -85,10 +85,10 @@ fun <A, B, Z> Kind<Kind<ForConst, A>, A>.map2Eval(
   MA: Monoid<A>,
   arg1: Eval<Kind<Kind<ForConst, A>, B>>,
   arg2: Function1<Tuple2<A, B>, Z>
-): Eval<Kind<Kind<ForConst, A>, Z>> = arrow.core.Const.apply<A>(MA).run {
-  this@map2Eval.map2Eval<A, B, Z>(arg1, arg2) as
-    arrow.core.Eval<arrow.Kind<arrow.Kind<arrow.core.ForConst, A>, Z>>
-}
+): Eval<Kind<Kind<ForConst, A>, Z>> =
+  arrow.core.Const.apply<A>(MA).run {
+    this@map2Eval.map2Eval<A, B, Z>(arg1, arg2) as arrow.core.Eval<arrow.Kind<arrow.Kind<arrow.core.ForConst, A>, Z>>
+  }
 
 @JvmName("map")
 @Suppress(
@@ -100,8 +100,8 @@ fun <A, B, Z> Kind<Kind<ForConst, A>, A>.map2Eval(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "map(MA, arg0, arg1, arg2)",
-    "arrow.core.Const.map"
+    "mapN(MA, arg0, arg1, arg2)",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -125,7 +125,7 @@ fun <A, B, Z> map(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
     "mapN(MA, arg0, arg1, arg2)",
-    "arrow.core.Const.mapN"
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -148,8 +148,8 @@ fun <A, B, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "map(MA, arg0, arg1, arg2, arg3)",
-    "arrow.core.Const.map"
+    "mapN(MA, arg0, arg1, arg2, arg3)",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -174,7 +174,7 @@ fun <A, B, C, Z> map(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
     "mapN(MA, arg0, arg1, arg2, arg3)",
-    "arrow.core.Const.mapN"
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -198,8 +198,8 @@ fun <A, B, C, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "map(MA, arg0, arg1, arg2, arg3, arg4)",
-    "arrow.core.Const.map"
+    "mapN(MA, arg0, arg1, arg2, arg3, arg4)",
+    "arrow.core.map"
   ),
   DeprecationLevel.WARNING
 )
@@ -225,7 +225,7 @@ fun <A, B, C, D, Z> map(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
     "mapN(MA, arg0, arg1, arg2, arg3, arg4)",
-    "arrow.core.Const.mapN"
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -250,8 +250,8 @@ fun <A, B, C, D, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "map(MA, arg0, arg1, arg2, arg3, arg4, arg5)",
-    "arrow.core.Const.map"
+    "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5)",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -278,7 +278,7 @@ fun <A, B, C, D, E, Z> map(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
     "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5)",
-    "arrow.core.Const.mapN"
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -304,8 +304,8 @@ fun <A, B, C, D, E, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "map(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-    "arrow.core.Const.map"
+    "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -333,7 +333,7 @@ fun <A, B, C, D, E, FF, Z> map(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
     "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-    "arrow.core.Const.mapN"
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -360,8 +360,8 @@ fun <A, B, C, D, E, FF, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "map(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-    "arrow.core.Const.map"
+    "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -391,7 +391,7 @@ fun <A, B, C, D, E, FF, G, Z> map(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
     "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-    "arrow.core.Const.mapN"
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -420,8 +420,8 @@ fun <A, B, C, D, E, FF, G, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "map(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-    "arrow.core.Const.map"
+    "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -452,7 +452,7 @@ fun <A, B, C, D, E, FF, G, H, Z> map(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
     "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-    "arrow.core.Const.mapN"
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -482,8 +482,8 @@ fun <A, B, C, D, E, FF, G, H, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "map(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-    "arrow.core.Const.map"
+    "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -515,7 +515,7 @@ fun <A, B, C, D, E, FF, G, H, I, Z> map(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
     "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-    "arrow.core.Const.mapN"
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -546,8 +546,8 @@ fun <A, B, C, D, E, FF, G, H, I, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "map(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)",
-    "arrow.core.Const.map"
+    "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -580,7 +580,7 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> map(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
     "mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)",
-    "arrow.core.Const.mapN"
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -599,8 +599,7 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> mapN(
   arg10: Function1<Tuple10<A, B, C, D, E, FF, G, H, I, J>, Z>
 ): Const<A, Z> = arrow.core.Const
   .apply<A>(MA)
-  .mapN<A, B, C, D, E, FF, G, H, I, J,
-    Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) as arrow.core.Const<A, Z>
+  .mapN<A, B, C, D, E, FF, G, H, I, J, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) as arrow.core.Const<A, Z>
 
 @JvmName("map2")
 @Suppress(
@@ -612,8 +611,8 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "map2(MA, arg1, arg2)",
-    "arrow.core.map2"
+    "mapN(MA, this, arg1).map(arg2)",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -635,15 +634,15 @@ fun <A, B, Z> Kind<Kind<ForConst, A>, A>.map2(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "product(MA, arg1)",
-    "arrow.core.product"
+    "mapN(MA, this, arg1) { a, b -> Tuple2(a, b) }",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
-fun <A, B> Kind<Kind<ForConst, A>, A>.product(MA: Monoid<A>, arg1: Kind<Kind<ForConst, A>, B>):
-  Const<A, Tuple2<A, B>> = arrow.core.Const.apply<A>(MA).run {
-  this@product.product<A, B>(arg1) as arrow.core.Const<A, arrow.core.Tuple2<A, B>>
-}
+fun <A, B> Kind<Kind<ForConst, A>, A>.product(MA: Monoid<A>, arg1: Kind<Kind<ForConst, A>, B>): Const<A, Tuple2<A, B>> =
+  arrow.core.Const.apply<A>(MA).run {
+    this@product.product<A, B>(arg1) as arrow.core.Const<A, arrow.core.Tuple2<A, B>>
+  }
 
 @JvmName("product1")
 @Suppress(
@@ -655,8 +654,8 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.product(MA: Monoid<A>, arg1: Kind<Kind<For
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "product(MA, arg1)",
-    "arrow.core.product"
+    "mapN(MA, this, arg1).map { (ab, c) -> Tuple3(ab.a, ab.b, c) }",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -677,8 +676,8 @@ fun <A, B, Z> Kind<Kind<ForConst, A>, Tuple2<A, B>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "product(MA, arg1)",
-    "arrow.core.product"
+    "mapN(MA, this, arg1).map { (abc, d) -> Tuple4(abc.a, abc.b, abc.c, d) }",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -700,8 +699,9 @@ fun <A, B, C, Z> Kind<Kind<ForConst, A>, Tuple3<A, B, C>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "product(MA, arg1)",
-    "arrow.core.product"
+    "mapN(MA, this, arg1).map { (abcd, e) -> Tuple5(abcd.a, abcd.b, abcd.c, abcd.d, e) }",
+    "arrow.core.retag",
+    "arrow.core.combine"
   ),
   DeprecationLevel.WARNING
 )
@@ -723,8 +723,9 @@ fun <A, B, C, D, Z> Kind<Kind<ForConst, A>, Tuple4<A, B, C, D>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "product(MA, arg1)",
-    "arrow.core.product"
+    "mapN(MA, this, arg1).map { (abcde, f) -> Tuple6(abcde.a, abcde.b, abcde.c, abcde.d, abcde.e, f) }",
+    "arrow.core.retag",
+    "arrow.core.combine"
   ),
   DeprecationLevel.WARNING
 )
@@ -733,8 +734,7 @@ fun <A, B, C, D, E, Z> Kind<Kind<ForConst, A>, Tuple5<A, B, C, D, E>>.product(
   arg1: Kind<Kind<ForConst, A>, Z>
 ): Const<A, Tuple6<A, B, C, D, E, Z>> =
   arrow.core.Const.apply<A>(MA).run {
-    this@product.product<A, B, C, D, E, Z>(arg1) as arrow.core.Const<A, arrow.core.Tuple6<A, B, C, D,
-      E, Z>>
+    this@product.product<A, B, C, D, E, Z>(arg1) as arrow.core.Const<A, arrow.core.Tuple6<A, B, C, D, E, Z>>
   }
 
 @JvmName("product5")
@@ -747,8 +747,10 @@ fun <A, B, C, D, E, Z> Kind<Kind<ForConst, A>, Tuple5<A, B, C, D, E>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "product(MA, arg1)",
-    "arrow.core.product"
+    "mapN(MA, this, arg1)\n" +
+      ".map { (abcdef, g) -> Tuple7(abcdef.a, abcdef.b, abcdef.c, abcdef.d, abcdef.e, abcdef.f, g) }",
+    "arrow.core.retag",
+    "arrow.core.combine"
   ),
   DeprecationLevel.WARNING
 )
@@ -757,8 +759,7 @@ fun <A, B, C, D, E, FF, Z> Kind<Kind<ForConst, A>, Tuple6<A, B, C, D, E, FF>>.pr
   arg1: Kind<Kind<ForConst, A>, Z>
 ): Const<A, Tuple7<A, B, C, D, E, FF, Z>> =
   arrow.core.Const.apply<A>(MA).run {
-    this@product.product<A, B, C, D, E, FF, Z>(arg1) as arrow.core.Const<A, arrow.core.Tuple7<A, B, C,
-      D, E, FF, Z>>
+    this@product.product<A, B, C, D, E, FF, Z>(arg1) as arrow.core.Const<A, arrow.core.Tuple7<A, B, C, D, E, FF, Z>>
   }
 
 @JvmName("product6")
@@ -771,17 +772,21 @@ fun <A, B, C, D, E, FF, Z> Kind<Kind<ForConst, A>, Tuple6<A, B, C, D, E, FF>>.pr
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "product(MA, arg1)",
-    "arrow.core.product"
+    "mapN(MA, this, arg1)\n" +
+      ".map { (abcdefg, h) -> Tuple8(abcdefg.a, abcdefg.b, abcdefg.c, abcdefg.d, abcdefg.e, abcdefg.f, abcdefg.g, h) }",
+    "arrow.core.retag",
+    "arrow.core.combine"
   ),
   DeprecationLevel.WARNING
 )
-fun <A, B, C, D, E, FF, G, Z> Kind<Kind<ForConst, A>, Tuple7<A, B, C, D, E, FF,
-  G>>.product(MA: Monoid<A>, arg1: Kind<Kind<ForConst, A>, Z>): Const<A, Tuple8<A, B, C, D, E, FF,
-  G, Z>> = arrow.core.Const.apply<A>(MA).run {
-  this@product.product<A, B, C, D, E, FF, G, Z>(arg1) as arrow.core.Const<A, arrow.core.Tuple8<A, B,
-    C, D, E, FF, G, Z>>
-}
+fun <A, B, C, D, E, FF, G, Z> Kind<Kind<ForConst, A>, Tuple7<A, B, C, D, E, FF, G>>.product(
+  MA: Monoid<A>,
+  arg1: Kind<Kind<ForConst, A>, Z>
+): Const<A, Tuple8<A, B, C, D, E, FF, G, Z>> =
+  arrow.core.Const.apply<A>(MA).run {
+    this@product.product<A, B, C, D, E, FF, G, Z>(arg1) as
+      arrow.core.Const<A, arrow.core.Tuple8<A, B, C, D, E, FF, G, Z>>
+  }
 
 @JvmName("product7")
 @Suppress(
@@ -793,17 +798,21 @@ fun <A, B, C, D, E, FF, G, Z> Kind<Kind<ForConst, A>, Tuple7<A, B, C, D, E, FF,
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "product(MA, arg1)",
-    "arrow.core.product"
+    "mapN(MA, this, arg1)\n" +
+      ".map { (abcdefgh, i) -> Tuple9(abcdefgh.a, abcdefgh.b, abcdefgh.c, abcdefgh.d, abcdefgh.e, abcdefgh.f, abcdefgh.g, abcdefgh.h, i) }",
+    "arrow.core.retag",
+    "arrow.core.combine"
   ),
   DeprecationLevel.WARNING
 )
-fun <A, B, C, D, E, FF, G, H, Z> Kind<Kind<ForConst, A>, Tuple8<A, B, C, D, E, FF, G,
-  H>>.product(MA: Monoid<A>, arg1: Kind<Kind<ForConst, A>, Z>): Const<A, Tuple9<A, B, C, D, E, FF,
-  G, H, Z>> = arrow.core.Const.apply<A>(MA).run {
-  this@product.product<A, B, C, D, E, FF, G, H, Z>(arg1) as arrow.core.Const<A, arrow.core.Tuple9<A,
-    B, C, D, E, FF, G, H, Z>>
-}
+fun <A, B, C, D, E, FF, G, H, Z> Kind<Kind<ForConst, A>, Tuple8<A, B, C, D, E, FF, G, H>>.product(
+  MA: Monoid<A>,
+  arg1: Kind<Kind<ForConst, A>, Z>
+): Const<A, Tuple9<A, B, C, D, E, FF, G, H, Z>> =
+  arrow.core.Const.apply<A>(MA).run {
+    this@product.product<A, B, C, D, E, FF, G, H, Z>(arg1) as
+      arrow.core.Const<A, arrow.core.Tuple9<A, B, C, D, E, FF, G, H, Z>>
+  }
 
 @JvmName("product8")
 @Suppress(
@@ -815,17 +824,21 @@ fun <A, B, C, D, E, FF, G, H, Z> Kind<Kind<ForConst, A>, Tuple8<A, B, C, D, E, F
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "product(MA, arg1)",
-    "arrow.core.product"
+    "mapN(MA, this, arg1)\n" +
+      ".map { (abcdefghi, j) -> Tuple10(abcdefghi.a, abcdefghi.b, abcdefghi.c, abcdefghi.d, abcdefghi.e, abcdefghi.f, abcdefghi.g, abcdefghi.h, abcdefghi.i, j) }",
+    "arrow.core.retag",
+    "arrow.core.combine"
   ),
   DeprecationLevel.WARNING
 )
-fun <A, B, C, D, E, FF, G, H, I, Z> Kind<Kind<ForConst, A>, Tuple9<A, B, C, D, E, FF, G, H,
-  I>>.product(MA: Monoid<A>, arg1: Kind<Kind<ForConst, A>, Z>): Const<A, Tuple10<A, B, C, D, E,
-  FF, G, H, I, Z>> = arrow.core.Const.apply<A>(MA).run {
-  this@product.product<A, B, C, D, E, FF, G, H, I, Z>(arg1) as arrow.core.Const<A,
-    arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, Z>>
-}
+fun <A, B, C, D, E, FF, G, H, I, Z> Kind<Kind<ForConst, A>, Tuple9<A, B, C, D, E, FF, G, H, I>>.product(
+  MA: Monoid<A>,
+  arg1: Kind<Kind<ForConst, A>, Z>
+): Const<A, Tuple10<A, B, C, D, E, FF, G, H, I, Z>> =
+  arrow.core.Const.apply<A>(MA).run {
+    this@product.product<A, B, C, D, E, FF, G, H, I, Z>(arg1) as
+      arrow.core.Const<A, arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, Z>>
+  }
 
 @JvmName("tupled")
 @Suppress(
@@ -837,8 +850,8 @@ fun <A, B, C, D, E, FF, G, H, I, Z> Kind<Kind<ForConst, A>, Tuple9<A, B, C, D, E
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "tupled(MA, arg0, arg1)",
-    "arrow.core.Const.tupled"
+    "mapN(SG, arg0, arg1) { a, b -> Tuple2(a, b) }",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -860,8 +873,8 @@ fun <A, B> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "tupledN(MA, arg0, arg1)",
-    "arrow.core.Const.tupledN"
+    "mapN(SG, arg0, arg1) { a, b -> Tuple2(a, b) }",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -883,8 +896,8 @@ fun <A, B> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "tupled(MA, arg0, arg1, arg2)",
-    "arrow.core.Const.tupled"
+    "mapN(SG, arg0, arg1, arg2) { a, b, c -> Tuple3(a, b, c) }",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -907,8 +920,8 @@ fun <A, B, C> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "tupledN(MA, arg0, arg1, arg2)",
-    "arrow.core.Const.tupledN"
+    "mapN(SG, arg0, arg1, arg2) { a, b, c -> Tuple3(a, b, c) }",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -931,8 +944,8 @@ fun <A, B, C> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "tupled(MA, arg0, arg1, arg2, arg3)",
-    "arrow.core.Const.tupled"
+    "mapN(SG, arg0, arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -956,8 +969,8 @@ fun <A, B, C, D> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "tupledN(MA, arg0, arg1, arg2, arg3)",
-    "arrow.core.Const.tupledN"
+    "mapN(SG, arg0, arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -969,8 +982,7 @@ fun <A, B, C, D> tupledN(
   arg3: Kind<Kind<ForConst, A>, D>
 ): Const<A, Tuple4<A, B, C, D>> = arrow.core.Const
   .apply<A>(MA)
-  .tupledN<A, B, C, D>(arg0, arg1, arg2, arg3) as arrow.core.Const<A, arrow.core.Tuple4<A, B, C,
-  D>>
+  .tupledN<A, B, C, D>(arg0, arg1, arg2, arg3) as arrow.core.Const<A, arrow.core.Tuple4<A, B, C, D>>
 
 @JvmName("tupled")
 @Suppress(
@@ -982,8 +994,8 @@ fun <A, B, C, D> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "tupled(MA, arg0, arg1, arg2, arg3, arg4)",
-    "arrow.core.Const.tupled"
+    "mapN(SG, arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -1009,8 +1021,8 @@ fun <A, B, C, D, E> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "tupledN(MA, arg0, arg1, arg2, arg3, arg4)",
-    "arrow.core.Const.tupledN"
+    "mapN(SG, arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -1036,8 +1048,8 @@ fun <A, B, C, D, E> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "tupled(MA, arg0, arg1, arg2, arg3, arg4, arg5)",
-    "arrow.core.Const.tupled"
+    "mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, ff -> Tuple6(a, b, c, d, e, ff) }",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -1064,8 +1076,8 @@ fun <A, B, C, D, E, FF> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "tupledN(MA, arg0, arg1, arg2, arg3, arg4, arg5)",
-    "arrow.core.Const.tupledN"
+    "mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, ff -> Tuple6(a, b, c, d, e, ff) }",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -1077,10 +1089,11 @@ fun <A, B, C, D, E, FF> tupledN(
   arg3: Kind<Kind<ForConst, A>, D>,
   arg4: Kind<Kind<ForConst, A>, E>,
   arg5: Kind<Kind<ForConst, A>, FF>
-): Const<A, Tuple6<A, B, C, D, E, FF>> = arrow.core.Const
-  .apply<A>(MA)
-  .tupledN<A, B, C, D, E, FF>(arg0, arg1, arg2, arg3, arg4, arg5) as arrow.core.Const<A,
-  arrow.core.Tuple6<A, B, C, D, E, FF>>
+): Const<A, Tuple6<A, B, C, D, E, FF>> =
+  arrow.core.Const
+    .apply<A>(MA)
+    .tupledN<A, B, C, D, E, FF>(arg0, arg1, arg2, arg3, arg4, arg5) as
+    arrow.core.Const<A, arrow.core.Tuple6<A, B, C, D, E, FF>>
 
 @JvmName("tupled")
 @Suppress(
@@ -1092,8 +1105,8 @@ fun <A, B, C, D, E, FF> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "tupled(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-    "arrow.core.Const.tupled"
+    "mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, ff, g -> Tuple7(a, b, c, d, e, ff, g) }",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -1121,8 +1134,8 @@ fun <A, B, C, D, E, FF, G> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "tupledN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-    "arrow.core.Const.tupledN"
+    "mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, ff, g -> Tuple7(a, b, c, d, e, ff, g) }",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -1150,8 +1163,8 @@ fun <A, B, C, D, E, FF, G> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "tupled(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-    "arrow.core.Const.tupled"
+    "mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, ff, g, h -> Tuple8(a, b, c, d, e, ff, g, h) }",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -1180,8 +1193,8 @@ fun <A, B, C, D, E, FF, G, H> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "tupledN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-    "arrow.core.Const.tupledN"
+    "mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, ff, g, h -> Tuple8(a, b, c, d, e, ff, g, h) }",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -1210,8 +1223,9 @@ fun <A, B, C, D, E, FF, G, H> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "tupled(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-    "arrow.core.Const.tupled"
+    "mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, ff, g, h, i -> \n" +
+      "Tuple9(a, b, c, d, e, ff, g, h, i) }",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -1241,8 +1255,9 @@ fun <A, B, C, D, E, FF, G, H, I> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "tupledN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-    "arrow.core.Const.tupledN"
+    "mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, ff, g, h, i -> \n" +
+      "Tuple9(a, b, c, d, e, ff, g, h, i) }",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -1272,8 +1287,9 @@ fun <A, B, C, D, E, FF, G, H, I> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "tupled(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-    "arrow.core.Const.tupled"
+    "mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, ff, g, h, i, j -> \n" +
+      "Tuple10(a, b, c, d, e, ff, g, h, i, j) }",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -1289,11 +1305,11 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupled(
   arg7: Kind<Kind<ForConst, A>, H>,
   arg8: Kind<Kind<ForConst, A>, I>,
   arg9: Kind<Kind<ForConst, A>, J>
-): Const<A, Tuple10<A, B, C, D, E, FF, G, H, I, J>> = arrow.core.Const
-  .apply<A>(MA)
-  .tupled<A, B, C, D, E, FF, G, H, I,
-    J>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) as arrow.core.Const<A,
-  arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, J>>
+): Const<A, Tuple10<A, B, C, D, E, FF, G, H, I, J>> =
+  arrow.core.Const
+    .apply<A>(MA)
+    .tupled<A, B, C, D, E, FF, G, H, I, J>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) as
+    arrow.core.Const<A, arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, J>>
 
 @JvmName("tupledN")
 @Suppress(
@@ -1305,8 +1321,9 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "tupledN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-    "arrow.core.Const.tupledN"
+    "mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, ff, g, h, i, j -> \n" +
+      "Tuple10(a, b, c, d, e, ff, g, h, i, j) }",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -1322,11 +1339,11 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupledN(
   arg7: Kind<Kind<ForConst, A>, H>,
   arg8: Kind<Kind<ForConst, A>, I>,
   arg9: Kind<Kind<ForConst, A>, J>
-): Const<A, Tuple10<A, B, C, D, E, FF, G, H, I, J>> = arrow.core.Const
-  .apply<A>(MA)
-  .tupledN<A, B, C, D, E, FF, G, H, I,
-    J>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) as arrow.core.Const<A,
-  arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, J>>
+): Const<A, Tuple10<A, B, C, D, E, FF, G, H, I, J>> =
+  arrow.core.Const
+    .apply<A>(MA)
+    .tupledN<A, B, C, D, E, FF, G, H, I, J>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) as
+    arrow.core.Const<A, arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, J>>
 
 @JvmName("followedBy")
 @Suppress(
@@ -1338,15 +1355,18 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "followedBy(MA, arg1)",
-    "arrow.core.followedBy"
+    "mapN(SG, this, arg1) { (_, right) -> right }",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
-fun <A, B> Kind<Kind<ForConst, A>, A>.followedBy(MA: Monoid<A>, arg1: Kind<Kind<ForConst, A>, B>):
-  Const<A, B> = arrow.core.Const.apply<A>(MA).run {
-  this@followedBy.followedBy<A, B>(arg1) as arrow.core.Const<A, B>
-}
+fun <A, B> Kind<Kind<ForConst, A>, A>.followedBy(
+  MA: Monoid<A>,
+  arg1: Kind<Kind<ForConst, A>, B>
+): Const<A, B> =
+  arrow.core.Const.apply<A>(MA).run {
+    this@followedBy.followedBy<A, B>(arg1) as arrow.core.Const<A, B>
+  }
 
 @JvmName("apTap")
 @Suppress(
@@ -1358,8 +1378,8 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.followedBy(MA: Monoid<A>, arg1: Kind<Kind<
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "apTap(MA, arg1)",
-    "arrow.core.apTap"
+    "mapN(SG, this, arg1) { (left, _) -> left }",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/apply/ConstApply.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/apply/ConstApply.kt
@@ -32,7 +32,7 @@ import kotlin.jvm.JvmName
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
     "ap(MA, arg1)",
-    "arrow.core.Const.ap"
+    "arrow.core.ap"
   ),
   DeprecationLevel.WARNING
 )

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/apply/ConstApply.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/apply/ConstApply.kt
@@ -700,8 +700,7 @@ fun <A, B, C, Z> Kind<Kind<ForConst, A>, Tuple3<A, B, C>>.product(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
     "mapN(MA, this, arg1).map { (abcd, e) -> Tuple5(abcd.a, abcd.b, abcd.c, abcd.d, e) }",
-    "arrow.core.retag",
-    "arrow.core.combine"
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -724,8 +723,7 @@ fun <A, B, C, D, Z> Kind<Kind<ForConst, A>, Tuple4<A, B, C, D>>.product(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
     "mapN(MA, this, arg1).map { (abcde, f) -> Tuple6(abcde.a, abcde.b, abcde.c, abcde.d, abcde.e, f) }",
-    "arrow.core.retag",
-    "arrow.core.combine"
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -749,8 +747,7 @@ fun <A, B, C, D, E, Z> Kind<Kind<ForConst, A>, Tuple5<A, B, C, D, E>>.product(
   ReplaceWith(
     "mapN(MA, this, arg1)\n" +
       ".map { (abcdef, g) -> Tuple7(abcdef.a, abcdef.b, abcdef.c, abcdef.d, abcdef.e, abcdef.f, g) }",
-    "arrow.core.retag",
-    "arrow.core.combine"
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -774,8 +771,7 @@ fun <A, B, C, D, E, FF, Z> Kind<Kind<ForConst, A>, Tuple6<A, B, C, D, E, FF>>.pr
   ReplaceWith(
     "mapN(MA, this, arg1)\n" +
       ".map { (abcdefg, h) -> Tuple8(abcdefg.a, abcdefg.b, abcdefg.c, abcdefg.d, abcdefg.e, abcdefg.f, abcdefg.g, h) }",
-    "arrow.core.retag",
-    "arrow.core.combine"
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -800,8 +796,7 @@ fun <A, B, C, D, E, FF, G, Z> Kind<Kind<ForConst, A>, Tuple7<A, B, C, D, E, FF, 
   ReplaceWith(
     "mapN(MA, this, arg1)\n" +
       ".map { (abcdefgh, i) -> Tuple9(abcdefgh.a, abcdefgh.b, abcdefgh.c, abcdefgh.d, abcdefgh.e, abcdefgh.f, abcdefgh.g, abcdefgh.h, i) }",
-    "arrow.core.retag",
-    "arrow.core.combine"
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -826,8 +821,7 @@ fun <A, B, C, D, E, FF, G, H, Z> Kind<Kind<ForConst, A>, Tuple8<A, B, C, D, E, F
   ReplaceWith(
     "mapN(MA, this, arg1)\n" +
       ".map { (abcdefghi, j) -> Tuple10(abcdefghi.a, abcdefghi.b, abcdefghi.c, abcdefghi.d, abcdefghi.e, abcdefghi.f, abcdefghi.g, abcdefghi.h, abcdefghi.i, j) }",
-    "arrow.core.retag",
-    "arrow.core.combine"
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/apply/ConstApply.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/apply/ConstApply.kt
@@ -100,8 +100,9 @@ fun <A, B, Z> Kind<Kind<ForConst, A>, A>.map2Eval(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2)",
-    "arrow.core.Cons"
+    "Cons.mapN(MA, arg0, arg1) { a, b -> arg2(Tuple2(a,b)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
 )
@@ -124,8 +125,9 @@ fun <A, B, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2)",
-    "arrow.core.Cons"
+    "Cons.mapN(MA, arg0, arg1) { a, b -> arg2(Tuple2(a,b)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
 )
@@ -148,8 +150,9 @@ fun <A, B, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3)",
-    "arrow.core.Cons"
+    "Cons.mapN(MA, arg0, arg1, arg2) { a, b, c -> arg3(Tuple3(a, b, c)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
 )
@@ -173,8 +176,9 @@ fun <A, B, C, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3)",
-    "arrow.core.Cons"
+    "Cons.mapN(MA, arg0, arg1, arg2) { a, b, c -> arg3(Tuple3(a, b, c)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
 )
@@ -198,8 +202,9 @@ fun <A, B, C, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4)",
-    "arrow.core.map"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
 )
@@ -224,8 +229,9 @@ fun <A, B, C, D, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4)",
-    "arrow.core.Cons"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
 )
@@ -250,8 +256,9 @@ fun <A, B, C, D, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5)",
-    "arrow.core.Cons"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
 )
@@ -277,8 +284,9 @@ fun <A, B, C, D, E, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5)",
-    "arrow.core.Cons"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
 )
@@ -304,8 +312,9 @@ fun <A, B, C, D, E, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-    "arrow.core.Cons"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> arg6(Tuple6(a, b, c, d, e, f)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
 )
@@ -332,8 +341,9 @@ fun <A, B, C, D, E, FF, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-    "arrow.core.Cons"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> arg6(Tuple6(a, b, c, d, e, f)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
 )
@@ -360,8 +370,9 @@ fun <A, B, C, D, E, FF, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-    "arrow.core.Cons"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> arg7(Tuple7(a, b, c, d, e, f, g)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
 )
@@ -390,8 +401,9 @@ fun <A, B, C, D, E, FF, G, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-    "arrow.core.Cons"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> arg7(Tuple7(a, b, c, d, e, f, g)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
 )
@@ -420,8 +432,9 @@ fun <A, B, C, D, E, FF, G, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-    "arrow.core.Cons"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> arg8(Tuple8(a, b, c, d, e, f, g, h)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
 )
@@ -451,8 +464,9 @@ fun <A, B, C, D, E, FF, G, H, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-    "arrow.core.Cons"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> arg8(Tuple8(a, b, c, d, e, f, g, h)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
 )
@@ -482,8 +496,10 @@ fun <A, B, C, D, E, FF, G, H, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-    "arrow.core.Cons"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)\n" +
+      "{ a, b, c, d, e, f, g, h, i -> arg9(Tuple9(a, b, c, d, e, f, g, h, i)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
 )
@@ -514,8 +530,10 @@ fun <A, B, C, D, E, FF, G, H, I, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-    "arrow.core.Cons"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)\n" +
+      "{ a, b, c, d, e, f, g, h, i -> arg9(Tuple9(a, b, c, d, e, f, g, h, i)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
 )
@@ -546,8 +564,10 @@ fun <A, B, C, D, E, FF, G, H, I, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)",
-    "arrow.core.Cons"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)\n" +
+      "{ a, b, c, d, e, f, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, f, g, h, i, j)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
 )
@@ -579,8 +599,10 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)",
-    "arrow.core.Cons"
+    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)\n" +
+      "{ a, b, c, d, e, f, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, f, g, h, i, j)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
 )
@@ -654,8 +676,9 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.product(MA: Monoid<A>, arg1: Kind<Kind<For
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, this, arg1).map { (ab, c) -> Tuple3(ab.a, ab.b, c) }",
-    "arrow.core.Cons"
+    "Cons.mapN(MA, this, arg1).map { ab, c -> Tuple3(ab.a, ab.b, c) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
 )
@@ -676,8 +699,9 @@ fun <A, B, Z> Kind<Kind<ForConst, A>, Tuple2<A, B>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, this, arg1).map { (abc, d) -> Tuple4(abc.a, abc.b, abc.c, d) }",
-    "arrow.core.Cons"
+    "Cons.mapN(MA, this, arg1).map { abc, d -> Tuple4(abc.a, abc.b, abc.c, d) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
 )
@@ -699,8 +723,9 @@ fun <A, B, C, Z> Kind<Kind<ForConst, A>, Tuple3<A, B, C>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, this, arg1).map { (abcd, e) -> Tuple5(abcd.a, abcd.b, abcd.c, abcd.d, e) }",
-    "arrow.core.Cons"
+    "Cons.mapN(MA, this, arg1).map { abcd, e -> Tuple5(abcd.a, abcd.b, abcd.c, abcd.d, e) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
 )
@@ -722,8 +747,9 @@ fun <A, B, C, D, Z> Kind<Kind<ForConst, A>, Tuple4<A, B, C, D>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, this, arg1).map { (abcde, f) -> Tuple6(abcde.a, abcde.b, abcde.c, abcde.d, abcde.e, f) }",
-    "arrow.core.Cons"
+    "Cons.mapN(MA, this, arg1).map { abcde, f -> Tuple6(abcde.a, abcde.b, abcde.c, abcde.d, abcde.e, f) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
 )
@@ -746,8 +772,9 @@ fun <A, B, C, D, E, Z> Kind<Kind<ForConst, A>, Tuple5<A, B, C, D, E>>.product(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
     "Cons.mapN(MA, this, arg1)\n" +
-      ".map { (abcdef, g) -> Tuple7(abcdef.a, abcdef.b, abcdef.c, abcdef.d, abcdef.e, abcdef.f, g) }",
-    "arrow.core.Cons"
+      ".map { abcdef, g -> Tuple7(abcdef.a, abcdef.b, abcdef.c, abcdef.d, abcdef.e, abcdef.f, g) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
 )
@@ -770,8 +797,9 @@ fun <A, B, C, D, E, FF, Z> Kind<Kind<ForConst, A>, Tuple6<A, B, C, D, E, FF>>.pr
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
     "Cons.mapN(MA, this, arg1)\n" +
-      ".map { (abcdefg, h) -> Tuple8(abcdefg.a, abcdefg.b, abcdefg.c, abcdefg.d, abcdefg.e, abcdefg.f, abcdefg.g, h) }",
-    "arrow.core.Cons"
+      ".map { abcdefg, h -> Tuple8(abcdefg.a, abcdefg.b, abcdefg.c, abcdefg.d, abcdefg.e, abcdefg.f, abcdefg.g, h) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
 )
@@ -795,8 +823,9 @@ fun <A, B, C, D, E, FF, G, Z> Kind<Kind<ForConst, A>, Tuple7<A, B, C, D, E, FF, 
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
     "Cons.mapN(MA, this, arg1)\n" +
-      ".map { (abcdefgh, i) -> Tuple9(abcdefgh.a, abcdefgh.b, abcdefgh.c, abcdefgh.d, abcdefgh.e, abcdefgh.f, abcdefgh.g, abcdefgh.h, i) }",
-    "arrow.core.Cons"
+      ".map { abcdefgh, i -> Tuple9(abcdefgh.a, abcdefgh.b, abcdefgh.c, abcdefgh.d, abcdefgh.e, abcdefgh.f, abcdefgh.g, abcdefgh.h, i) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
 )
@@ -820,8 +849,9 @@ fun <A, B, C, D, E, FF, G, H, Z> Kind<Kind<ForConst, A>, Tuple8<A, B, C, D, E, F
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
     "Cons.mapN(MA, this, arg1)\n" +
-      ".map { (abcdefghi, j) -> Tuple10(abcdefghi.a, abcdefghi.b, abcdefghi.c, abcdefghi.d, abcdefghi.e, abcdefghi.f, abcdefghi.g, abcdefghi.h, abcdefghi.i, j) }",
-    "arrow.core.Cons"
+      ".map { abcdefghi, j -> Tuple10(abcdefghi.a, abcdefghi.b, abcdefghi.c, abcdefghi.d, abcdefghi.e, abcdefghi.f, abcdefghi.g, abcdefghi.h, abcdefghi.i, j) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
 )

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/contravariant/ConstContravariant.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/contravariant/ConstContravariant.kt
@@ -16,8 +16,7 @@ import kotlin.jvm.JvmName
  * cached extension
  */
 @PublishedApi()
-internal val contravariant_singleton: ConstContravariant<Any?> = object : ConstContravariant<Any?>
-    {}
+internal val contravariant_singleton: ConstContravariant<Any?> = object : ConstContravariant<Any?> {}
 
 @JvmName("contramap")
 @Suppress(
@@ -29,15 +28,15 @@ internal val contravariant_singleton: ConstContravariant<Any?> = object : ConstC
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "contramap(arg1)",
-  "arrow.core.contramap"
+    "contramap(arg1)",
+    "arrow.core.contramap"
   ),
   DeprecationLevel.WARNING
 )
 fun <A, B> Kind<Kind<ForConst, A>, A>.contramap(arg1: Function1<B, A>): Const<A, B> =
-    arrow.core.Const.contravariant<A>().run {
-  this@contramap.contramap<A, B>(arg1) as arrow.core.Const<A, B>
-}
+  arrow.core.Const.contravariant<A>().run {
+    this@contramap.contramap<A, B>(arg1) as arrow.core.Const<A, B>
+  }
 
 @JvmName("lift1")
 @Suppress(
@@ -46,19 +45,12 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.contramap(arg1: Function1<B, A>): Const<A,
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "lift(arg0)",
-  "arrow.core.Const.lift"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
 fun <A, B> lift(arg0: Function1<A, B>): Function1<Kind<Kind<ForConst, A>, B>, Kind<Kind<ForConst,
-    A>, A>> = arrow.core.Const
-   .contravariant<A>()
-   .lift<A, B>(arg0) as kotlin.Function1<arrow.Kind<arrow.Kind<arrow.core.ForConst, A>, B>,
-    arrow.Kind<arrow.Kind<arrow.core.ForConst, A>, A>>
+  A>, A>> = arrow.core.Const
+  .contravariant<A>()
+  .lift<A, B>(arg0) as kotlin.Function1<arrow.Kind<arrow.Kind<arrow.core.ForConst, A>, B>,
+  arrow.Kind<arrow.Kind<arrow.core.ForConst, A>, A>>
 
 @JvmName("imap")
 @Suppress(
@@ -70,15 +62,15 @@ fun <A, B> lift(arg0: Function1<A, B>): Function1<Kind<Kind<ForConst, A>, B>, Ki
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "imap(arg1, arg2)",
-  "arrow.core.imap"
+    "imap(arg1, arg2)",
+    "arrow.core.imap"
   ),
   DeprecationLevel.WARNING
 )
-fun <A, B> Kind<Kind<ForConst, A>, A>.imap(arg1: Function1<A, B>, arg2: Function1<B, A>): Const<A,
-    B> = arrow.core.Const.contravariant<A>().run {
-  this@imap.imap<A, B>(arg1, arg2) as arrow.core.Const<A, B>
-}
+fun <A, B> Kind<Kind<ForConst, A>, A>.imap(arg1: Function1<A, B>, arg2: Function1<B, A>): Const<A, B> =
+  arrow.core.Const.contravariant<A>().run {
+    this@imap.imap<A, B>(arg1, arg2) as arrow.core.Const<A, B>
+  }
 
 @JvmName("narrow")
 @Suppress(
@@ -90,19 +82,23 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.imap(arg1: Function1<A, B>, arg2: Function
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "narrow()",
-  "arrow.core.narrow"
+    "narrow()",
+    "arrow.core.narrow"
   ),
   DeprecationLevel.WARNING
 )
 fun <A, B : A> Kind<Kind<ForConst, A>, A>.narrow(): Const<A, B> =
-    arrow.core.Const.contravariant<A>().run {
-  this@narrow.narrow<A, B>() as arrow.core.Const<A, B>
-}
+  arrow.core.Const.contravariant<A>().run {
+    this@narrow.narrow<A, B>() as arrow.core.Const<A, B>
+  }
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-inline fun <A> Companion.contravariant(): ConstContravariant<A> = contravariant_singleton as
-    arrow.core.extensions.ConstContravariant<A>
+@Deprecated(
+  "Contravariant typeclass is deprecated. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
+)
+inline fun <A> Companion.contravariant(): ConstContravariant<A> =
+  contravariant_singleton as arrow.core.extensions.ConstContravariant<A>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/divide/ConstDivideInstance.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/divide/ConstDivideInstance.kt
@@ -15,10 +15,6 @@ import arrow.core.Tuple8
 import arrow.core.Tuple9
 import arrow.core.extensions.ConstDivideInstance
 import arrow.typeclasses.Monoid
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 @JvmName("divide")
 @Suppress(
@@ -30,8 +26,8 @@ import kotlin.jvm.JvmName
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "divide(MO, arg0, arg1, arg2)",
-    "arrow.core.Const.divide"
+    "mapN(MO, arg0, arg1).map(arg2)",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -44,207 +40,6 @@ fun <O, A, B, Z> divide(
   .divide<O>(MO)
   .divide<A, B, Z>(arg0, arg1, arg2) as arrow.core.Const<O, Z>
 
-@JvmName("product")
-@Suppress(
-  "UNCHECKED_CAST",
-  "USELESS_CAST",
-  "EXTENSION_SHADOWED_BY_MEMBER",
-  "UNUSED_PARAMETER"
-)
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "product(MO, arg1)",
-    "arrow.core.product"
-  ),
-  DeprecationLevel.WARNING
-)
-fun <O, A, B> Kind<Kind<ForConst, O>, A>.product(MO: Monoid<O>, arg1: Kind<Kind<ForConst, O>, B>):
-  Const<O, Tuple2<A, B>> = arrow.core.Const.divide<O>(MO).run {
-  this@product.product<A, B>(arg1) as arrow.core.Const<O, arrow.core.Tuple2<A, B>>
-}
-
-@JvmName("product1")
-@Suppress(
-  "UNCHECKED_CAST",
-  "USELESS_CAST",
-  "EXTENSION_SHADOWED_BY_MEMBER",
-  "UNUSED_PARAMETER"
-)
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "product(MO, arg1)",
-    "arrow.core.product"
-  ),
-  DeprecationLevel.WARNING
-)
-fun <O, A, B, C> Kind<Kind<ForConst, O>, Tuple2<A, B>>.product(
-  MO: Monoid<O>,
-  arg1: Kind<Kind<ForConst, O>, C>
-): Const<O, Tuple3<A, B, C>> =
-  arrow.core.Const.divide<O>(MO).run {
-    this@product.product<A, B, C>(arg1) as arrow.core.Const<O, arrow.core.Tuple3<A, B, C>>
-  }
-
-@JvmName("product2")
-@Suppress(
-  "UNCHECKED_CAST",
-  "USELESS_CAST",
-  "EXTENSION_SHADOWED_BY_MEMBER",
-  "UNUSED_PARAMETER"
-)
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "product(MO, arg1)",
-    "arrow.core.product"
-  ),
-  DeprecationLevel.WARNING
-)
-fun <O, A, B, C, D> Kind<Kind<ForConst, O>, Tuple3<A, B, C>>.product(
-  MO: Monoid<O>,
-  arg1: Kind<Kind<ForConst, O>, D>
-): Const<O, Tuple4<A, B, C, D>> =
-  arrow.core.Const.divide<O>(MO).run {
-    this@product.product<A, B, C, D>(arg1) as arrow.core.Const<O, arrow.core.Tuple4<A, B, C, D>>
-  }
-
-@JvmName("product3")
-@Suppress(
-  "UNCHECKED_CAST",
-  "USELESS_CAST",
-  "EXTENSION_SHADOWED_BY_MEMBER",
-  "UNUSED_PARAMETER"
-)
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "product(MO, arg1)",
-    "arrow.core.product"
-  ),
-  DeprecationLevel.WARNING
-)
-fun <O, A, B, C, D, E> Kind<Kind<ForConst, O>, Tuple4<A, B, C, D>>.product(
-  MO: Monoid<O>,
-  arg1: Kind<Kind<ForConst, O>, E>
-): Const<O, Tuple5<A, B, C, D, E>> =
-  arrow.core.Const.divide<O>(MO).run {
-    this@product.product<A, B, C, D, E>(arg1) as arrow.core.Const<O, arrow.core.Tuple5<A, B, C, D, E>>
-  }
-
-@JvmName("product4")
-@Suppress(
-  "UNCHECKED_CAST",
-  "USELESS_CAST",
-  "EXTENSION_SHADOWED_BY_MEMBER",
-  "UNUSED_PARAMETER"
-)
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "product(MO, arg1)",
-    "arrow.core.product"
-  ),
-  DeprecationLevel.WARNING
-)
-fun <O, A, B, C, D, E, FF> Kind<Kind<ForConst, O>, Tuple5<A, B, C, D, E>>.product(
-  MO: Monoid<O>,
-  arg1: Kind<Kind<ForConst, O>, FF>
-): Const<O, Tuple6<A, B, C, D, E, FF>> =
-  arrow.core.Const.divide<O>(MO).run {
-    this@product.product<A, B, C, D, E, FF>(arg1) as arrow.core.Const<O, arrow.core.Tuple6<A, B, C, D,
-      E, FF>>
-  }
-
-@JvmName("product5")
-@Suppress(
-  "UNCHECKED_CAST",
-  "USELESS_CAST",
-  "EXTENSION_SHADOWED_BY_MEMBER",
-  "UNUSED_PARAMETER"
-)
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "product(MO, arg1)",
-    "arrow.core.product"
-  ),
-  DeprecationLevel.WARNING
-)
-fun <O, A, B, C, D, E, FF, G> Kind<Kind<ForConst, O>, Tuple6<A, B, C, D, E,
-  FF>>.product(MO: Monoid<O>, arg1: Kind<Kind<ForConst, O>, G>): Const<O, Tuple7<A, B, C, D, E,
-  FF, G>> = arrow.core.Const.divide<O>(MO).run {
-  this@product.product<A, B, C, D, E, FF, G>(arg1) as arrow.core.Const<O, arrow.core.Tuple7<A, B, C,
-    D, E, FF, G>>
-}
-
-@JvmName("product6")
-@Suppress(
-  "UNCHECKED_CAST",
-  "USELESS_CAST",
-  "EXTENSION_SHADOWED_BY_MEMBER",
-  "UNUSED_PARAMETER"
-)
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "product(MO, arg1)",
-    "arrow.core.product"
-  ),
-  DeprecationLevel.WARNING
-)
-fun <O, A, B, C, D, E, FF, G, H> Kind<Kind<ForConst, O>, Tuple7<A, B, C, D, E, FF,
-  G>>.product(MO: Monoid<O>, arg1: Kind<Kind<ForConst, O>, H>): Const<O, Tuple8<A, B, C, D, E, FF,
-  G, H>> = arrow.core.Const.divide<O>(MO).run {
-  this@product.product<A, B, C, D, E, FF, G, H>(arg1) as arrow.core.Const<O, arrow.core.Tuple8<A, B,
-    C, D, E, FF, G, H>>
-}
-
-@JvmName("product7")
-@Suppress(
-  "UNCHECKED_CAST",
-  "USELESS_CAST",
-  "EXTENSION_SHADOWED_BY_MEMBER",
-  "UNUSED_PARAMETER"
-)
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "product(MO, arg1)",
-    "arrow.core.product"
-  ),
-  DeprecationLevel.WARNING
-)
-fun <O, A, B, C, D, E, FF, G, H, I> Kind<Kind<ForConst, O>, Tuple8<A, B, C, D, E, FF, G,
-  H>>.product(MO: Monoid<O>, arg1: Kind<Kind<ForConst, O>, I>): Const<O, Tuple9<A, B, C, D, E, FF,
-  G, H, I>> = arrow.core.Const.divide<O>(MO).run {
-  this@product.product<A, B, C, D, E, FF, G, H, I>(arg1) as arrow.core.Const<O, arrow.core.Tuple9<A,
-    B, C, D, E, FF, G, H, I>>
-}
-
-@JvmName("product8")
-@Suppress(
-  "UNCHECKED_CAST",
-  "USELESS_CAST",
-  "EXTENSION_SHADOWED_BY_MEMBER",
-  "UNUSED_PARAMETER"
-)
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "product(MO, arg1)",
-    "arrow.core.product"
-  ),
-  DeprecationLevel.WARNING
-)
-fun <O, A, B, C, D, E, FF, G, H, I, J> Kind<Kind<ForConst, O>, Tuple9<A, B, C, D, E, FF, G, H,
-  I>>.product(MO: Monoid<O>, arg1: Kind<Kind<ForConst, O>, J>): Const<O, Tuple10<A, B, C, D, E,
-  FF, G, H, I, J>> = arrow.core.Const.divide<O>(MO).run {
-  this@product.product<A, B, C, D, E, FF, G, H, I, J>(arg1) as arrow.core.Const<O,
-    arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, J>>
-}
-
 @JvmName("divide")
 @Suppress(
   "UNCHECKED_CAST",
@@ -255,8 +50,8 @@ fun <O, A, B, C, D, E, FF, G, H, I, J> Kind<Kind<ForConst, O>, Tuple9<A, B, C, D
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "divide(MO, arg0, arg1, arg2, arg3)",
-    "arrow.core.Const.divide"
+    "mapN(MO, arg0, arg1, arg2).map(arg3)",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -280,8 +75,8 @@ fun <O, A, B, C, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "divide(MO, arg0, arg1, arg2, arg3, arg4)",
-    "arrow.core.Const.divide"
+    "mapN(MO, arg0, arg1, arg2, arg3).map(arg4)",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -306,8 +101,8 @@ fun <O, A, B, C, D, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "divide(MO, arg0, arg1, arg2, arg3, arg4, arg5)",
-    "arrow.core.Const.divide"
+    "mapN(MO, arg0, arg1, arg2, arg3, arg4).map(arg5)",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -333,8 +128,8 @@ fun <O, A, B, C, D, E, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "divide(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-    "arrow.core.Const.divide"
+    "mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5).map(arg6)",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -361,8 +156,8 @@ fun <O, A, B, C, D, E, FF, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "divide(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-    "arrow.core.Const.divide"
+    "mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6).map(arg7)",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -391,8 +186,8 @@ fun <O, A, B, C, D, E, FF, G, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "divide(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-    "arrow.core.Const.divide"
+    "mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7).map(arg8)",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -422,8 +217,8 @@ fun <O, A, B, C, D, E, FF, G, H, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "divide(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-    "arrow.core.Const.divide"
+    "mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).map(arg9)",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -454,8 +249,8 @@ fun <O, A, B, C, D, E, FF, G, H, I, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "divide(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)",
-    "arrow.core.Const.divide"
+    "mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).map(arg10)",
+    "arrow.core.mapN"
   ),
   DeprecationLevel.WARNING
 )
@@ -477,6 +272,211 @@ fun <O, A, B, C, D, E, FF, G, H, I, J, Z> divide(
   .divide<A, B, C, D, E, FF, G, H, I, J,
     Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) as arrow.core.Const<O, Z>
 
+@JvmName("product")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(
+  "@extension kinded projected functions are deprecated",
+  ReplaceWith(
+    "mapN(MA, this, arg1) { a, b -> Tuple2(a, b) }",
+    "arrow.core.mapN"
+  ),
+  DeprecationLevel.WARNING
+)
+fun <O, A, B> Kind<Kind<ForConst, O>, A>.product(MO: Monoid<O>, arg1: Kind<Kind<ForConst, O>, B>):
+  Const<O, Tuple2<A, B>> = arrow.core.Const.divide<O>(MO).run {
+  this@product.product<A, B>(arg1) as arrow.core.Const<O, arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("product1")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(
+  "@extension kinded projected functions are deprecated",
+  ReplaceWith(
+    "mapN(MA, this, arg1).map { (ab, c) -> Tuple3(ab.a, ab.b, c) }",
+    "arrow.core.mapN"
+  ),
+  DeprecationLevel.WARNING
+)
+fun <O, A, B, C> Kind<Kind<ForConst, O>, Tuple2<A, B>>.product(
+  MO: Monoid<O>,
+  arg1: Kind<Kind<ForConst, O>, C>
+): Const<O, Tuple3<A, B, C>> =
+  arrow.core.Const.divide<O>(MO).run {
+    this@product.product<A, B, C>(arg1) as arrow.core.Const<O, arrow.core.Tuple3<A, B, C>>
+  }
+
+@JvmName("product2")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(
+  "@extension kinded projected functions are deprecated",
+  ReplaceWith(
+    "mapN(MA, this, arg1).map { (abc, d) -> Tuple4(abc.a, abc.b, abc.c, d) }",
+    "arrow.core.mapN"
+  ),
+  DeprecationLevel.WARNING
+)
+fun <O, A, B, C, D> Kind<Kind<ForConst, O>, Tuple3<A, B, C>>.product(
+  MO: Monoid<O>,
+  arg1: Kind<Kind<ForConst, O>, D>
+): Const<O, Tuple4<A, B, C, D>> =
+  arrow.core.Const.divide<O>(MO).run {
+    this@product.product<A, B, C, D>(arg1) as arrow.core.Const<O, arrow.core.Tuple4<A, B, C, D>>
+  }
+
+@JvmName("product3")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(
+  "@extension kinded projected functions are deprecated",
+  ReplaceWith(
+    "mapN(MA, this, arg1).map { (abcd, e) -> Tuple5(abcd.a, abcd.b, abcd.c, abcd.d, e) }",
+    "arrow.core.mapN"
+  ),
+  DeprecationLevel.WARNING
+)
+fun <O, A, B, C, D, E> Kind<Kind<ForConst, O>, Tuple4<A, B, C, D>>.product(
+  MO: Monoid<O>,
+  arg1: Kind<Kind<ForConst, O>, E>
+): Const<O, Tuple5<A, B, C, D, E>> =
+  arrow.core.Const.divide<O>(MO).run {
+    this@product.product<A, B, C, D, E>(arg1) as arrow.core.Const<O, arrow.core.Tuple5<A, B, C, D, E>>
+  }
+
+@JvmName("product4")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(
+  "@extension kinded projected functions are deprecated",
+  ReplaceWith(
+    "mapN(MA, this, arg1).map { (abcde, f) -> Tuple6(abcde.a, abcde.b, abcde.c, abcde.d, abcde.e, f) }",
+    "arrow.core.mapN"
+  ),
+  DeprecationLevel.WARNING
+)
+fun <O, A, B, C, D, E, FF> Kind<Kind<ForConst, O>, Tuple5<A, B, C, D, E>>.product(
+  MO: Monoid<O>,
+  arg1: Kind<Kind<ForConst, O>, FF>
+): Const<O, Tuple6<A, B, C, D, E, FF>> =
+  arrow.core.Const.divide<O>(MO).run {
+    this@product.product<A, B, C, D, E, FF>(arg1) as arrow.core.Const<O, arrow.core.Tuple6<A, B, C, D,
+      E, FF>>
+  }
+
+@JvmName("product5")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(
+  "@extension kinded projected functions are deprecated",
+  ReplaceWith(
+    "mapN(MA, this, arg1)\n" +
+      ".map { (abcdef, g) -> Tuple7(abcdef.a, abcdef.b, abcdef.c, abcdef.d, abcdef.e, abcdef.f, g) }",
+    "arrow.core.mapN"
+  ),
+  DeprecationLevel.WARNING
+)
+fun <O, A, B, C, D, E, FF, G> Kind<Kind<ForConst, O>, Tuple6<A, B, C, D, E,
+  FF>>.product(MO: Monoid<O>, arg1: Kind<Kind<ForConst, O>, G>): Const<O, Tuple7<A, B, C, D, E,
+  FF, G>> = arrow.core.Const.divide<O>(MO).run {
+  this@product.product<A, B, C, D, E, FF, G>(arg1) as arrow.core.Const<O, arrow.core.Tuple7<A, B, C,
+    D, E, FF, G>>
+}
+
+@JvmName("product6")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(
+  "@extension kinded projected functions are deprecated",
+  ReplaceWith(
+    "mapN(MA, this, arg1)\n" +
+      ".map { (abcdefg, h) -> Tuple8(abcdefg.a, abcdefg.b, abcdefg.c, abcdefg.d, abcdefg.e, abcdefg.f, abcdefg.g, h) }",
+    "arrow.core.mapN"
+  ),
+  DeprecationLevel.WARNING
+)
+fun <O, A, B, C, D, E, FF, G, H> Kind<Kind<ForConst, O>, Tuple7<A, B, C, D, E, FF,
+  G>>.product(MO: Monoid<O>, arg1: Kind<Kind<ForConst, O>, H>): Const<O, Tuple8<A, B, C, D, E, FF,
+  G, H>> = arrow.core.Const.divide<O>(MO).run {
+  this@product.product<A, B, C, D, E, FF, G, H>(arg1) as arrow.core.Const<O, arrow.core.Tuple8<A, B,
+    C, D, E, FF, G, H>>
+}
+
+@JvmName("product7")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(
+  "@extension kinded projected functions are deprecated",
+  ReplaceWith(
+    "mapN(MA, this, arg1)\n" +
+      ".map { (abcdefgh, i) -> Tuple9(abcdefgh.a, abcdefgh.b, abcdefgh.c, abcdefgh.d, abcdefgh.e, abcdefgh.f, abcdefgh.g, abcdefgh.h, i) }",
+    "arrow.core.mapN"
+  ),
+  DeprecationLevel.WARNING
+)
+fun <O, A, B, C, D, E, FF, G, H, I> Kind<Kind<ForConst, O>, Tuple8<A, B, C, D, E, FF, G,
+  H>>.product(MO: Monoid<O>, arg1: Kind<Kind<ForConst, O>, I>): Const<O, Tuple9<A, B, C, D, E, FF,
+  G, H, I>> = arrow.core.Const.divide<O>(MO).run {
+  this@product.product<A, B, C, D, E, FF, G, H, I>(arg1) as arrow.core.Const<O, arrow.core.Tuple9<A,
+    B, C, D, E, FF, G, H, I>>
+}
+
+@JvmName("product8")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(
+  "@extension kinded projected functions are deprecated",
+  ReplaceWith(
+    "mapN(MA, this, arg1)\n" +
+      ".map { (abcdefghi, j) -> Tuple10(abcdefghi.a, abcdefghi.b, abcdefghi.c, abcdefghi.d, abcdefghi.e, abcdefghi.f, abcdefghi.g, abcdefghi.h, abcdefghi.i, j) }",
+    "arrow.core.mapN"
+  ),
+  DeprecationLevel.WARNING
+)
+fun <O, A, B, C, D, E, FF, G, H, I, J> Kind<Kind<ForConst, O>, Tuple9<A, B, C, D, E, FF, G, H,
+  I>>.product(MO: Monoid<O>, arg1: Kind<Kind<ForConst, O>, J>): Const<O, Tuple10<A, B, C, D, E,
+  FF, G, H, I, J>> = arrow.core.Const.divide<O>(MO).run {
+  this@product.product<A, B, C, D, E, FF, G, H, I, J>(arg1) as arrow.core.Const<O,
+    arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, J>>
+}
+
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
@@ -485,8 +485,8 @@ fun <O, A, B, C, D, E, FF, G, H, I, J, Z> divide(
   "Divide typeclass is deprecated. Use concrete methods on Const",
   level = DeprecationLevel.WARNING
 )
-inline fun <O> Companion.divide(MO: Monoid<O>): ConstDivideInstance<O> = object :
-  arrow.core.extensions.ConstDivideInstance<O> {
-  override fun MO(): arrow.typeclasses.Monoid<O> =
-    MO
-}
+inline fun <O> Companion.divide(MO: Monoid<O>): ConstDivideInstance<O> =
+  object : arrow.core.extensions.ConstDivideInstance<O> {
+    override fun MO(): arrow.typeclasses.Monoid<O> =
+      MO
+  }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/divide/ConstDivideInstance.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/divide/ConstDivideInstance.kt
@@ -30,8 +30,8 @@ import kotlin.jvm.JvmName
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "divide(MO, arg0, arg1, arg2)",
-  "arrow.core.Const.divide"
+    "divide(MO, arg0, arg1, arg2)",
+    "arrow.core.Const.divide"
   ),
   DeprecationLevel.WARNING
 )
@@ -41,8 +41,8 @@ fun <O, A, B, Z> divide(
   arg1: Kind<Kind<ForConst, O>, B>,
   arg2: Function1<Z, Tuple2<A, B>>
 ): Const<O, Z> = arrow.core.Const
-   .divide<O>(MO)
-   .divide<A, B, Z>(arg0, arg1, arg2) as arrow.core.Const<O, Z>
+  .divide<O>(MO)
+  .divide<A, B, Z>(arg0, arg1, arg2) as arrow.core.Const<O, Z>
 
 @JvmName("product")
 @Suppress(
@@ -54,13 +54,13 @@ fun <O, A, B, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(MO, arg1)",
-  "arrow.core.product"
+    "product(MO, arg1)",
+    "arrow.core.product"
   ),
   DeprecationLevel.WARNING
 )
 fun <O, A, B> Kind<Kind<ForConst, O>, A>.product(MO: Monoid<O>, arg1: Kind<Kind<ForConst, O>, B>):
-    Const<O, Tuple2<A, B>> = arrow.core.Const.divide<O>(MO).run {
+  Const<O, Tuple2<A, B>> = arrow.core.Const.divide<O>(MO).run {
   this@product.product<A, B>(arg1) as arrow.core.Const<O, arrow.core.Tuple2<A, B>>
 }
 
@@ -74,8 +74,8 @@ fun <O, A, B> Kind<Kind<ForConst, O>, A>.product(MO: Monoid<O>, arg1: Kind<Kind<
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(MO, arg1)",
-  "arrow.core.product"
+    "product(MO, arg1)",
+    "arrow.core.product"
   ),
   DeprecationLevel.WARNING
 )
@@ -83,9 +83,9 @@ fun <O, A, B, C> Kind<Kind<ForConst, O>, Tuple2<A, B>>.product(
   MO: Monoid<O>,
   arg1: Kind<Kind<ForConst, O>, C>
 ): Const<O, Tuple3<A, B, C>> =
-    arrow.core.Const.divide<O>(MO).run {
-  this@product.product<A, B, C>(arg1) as arrow.core.Const<O, arrow.core.Tuple3<A, B, C>>
-}
+  arrow.core.Const.divide<O>(MO).run {
+    this@product.product<A, B, C>(arg1) as arrow.core.Const<O, arrow.core.Tuple3<A, B, C>>
+  }
 
 @JvmName("product2")
 @Suppress(
@@ -97,8 +97,8 @@ fun <O, A, B, C> Kind<Kind<ForConst, O>, Tuple2<A, B>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(MO, arg1)",
-  "arrow.core.product"
+    "product(MO, arg1)",
+    "arrow.core.product"
   ),
   DeprecationLevel.WARNING
 )
@@ -107,8 +107,8 @@ fun <O, A, B, C, D> Kind<Kind<ForConst, O>, Tuple3<A, B, C>>.product(
   arg1: Kind<Kind<ForConst, O>, D>
 ): Const<O, Tuple4<A, B, C, D>> =
   arrow.core.Const.divide<O>(MO).run {
-  this@product.product<A, B, C, D>(arg1) as arrow.core.Const<O, arrow.core.Tuple4<A, B, C, D>>
-}
+    this@product.product<A, B, C, D>(arg1) as arrow.core.Const<O, arrow.core.Tuple4<A, B, C, D>>
+  }
 
 @JvmName("product3")
 @Suppress(
@@ -120,8 +120,8 @@ fun <O, A, B, C, D> Kind<Kind<ForConst, O>, Tuple3<A, B, C>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(MO, arg1)",
-  "arrow.core.product"
+    "product(MO, arg1)",
+    "arrow.core.product"
   ),
   DeprecationLevel.WARNING
 )
@@ -129,9 +129,9 @@ fun <O, A, B, C, D, E> Kind<Kind<ForConst, O>, Tuple4<A, B, C, D>>.product(
   MO: Monoid<O>,
   arg1: Kind<Kind<ForConst, O>, E>
 ): Const<O, Tuple5<A, B, C, D, E>> =
-    arrow.core.Const.divide<O>(MO).run {
-  this@product.product<A, B, C, D, E>(arg1) as arrow.core.Const<O, arrow.core.Tuple5<A, B, C, D, E>>
-}
+  arrow.core.Const.divide<O>(MO).run {
+    this@product.product<A, B, C, D, E>(arg1) as arrow.core.Const<O, arrow.core.Tuple5<A, B, C, D, E>>
+  }
 
 @JvmName("product4")
 @Suppress(
@@ -143,8 +143,8 @@ fun <O, A, B, C, D, E> Kind<Kind<ForConst, O>, Tuple4<A, B, C, D>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(MO, arg1)",
-  "arrow.core.product"
+    "product(MO, arg1)",
+    "arrow.core.product"
   ),
   DeprecationLevel.WARNING
 )
@@ -152,10 +152,10 @@ fun <O, A, B, C, D, E, FF> Kind<Kind<ForConst, O>, Tuple5<A, B, C, D, E>>.produc
   MO: Monoid<O>,
   arg1: Kind<Kind<ForConst, O>, FF>
 ): Const<O, Tuple6<A, B, C, D, E, FF>> =
-    arrow.core.Const.divide<O>(MO).run {
-  this@product.product<A, B, C, D, E, FF>(arg1) as arrow.core.Const<O, arrow.core.Tuple6<A, B, C, D,
-    E, FF>>
-}
+  arrow.core.Const.divide<O>(MO).run {
+    this@product.product<A, B, C, D, E, FF>(arg1) as arrow.core.Const<O, arrow.core.Tuple6<A, B, C, D,
+      E, FF>>
+  }
 
 @JvmName("product5")
 @Suppress(
@@ -167,14 +167,14 @@ fun <O, A, B, C, D, E, FF> Kind<Kind<ForConst, O>, Tuple5<A, B, C, D, E>>.produc
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(MO, arg1)",
-  "arrow.core.product"
+    "product(MO, arg1)",
+    "arrow.core.product"
   ),
   DeprecationLevel.WARNING
 )
 fun <O, A, B, C, D, E, FF, G> Kind<Kind<ForConst, O>, Tuple6<A, B, C, D, E,
-    FF>>.product(MO: Monoid<O>, arg1: Kind<Kind<ForConst, O>, G>): Const<O, Tuple7<A, B, C, D, E,
-    FF, G>> = arrow.core.Const.divide<O>(MO).run {
+  FF>>.product(MO: Monoid<O>, arg1: Kind<Kind<ForConst, O>, G>): Const<O, Tuple7<A, B, C, D, E,
+  FF, G>> = arrow.core.Const.divide<O>(MO).run {
   this@product.product<A, B, C, D, E, FF, G>(arg1) as arrow.core.Const<O, arrow.core.Tuple7<A, B, C,
     D, E, FF, G>>
 }
@@ -189,14 +189,14 @@ fun <O, A, B, C, D, E, FF, G> Kind<Kind<ForConst, O>, Tuple6<A, B, C, D, E,
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(MO, arg1)",
-  "arrow.core.product"
+    "product(MO, arg1)",
+    "arrow.core.product"
   ),
   DeprecationLevel.WARNING
 )
 fun <O, A, B, C, D, E, FF, G, H> Kind<Kind<ForConst, O>, Tuple7<A, B, C, D, E, FF,
-    G>>.product(MO: Monoid<O>, arg1: Kind<Kind<ForConst, O>, H>): Const<O, Tuple8<A, B, C, D, E, FF,
-    G, H>> = arrow.core.Const.divide<O>(MO).run {
+  G>>.product(MO: Monoid<O>, arg1: Kind<Kind<ForConst, O>, H>): Const<O, Tuple8<A, B, C, D, E, FF,
+  G, H>> = arrow.core.Const.divide<O>(MO).run {
   this@product.product<A, B, C, D, E, FF, G, H>(arg1) as arrow.core.Const<O, arrow.core.Tuple8<A, B,
     C, D, E, FF, G, H>>
 }
@@ -211,14 +211,14 @@ fun <O, A, B, C, D, E, FF, G, H> Kind<Kind<ForConst, O>, Tuple7<A, B, C, D, E, F
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(MO, arg1)",
-  "arrow.core.product"
+    "product(MO, arg1)",
+    "arrow.core.product"
   ),
   DeprecationLevel.WARNING
 )
 fun <O, A, B, C, D, E, FF, G, H, I> Kind<Kind<ForConst, O>, Tuple8<A, B, C, D, E, FF, G,
-    H>>.product(MO: Monoid<O>, arg1: Kind<Kind<ForConst, O>, I>): Const<O, Tuple9<A, B, C, D, E, FF,
-    G, H, I>> = arrow.core.Const.divide<O>(MO).run {
+  H>>.product(MO: Monoid<O>, arg1: Kind<Kind<ForConst, O>, I>): Const<O, Tuple9<A, B, C, D, E, FF,
+  G, H, I>> = arrow.core.Const.divide<O>(MO).run {
   this@product.product<A, B, C, D, E, FF, G, H, I>(arg1) as arrow.core.Const<O, arrow.core.Tuple9<A,
     B, C, D, E, FF, G, H, I>>
 }
@@ -233,14 +233,14 @@ fun <O, A, B, C, D, E, FF, G, H, I> Kind<Kind<ForConst, O>, Tuple8<A, B, C, D, E
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(MO, arg1)",
-  "arrow.core.product"
+    "product(MO, arg1)",
+    "arrow.core.product"
   ),
   DeprecationLevel.WARNING
 )
 fun <O, A, B, C, D, E, FF, G, H, I, J> Kind<Kind<ForConst, O>, Tuple9<A, B, C, D, E, FF, G, H,
-    I>>.product(MO: Monoid<O>, arg1: Kind<Kind<ForConst, O>, J>): Const<O, Tuple10<A, B, C, D, E,
-    FF, G, H, I, J>> = arrow.core.Const.divide<O>(MO).run {
+  I>>.product(MO: Monoid<O>, arg1: Kind<Kind<ForConst, O>, J>): Const<O, Tuple10<A, B, C, D, E,
+  FF, G, H, I, J>> = arrow.core.Const.divide<O>(MO).run {
   this@product.product<A, B, C, D, E, FF, G, H, I, J>(arg1) as arrow.core.Const<O,
     arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, J>>
 }
@@ -255,8 +255,8 @@ fun <O, A, B, C, D, E, FF, G, H, I, J> Kind<Kind<ForConst, O>, Tuple9<A, B, C, D
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "divide(MO, arg0, arg1, arg2, arg3)",
-  "arrow.core.Const.divide"
+    "divide(MO, arg0, arg1, arg2, arg3)",
+    "arrow.core.Const.divide"
   ),
   DeprecationLevel.WARNING
 )
@@ -267,8 +267,8 @@ fun <O, A, B, C, Z> divide(
   arg2: Kind<Kind<ForConst, O>, C>,
   arg3: Function1<Z, Tuple3<A, B, C>>
 ): Const<O, Z> = arrow.core.Const
-   .divide<O>(MO)
-   .divide<A, B, C, Z>(arg0, arg1, arg2, arg3) as arrow.core.Const<O, Z>
+  .divide<O>(MO)
+  .divide<A, B, C, Z>(arg0, arg1, arg2, arg3) as arrow.core.Const<O, Z>
 
 @JvmName("divide")
 @Suppress(
@@ -280,8 +280,8 @@ fun <O, A, B, C, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "divide(MO, arg0, arg1, arg2, arg3, arg4)",
-  "arrow.core.Const.divide"
+    "divide(MO, arg0, arg1, arg2, arg3, arg4)",
+    "arrow.core.Const.divide"
   ),
   DeprecationLevel.WARNING
 )
@@ -293,8 +293,8 @@ fun <O, A, B, C, D, Z> divide(
   arg3: Kind<Kind<ForConst, O>, D>,
   arg4: Function1<Z, Tuple4<A, B, C, D>>
 ): Const<O, Z> = arrow.core.Const
-   .divide<O>(MO)
-   .divide<A, B, C, D, Z>(arg0, arg1, arg2, arg3, arg4) as arrow.core.Const<O, Z>
+  .divide<O>(MO)
+  .divide<A, B, C, D, Z>(arg0, arg1, arg2, arg3, arg4) as arrow.core.Const<O, Z>
 
 @JvmName("divide")
 @Suppress(
@@ -306,8 +306,8 @@ fun <O, A, B, C, D, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "divide(MO, arg0, arg1, arg2, arg3, arg4, arg5)",
-  "arrow.core.Const.divide"
+    "divide(MO, arg0, arg1, arg2, arg3, arg4, arg5)",
+    "arrow.core.Const.divide"
   ),
   DeprecationLevel.WARNING
 )
@@ -320,8 +320,8 @@ fun <O, A, B, C, D, E, Z> divide(
   arg4: Kind<Kind<ForConst, O>, E>,
   arg5: Function1<Z, Tuple5<A, B, C, D, E>>
 ): Const<O, Z> = arrow.core.Const
-   .divide<O>(MO)
-   .divide<A, B, C, D, E, Z>(arg0, arg1, arg2, arg3, arg4, arg5) as arrow.core.Const<O, Z>
+  .divide<O>(MO)
+  .divide<A, B, C, D, E, Z>(arg0, arg1, arg2, arg3, arg4, arg5) as arrow.core.Const<O, Z>
 
 @JvmName("divide")
 @Suppress(
@@ -333,8 +333,8 @@ fun <O, A, B, C, D, E, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "divide(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-  "arrow.core.Const.divide"
+    "divide(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
+    "arrow.core.Const.divide"
   ),
   DeprecationLevel.WARNING
 )
@@ -348,8 +348,8 @@ fun <O, A, B, C, D, E, FF, Z> divide(
   arg5: Kind<Kind<ForConst, O>, FF>,
   arg6: Function1<Z, Tuple6<A, B, C, D, E, FF>>
 ): Const<O, Z> = arrow.core.Const
-   .divide<O>(MO)
-   .divide<A, B, C, D, E, FF, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as arrow.core.Const<O, Z>
+  .divide<O>(MO)
+  .divide<A, B, C, D, E, FF, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as arrow.core.Const<O, Z>
 
 @JvmName("divide")
 @Suppress(
@@ -361,8 +361,8 @@ fun <O, A, B, C, D, E, FF, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "divide(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-  "arrow.core.Const.divide"
+    "divide(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
+    "arrow.core.Const.divide"
   ),
   DeprecationLevel.WARNING
 )
@@ -377,9 +377,9 @@ fun <O, A, B, C, D, E, FF, G, Z> divide(
   arg6: Kind<Kind<ForConst, O>, G>,
   arg7: Function1<Z, Tuple7<A, B, C, D, E, FF, G>>
 ): Const<O, Z> = arrow.core.Const
-   .divide<O>(MO)
-   .divide<A, B, C, D, E, FF, G, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as
-    arrow.core.Const<O, Z>
+  .divide<O>(MO)
+  .divide<A, B, C, D, E, FF, G, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as
+  arrow.core.Const<O, Z>
 
 @JvmName("divide")
 @Suppress(
@@ -391,8 +391,8 @@ fun <O, A, B, C, D, E, FF, G, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "divide(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-  "arrow.core.Const.divide"
+    "divide(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
+    "arrow.core.Const.divide"
   ),
   DeprecationLevel.WARNING
 )
@@ -408,9 +408,9 @@ fun <O, A, B, C, D, E, FF, G, H, Z> divide(
   arg7: Kind<Kind<ForConst, O>, H>,
   arg8: Function1<Z, Tuple8<A, B, C, D, E, FF, G, H>>
 ): Const<O, Z> = arrow.core.Const
-   .divide<O>(MO)
-   .divide<A, B, C, D, E, FF, G, H, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
-    arrow.core.Const<O, Z>
+  .divide<O>(MO)
+  .divide<A, B, C, D, E, FF, G, H, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
+  arrow.core.Const<O, Z>
 
 @JvmName("divide")
 @Suppress(
@@ -422,8 +422,8 @@ fun <O, A, B, C, D, E, FF, G, H, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "divide(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-  "arrow.core.Const.divide"
+    "divide(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
+    "arrow.core.Const.divide"
   ),
   DeprecationLevel.WARNING
 )
@@ -440,8 +440,8 @@ fun <O, A, B, C, D, E, FF, G, H, I, Z> divide(
   arg8: Kind<Kind<ForConst, O>, I>,
   arg9: Function1<Z, Tuple9<A, B, C, D, E, FF, G, H, I>>
 ): Const<O, Z> = arrow.core.Const
-   .divide<O>(MO)
-   .divide<A, B, C, D, E, FF, G, H, I,
+  .divide<O>(MO)
+  .divide<A, B, C, D, E, FF, G, H, I,
     Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) as arrow.core.Const<O, Z>
 
 @JvmName("divide")
@@ -454,8 +454,8 @@ fun <O, A, B, C, D, E, FF, G, H, I, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "divide(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)",
-  "arrow.core.Const.divide"
+    "divide(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)",
+    "arrow.core.Const.divide"
   ),
   DeprecationLevel.WARNING
 )
@@ -473,14 +473,20 @@ fun <O, A, B, C, D, E, FF, G, H, I, J, Z> divide(
   arg9: Kind<Kind<ForConst, O>, J>,
   arg10: Function1<Z, Tuple10<A, B, C, D, E, FF, G, H, I, J>>
 ): Const<O, Z> = arrow.core.Const
-   .divide<O>(MO)
-   .divide<A, B, C, D, E, FF, G, H, I, J,
+  .divide<O>(MO)
+  .divide<A, B, C, D, E, FF, G, H, I, J,
     Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) as arrow.core.Const<O, Z>
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated(
+  "Divide typeclass is deprecated. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
+)
 inline fun <O> Companion.divide(MO: Monoid<O>): ConstDivideInstance<O> = object :
-    arrow.core.extensions.ConstDivideInstance<O> { override fun MO(): arrow.typeclasses.Monoid<O> =
-    MO }
+  arrow.core.extensions.ConstDivideInstance<O> {
+  override fun MO(): arrow.typeclasses.Monoid<O> =
+    MO
+}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/divide/ConstDivideInstance.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/divide/ConstDivideInstance.kt
@@ -26,8 +26,9 @@ import arrow.typeclasses.Monoid
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, arg0, arg1).map(arg2)",
-    "arrow.core.Cons"
+    "Cons.mapN(MO, arg0, arg1) { a, b -> arg2(Tuple2(a,b)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
 )
@@ -50,8 +51,9 @@ fun <O, A, B, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, arg0, arg1, arg2).map(arg3)",
-    "arrow.core.Cons"
+    "Cons.mapN(MO, arg0, arg1, arg2) { a, b, c -> arg3(Tuple3(a, b, c)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
 )
@@ -75,8 +77,9 @@ fun <O, A, B, C, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, arg0, arg1, arg2, arg3).map(arg4)",
-    "arrow.core.Cons"
+    "Cons.mapN(MO, arg0, arg1, arg2, arg3) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
 )
@@ -101,8 +104,9 @@ fun <O, A, B, C, D, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, arg0, arg1, arg2, arg3, arg4).map(arg5)",
-    "arrow.core.Cons"
+    "Cons.mapN(MO, arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
 )
@@ -128,8 +132,9 @@ fun <O, A, B, C, D, E, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5).map(arg6)",
-    "arrow.core.Cons"
+    "Cons.mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> arg6(Tuple6(a, b, c, d, e, f)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
 )
@@ -156,8 +161,9 @@ fun <O, A, B, C, D, E, FF, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6).map(arg7)",
-    "arrow.core.Cons"
+    "Cons.mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> arg7(Tuple7(a, b, c, d, e, f, g)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
 )
@@ -186,8 +192,9 @@ fun <O, A, B, C, D, E, FF, G, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7).map(arg8)",
-    "arrow.core.Cons"
+    "Cons.mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> arg8(Tuple8(a, b, c, d, e, f, g, h)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
 )
@@ -217,8 +224,10 @@ fun <O, A, B, C, D, E, FF, G, H, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).map(arg9)",
-    "arrow.core.Cons"
+    "Cons.mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)\n" +
+      "{ a, b, c, d, e, f, g, h, i -> arg9(Tuple9(a, b, c, d, e, f, g, h, i)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
 )
@@ -249,8 +258,10 @@ fun <O, A, B, C, D, E, FF, G, H, I, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).map(arg10)",
-    "arrow.core.Cons"
+    "Cons.mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)\n" +
+      "{ a, b, c, d, e, f, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, f, g, h, i, j)) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
 )
@@ -282,8 +293,9 @@ fun <O, A, B, C, D, E, FF, G, H, I, J, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, this, arg1) { a, b -> Tuple2(a, b) }",
-    "arrow.core.Cons"
+    "Cons.mapN(MO, this, arg1) { a, b -> Tuple2(a, b) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
 )
@@ -302,8 +314,9 @@ fun <O, A, B> Kind<Kind<ForConst, O>, A>.product(MO: Monoid<O>, arg1: Kind<Kind<
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, this, arg1).map { (ab, c) -> Tuple3(ab.a, ab.b, c) }",
-    "arrow.core.Cons"
+    "Cons.mapN(MO, this, arg1).map { ab, c -> Tuple3(ab.a, ab.b, c) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
 )
@@ -325,8 +338,9 @@ fun <O, A, B, C> Kind<Kind<ForConst, O>, Tuple2<A, B>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, this, arg1).map { (abc, d) -> Tuple4(abc.a, abc.b, abc.c, d) }",
-    "arrow.core.Cons"
+    "Cons.mapN(MO, this, arg1).map { abc, d -> Tuple4(abc.a, abc.b, abc.c, d) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
 )
@@ -348,8 +362,9 @@ fun <O, A, B, C, D> Kind<Kind<ForConst, O>, Tuple3<A, B, C>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, this, arg1).map { (abcd, e) -> Tuple5(abcd.a, abcd.b, abcd.c, abcd.d, e) }",
-    "arrow.core.Cons"
+    "Cons.mapN(MO, this, arg1).map { abcd, e -> Tuple5(abcd.a, abcd.b, abcd.c, abcd.d, e) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
 )
@@ -371,8 +386,9 @@ fun <O, A, B, C, D, E> Kind<Kind<ForConst, O>, Tuple4<A, B, C, D>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, this, arg1).map { (abcde, f) -> Tuple6(abcde.a, abcde.b, abcde.c, abcde.d, abcde.e, f) }",
-    "arrow.core.Cons"
+    "Cons.mapN(MO, this, arg1).map { abcde, f -> Tuple6(abcde.a, abcde.b, abcde.c, abcde.d, abcde.e, f) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
 )
@@ -395,9 +411,10 @@ fun <O, A, B, C, D, E, FF> Kind<Kind<ForConst, O>, Tuple5<A, B, C, D, E>>.produc
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, this, arg1)\n" +
-      ".map { (abcdef, g) -> Tuple7(abcdef.a, abcdef.b, abcdef.c, abcdef.d, abcdef.e, abcdef.f, g) }",
-    "arrow.core.Cons"
+    "Cons.mapN(MO, this, arg1)\n" +
+      ".map { abcdef, g -> Tuple7(abcdef.a, abcdef.b, abcdef.c, abcdef.d, abcdef.e, abcdef.f, g) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
 )
@@ -418,9 +435,10 @@ fun <O, A, B, C, D, E, FF, G> Kind<Kind<ForConst, O>, Tuple6<A, B, C, D, E,
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, this, arg1)\n" +
-      ".map { (abcdefg, h) -> Tuple8(abcdefg.a, abcdefg.b, abcdefg.c, abcdefg.d, abcdefg.e, abcdefg.f, abcdefg.g, h) }",
-    "arrow.core.Cons"
+    "Cons.mapN(MO, this, arg1)\n" +
+      ".map { abcdefg, h -> Tuple8(abcdefg.a, abcdefg.b, abcdefg.c, abcdefg.d, abcdefg.e, abcdefg.f, abcdefg.g, h) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
 )
@@ -441,9 +459,10 @@ fun <O, A, B, C, D, E, FF, G, H> Kind<Kind<ForConst, O>, Tuple7<A, B, C, D, E, F
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, this, arg1)\n" +
-      ".map { (abcdefgh, i) -> Tuple9(abcdefgh.a, abcdefgh.b, abcdefgh.c, abcdefgh.d, abcdefgh.e, abcdefgh.f, abcdefgh.g, abcdefgh.h, i) }",
-    "arrow.core.Cons"
+    "Cons.mapN(MO, this, arg1)\n" +
+      ".map { abcdefgh, i -> Tuple9(abcdefgh.a, abcdefgh.b, abcdefgh.c, abcdefgh.d, abcdefgh.e, abcdefgh.f, abcdefgh.g, abcdefgh.h, i) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
 )
@@ -464,9 +483,10 @@ fun <O, A, B, C, D, E, FF, G, H, I> Kind<Kind<ForConst, O>, Tuple8<A, B, C, D, E
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, this, arg1)\n" +
-      ".map { (abcdefghi, j) -> Tuple10(abcdefghi.a, abcdefghi.b, abcdefghi.c, abcdefghi.d, abcdefghi.e, abcdefghi.f, abcdefghi.g, abcdefghi.h, abcdefghi.i, j) }",
-    "arrow.core.Cons"
+    "Cons.mapN(MO, this, arg1)\n" +
+      ".map { abcdefghi, j -> Tuple10(abcdefghi.a, abcdefghi.b, abcdefghi.c, abcdefghi.d, abcdefghi.e, abcdefghi.f, abcdefghi.g, abcdefghi.h, abcdefghi.i, j) }",
+    "arrow.core.Cons",
+    "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
 )

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/divide/ConstDivideInstance.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/divide/ConstDivideInstance.kt
@@ -26,8 +26,8 @@ import arrow.typeclasses.Monoid
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MO, arg0, arg1).map(arg2)",
-    "arrow.core.mapN"
+    "Cons.mapN(MO, arg0, arg1).map(arg2)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -50,8 +50,8 @@ fun <O, A, B, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MO, arg0, arg1, arg2).map(arg3)",
-    "arrow.core.mapN"
+    "Cons.mapN(MO, arg0, arg1, arg2).map(arg3)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -75,8 +75,8 @@ fun <O, A, B, C, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MO, arg0, arg1, arg2, arg3).map(arg4)",
-    "arrow.core.mapN"
+    "Cons.mapN(MO, arg0, arg1, arg2, arg3).map(arg4)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -101,8 +101,8 @@ fun <O, A, B, C, D, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MO, arg0, arg1, arg2, arg3, arg4).map(arg5)",
-    "arrow.core.mapN"
+    "Cons.mapN(MO, arg0, arg1, arg2, arg3, arg4).map(arg5)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -128,8 +128,8 @@ fun <O, A, B, C, D, E, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5).map(arg6)",
-    "arrow.core.mapN"
+    "Cons.mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5).map(arg6)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -156,8 +156,8 @@ fun <O, A, B, C, D, E, FF, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6).map(arg7)",
-    "arrow.core.mapN"
+    "Cons.mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6).map(arg7)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -186,8 +186,8 @@ fun <O, A, B, C, D, E, FF, G, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7).map(arg8)",
-    "arrow.core.mapN"
+    "Cons.mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7).map(arg8)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -217,8 +217,8 @@ fun <O, A, B, C, D, E, FF, G, H, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).map(arg9)",
-    "arrow.core.mapN"
+    "Cons.mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).map(arg9)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -249,8 +249,8 @@ fun <O, A, B, C, D, E, FF, G, H, I, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).map(arg10)",
-    "arrow.core.mapN"
+    "Cons.mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).map(arg10)",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -282,8 +282,8 @@ fun <O, A, B, C, D, E, FF, G, H, I, J, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, this, arg1) { a, b -> Tuple2(a, b) }",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, this, arg1) { a, b -> Tuple2(a, b) }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -302,8 +302,8 @@ fun <O, A, B> Kind<Kind<ForConst, O>, A>.product(MO: Monoid<O>, arg1: Kind<Kind<
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, this, arg1).map { (ab, c) -> Tuple3(ab.a, ab.b, c) }",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, this, arg1).map { (ab, c) -> Tuple3(ab.a, ab.b, c) }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -325,8 +325,8 @@ fun <O, A, B, C> Kind<Kind<ForConst, O>, Tuple2<A, B>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, this, arg1).map { (abc, d) -> Tuple4(abc.a, abc.b, abc.c, d) }",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, this, arg1).map { (abc, d) -> Tuple4(abc.a, abc.b, abc.c, d) }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -348,8 +348,8 @@ fun <O, A, B, C, D> Kind<Kind<ForConst, O>, Tuple3<A, B, C>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, this, arg1).map { (abcd, e) -> Tuple5(abcd.a, abcd.b, abcd.c, abcd.d, e) }",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, this, arg1).map { (abcd, e) -> Tuple5(abcd.a, abcd.b, abcd.c, abcd.d, e) }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -371,8 +371,8 @@ fun <O, A, B, C, D, E> Kind<Kind<ForConst, O>, Tuple4<A, B, C, D>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, this, arg1).map { (abcde, f) -> Tuple6(abcde.a, abcde.b, abcde.c, abcde.d, abcde.e, f) }",
-    "arrow.core.mapN"
+    "Cons.mapN(MA, this, arg1).map { (abcde, f) -> Tuple6(abcde.a, abcde.b, abcde.c, abcde.d, abcde.e, f) }",
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -395,9 +395,9 @@ fun <O, A, B, C, D, E, FF> Kind<Kind<ForConst, O>, Tuple5<A, B, C, D, E>>.produc
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, this, arg1)\n" +
+    "Cons.mapN(MA, this, arg1)\n" +
       ".map { (abcdef, g) -> Tuple7(abcdef.a, abcdef.b, abcdef.c, abcdef.d, abcdef.e, abcdef.f, g) }",
-    "arrow.core.mapN"
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -418,9 +418,9 @@ fun <O, A, B, C, D, E, FF, G> Kind<Kind<ForConst, O>, Tuple6<A, B, C, D, E,
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, this, arg1)\n" +
+    "Cons.mapN(MA, this, arg1)\n" +
       ".map { (abcdefg, h) -> Tuple8(abcdefg.a, abcdefg.b, abcdefg.c, abcdefg.d, abcdefg.e, abcdefg.f, abcdefg.g, h) }",
-    "arrow.core.mapN"
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -441,9 +441,9 @@ fun <O, A, B, C, D, E, FF, G, H> Kind<Kind<ForConst, O>, Tuple7<A, B, C, D, E, F
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, this, arg1)\n" +
+    "Cons.mapN(MA, this, arg1)\n" +
       ".map { (abcdefgh, i) -> Tuple9(abcdefgh.a, abcdefgh.b, abcdefgh.c, abcdefgh.d, abcdefgh.e, abcdefgh.f, abcdefgh.g, abcdefgh.h, i) }",
-    "arrow.core.mapN"
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )
@@ -464,9 +464,9 @@ fun <O, A, B, C, D, E, FF, G, H, I> Kind<Kind<ForConst, O>, Tuple8<A, B, C, D, E
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "mapN(MA, this, arg1)\n" +
+    "Cons.mapN(MA, this, arg1)\n" +
       ".map { (abcdefghi, j) -> Tuple10(abcdefghi.a, abcdefghi.b, abcdefghi.c, abcdefghi.d, abcdefghi.e, abcdefghi.f, abcdefghi.g, abcdefghi.h, abcdefghi.i, j) }",
-    "arrow.core.mapN"
+    "arrow.core.Cons"
   ),
   DeprecationLevel.WARNING
 )

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/divisible/ConstDivisibleInstance.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/divisible/ConstDivisibleInstance.kt
@@ -31,6 +31,10 @@ fun <O, A> conquer(MOO: Monoid<O>): Const<O, A> = arrow.core.Const
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated(
+  "Divisible typeclass is deprecated. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
+)
 inline fun <O> Companion.divisible(MOO: Monoid<O>): ConstDivisibleInstance<O> = object :
     arrow.core.extensions.ConstDivisibleInstance<O> { override fun MOO():
     arrow.typeclasses.Monoid<O> = MOO }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/divisible/ConstDivisibleInstance.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/divisible/ConstDivisibleInstance.kt
@@ -18,14 +18,14 @@ import kotlin.jvm.JvmName
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "Const(MOO().empty())",
-  "arrow.core.Const"
+    "Const(MOO().empty())",
+    "arrow.core.Const"
   ),
   DeprecationLevel.WARNING
 )
 fun <O, A> conquer(MOO: Monoid<O>): Const<O, A> = arrow.core.Const
-   .divisible<O>(MOO)
-   .conquer<A>() as arrow.core.Const<O, A>
+  .divisible<O>(MOO)
+  .conquer<A>() as arrow.core.Const<O, A>
 
 @Suppress(
   "UNCHECKED_CAST",
@@ -35,6 +35,7 @@ fun <O, A> conquer(MOO: Monoid<O>): Const<O, A> = arrow.core.Const
   "Divisible typeclass is deprecated. Use concrete methods on Const",
   level = DeprecationLevel.WARNING
 )
-inline fun <O> Companion.divisible(MOO: Monoid<O>): ConstDivisibleInstance<O> = object :
-    arrow.core.extensions.ConstDivisibleInstance<O> { override fun MOO():
-    arrow.typeclasses.Monoid<O> = MOO }
+inline fun <O> Companion.divisible(MOO: Monoid<O>): ConstDivisibleInstance<O> =
+  object : arrow.core.extensions.ConstDivisibleInstance<O> {
+    override fun MOO(): arrow.typeclasses.Monoid<O> = MOO
+  }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/divisible/ConstDivisibleInstance.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/divisible/ConstDivisibleInstance.kt
@@ -18,8 +18,8 @@ import kotlin.jvm.JvmName
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "conquer(MOO)",
-  "arrow.core.Const.conquer"
+  "Const(MOO().empty())",
+  "arrow.core.Const"
   ),
   DeprecationLevel.WARNING
 )

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/eq/ConstEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/eq/ConstEq.kt
@@ -19,13 +19,13 @@ import kotlin.jvm.JvmName
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "neqv(EQ, arg1)",
-  "arrow.core.neqv"
+    "!eqv(EQ, arg1)",
+    "arrow.core.eqv"
   ),
   DeprecationLevel.WARNING
 )
 fun <A, T> Const<A, T>.neqv(EQ: Eq<A>, arg1: Const<A, T>): Boolean = arrow.core.Const.eq<A,
-    T>(EQ).run {
+  T>(EQ).run {
   this@neqv.neqv(arg1) as kotlin.Boolean
 }
 
@@ -33,5 +33,14 @@ fun <A, T> Const<A, T>.neqv(EQ: Eq<A>, arg1: Const<A, T>): Boolean = arrow.core.
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-inline fun <A, T> Companion.eq(EQ: Eq<A>): ConstEq<A, T> = object : arrow.core.extensions.ConstEq<A,
-    T> { override fun EQ(): arrow.typeclasses.Eq<A> = EQ }
+@Deprecated(
+  "@extension projected functions are deprecated",
+  ReplaceWith(
+    "Eq.const<A>(EQ)",
+    "arrow.core.const", "arrow.typeclasses.Eq"
+  ),
+  DeprecationLevel.WARNING
+)
+inline fun <A, T> Companion.eq(EQ: Eq<A>): ConstEq<A, T> = object : arrow.core.extensions.ConstEq<A, T> {
+  override fun EQ(): arrow.typeclasses.Eq<A> = EQ
+}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/eq/ConstEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/eq/ConstEq.kt
@@ -32,7 +32,7 @@ fun <A, T> Const<A, T>.neqv(EQ: Eq<A>, arg1: Const<A, T>): Boolean = arrow.core.
   "NOTHING_TO_INLINE"
 )
 @Deprecated(EqDeprecation)
-inline fun <A, T> Companion.eq(EQ: Eq<A>): ConstEq<A, T> = object : arrow.core.extensions.ConstEq<A,
-  T> {
-  override fun EQ(): arrow.typeclasses.Eq<A> = EQ
+inline fun <A, T> Companion.eq(EQ: Eq<A>): ConstEq<A, T> = object : arrow.core.extensions.ConstEq<A, T> {
+  override fun EQ(): arrow.typeclasses.Eq<A> =
+    EQ
 }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/eqK/ConstEqK.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/eqK/ConstEqK.kt
@@ -20,8 +20,8 @@ import kotlin.jvm.JvmName
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "eqK(EQA, arg1, arg2)",
-  "arrow.core.eqK"
+  "eqv(EQA, arg1)",
+  "arrow.core.eqv"
   ),
   DeprecationLevel.WARNING
 )

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/eqK/ConstEqK.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/eqK/ConstEqK.kt
@@ -40,14 +40,7 @@ fun <A> Kind<Kind<ForConst, A>, A>.eqK(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "liftEq(EQA, arg0)",
-  "arrow.core.Const.liftEq"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
 fun <A> liftEq(EQA: Eq<A>, arg0: Eq<A>): Eq<Kind<Kind<ForConst, A>, A>> = arrow.core.Const
    .eqK<A>(EQA)
    .liftEq<A>(arg0) as arrow.typeclasses.Eq<arrow.Kind<arrow.Kind<arrow.core.ForConst, A>, A>>
@@ -56,5 +49,6 @@ fun <A> liftEq(EQA: Eq<A>, arg0: Eq<A>): Eq<Kind<Kind<ForConst, A>, A>> = arrow.
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
 inline fun <A> Companion.eqK(EQA: Eq<A>): ConstEqK<A> = object : arrow.core.extensions.ConstEqK<A> {
     override fun EQA(): arrow.typeclasses.Eq<A> = EQA }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/foldable/ConstFoldable.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/foldable/ConstFoldable.kt
@@ -37,10 +37,7 @@ internal val foldable_singleton: ConstFoldable<Any?> = object : ConstFoldable<An
 )
 @Deprecated(
   "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "foldLeft(arg1, arg2)",
-    "arrow.core.foldLeft"
-  ),
+  ReplaceWith("arg1"),
   DeprecationLevel.WARNING
 )
 fun <A, B> Kind<Kind<ForConst, A>, A>.foldLeft(arg1: B, arg2: Function2<B, A, B>): B =
@@ -57,10 +54,7 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.foldLeft(arg1: B, arg2: Function2<B, A, B>
 )
 @Deprecated(
   "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "foldRight(arg1, arg2)",
-    "arrow.core.foldRight"
-  ),
+  ReplaceWith("arg1"),
   DeprecationLevel.WARNING
 )
 fun <A, B> Kind<Kind<ForConst, A>, A>.foldRight(
@@ -96,8 +90,8 @@ fun <A> Kind<Kind<ForConst, A>, A>.fold(arg1: Monoid<A>): A = arrow.core.Const.f
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Option.fromNullable(reduceOrNull(arg1, arg2))",
-    "arrow.core.reduceOrNull",
+    "Option.empty()",
+    "arrow.core.empty",
     "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
@@ -119,19 +113,20 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.reduceLeftToOption(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "reduceRightNull(arg1, arg2).map { Option.fromNullable(it) }",
-    "arrow.core.reduceRightNull",
-    "arrow.core.Option"
+    "Eval.Now<Option<B>>(Option.empty())",
+    "arrow.core.empty",
+    "arrow.core.Option",
+    "arrow.core.Eval"
   ),
   DeprecationLevel.WARNING
 )
 fun <A, B> Kind<Kind<ForConst, A>, A>.reduceRightToOption(
   arg1: Function1<A, B>,
   arg2: Function2<A, Eval<B>, Eval<B>>
-): Eval<Option<B>> = arrow.core.Const.foldable<A>().run {
-  this@reduceRightToOption.reduceRightToOption<A, B>(arg1, arg2) as
-    arrow.core.Eval<arrow.core.Option<B>>
-}
+): Eval<Option<B>> =
+  arrow.core.Const.foldable<A>().run {
+    this@reduceRightToOption.reduceRightToOption<A, B>(arg1, arg2) as arrow.core.Eval<arrow.core.Option<B>>
+  }
 
 @JvmName("reduceLeftOption")
 @Suppress(
@@ -143,8 +138,8 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.reduceRightToOption(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Option.fromNullable(reduceOrNull({ it }, arg1))",
-    "arrow.core.reduceOrNull",
+    "Option.empty()",
+    "arrow.core.empty",
     "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
@@ -164,9 +159,10 @@ fun <A> Kind<Kind<ForConst, A>, A>.reduceLeftOption(arg1: Function2<A, A, A>): O
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "reduceOrNull({ it }, arg2).map { Option.fromNullable(it) }",
-    "arrow.core.reduceOrNull",
-    "arrow.core.Option"
+    "Eval.Now<Option<B>>(Option.empty())",
+    "arrow.core.empty",
+    "arrow.core.Option",
+    "arrow.core.Eval"
   ),
   DeprecationLevel.WARNING
 )

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/foldable/ConstFoldable.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/foldable/ConstFoldable.kt
@@ -38,15 +38,15 @@ internal val foldable_singleton: ConstFoldable<Any?> = object : ConstFoldable<An
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "foldLeft(arg1, arg2)",
-  "arrow.core.foldLeft"
+    "foldLeft(arg1, arg2)",
+    "arrow.core.foldLeft"
   ),
   DeprecationLevel.WARNING
 )
 fun <A, B> Kind<Kind<ForConst, A>, A>.foldLeft(arg1: B, arg2: Function2<B, A, B>): B =
-    arrow.core.Const.foldable<A>().run {
-  this@foldLeft.foldLeft<A, B>(arg1, arg2) as B
-}
+  arrow.core.Const.foldable<A>().run {
+    this@foldLeft.foldLeft<A, B>(arg1, arg2) as B
+  }
 
 @JvmName("foldRight")
 @Suppress(
@@ -58,8 +58,8 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.foldLeft(arg1: B, arg2: Function2<B, A, B>
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "foldRight(arg1, arg2)",
-  "arrow.core.foldRight"
+    "foldRight(arg1, arg2)",
+    "arrow.core.foldRight"
   ),
   DeprecationLevel.WARNING
 )
@@ -79,10 +79,7 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.foldRight(
 )
 @Deprecated(
   "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "fold(arg1)",
-  "arrow.core.fold"
-  ),
+  ReplaceWith("arg1.empty()"),
   DeprecationLevel.WARNING
 )
 fun <A> Kind<Kind<ForConst, A>, A>.fold(arg1: Monoid<A>): A = arrow.core.Const.foldable<A>().run {
@@ -99,8 +96,9 @@ fun <A> Kind<Kind<ForConst, A>, A>.fold(arg1: Monoid<A>): A = arrow.core.Const.f
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "reduceLeftToOption(arg1, arg2)",
-  "arrow.core.reduceLeftToOption"
+    "Option.fromNullable(reduceOrNull(arg1, arg2))",
+    "arrow.core.reduceOrNull",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -121,8 +119,9 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.reduceLeftToOption(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "reduceRightToOption(arg1, arg2)",
-  "arrow.core.reduceRightToOption"
+    "reduceRightNull(arg1, arg2).map { Option.fromNullable(it) }",
+    "arrow.core.reduceRightNull",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -144,15 +143,16 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.reduceRightToOption(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "reduceLeftOption(arg1)",
-  "arrow.core.reduceLeftOption"
+    "Option.fromNullable(reduceOrNull({ it }, arg1))",
+    "arrow.core.reduceOrNull",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
 fun <A> Kind<Kind<ForConst, A>, A>.reduceLeftOption(arg1: Function2<A, A, A>): Option<A> =
-    arrow.core.Const.foldable<A>().run {
-  this@reduceLeftOption.reduceLeftOption<A>(arg1) as arrow.core.Option<A>
-}
+  arrow.core.Const.foldable<A>().run {
+    this@reduceLeftOption.reduceLeftOption<A>(arg1) as arrow.core.Option<A>
+  }
 
 @JvmName("reduceRightOption")
 @Suppress(
@@ -164,13 +164,14 @@ fun <A> Kind<Kind<ForConst, A>, A>.reduceLeftOption(arg1: Function2<A, A, A>): O
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "reduceRightOption(arg1)",
-  "arrow.core.reduceRightOption"
+    "reduceOrNull({ it }, arg2).map { Option.fromNullable(it) }",
+    "arrow.core.reduceOrNull",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
 fun <A> Kind<Kind<ForConst, A>, A>.reduceRightOption(arg1: Function2<A, Eval<A>, Eval<A>>):
-    Eval<Option<A>> = arrow.core.Const.foldable<A>().run {
+  Eval<Option<A>> = arrow.core.Const.foldable<A>().run {
   this@reduceRightOption.reduceRightOption<A>(arg1) as arrow.core.Eval<arrow.core.Option<A>>
 }
 
@@ -183,16 +184,13 @@ fun <A> Kind<Kind<ForConst, A>, A>.reduceRightOption(arg1: Function2<A, Eval<A>,
 )
 @Deprecated(
   "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "combineAll(arg1)",
-  "arrow.core.combineAll"
-  ),
+  ReplaceWith("arg1.empty()"),
   DeprecationLevel.WARNING
 )
 fun <A> Kind<Kind<ForConst, A>, A>.combineAll(arg1: Monoid<A>): A =
-    arrow.core.Const.foldable<A>().run {
-  this@combineAll.combineAll<A>(arg1) as A
-}
+  arrow.core.Const.foldable<A>().run {
+    this@combineAll.combineAll<A>(arg1) as A
+  }
 
 @JvmName("foldMap")
 @Suppress(
@@ -203,16 +201,13 @@ fun <A> Kind<Kind<ForConst, A>, A>.combineAll(arg1: Monoid<A>): A =
 )
 @Deprecated(
   "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "foldMap(arg1, arg2)",
-  "arrow.core.foldMap"
-  ),
+  ReplaceWith("arg1.empty()"),
   DeprecationLevel.WARNING
 )
 fun <A, B> Kind<Kind<ForConst, A>, A>.foldMap(arg1: Monoid<B>, arg2: Function1<A, B>): B =
-    arrow.core.Const.foldable<A>().run {
-  this@foldMap.foldMap<A, B>(arg1, arg2) as B
-}
+  arrow.core.Const.foldable<A>().run {
+    this@foldMap.foldMap<A, B>(arg1, arg2) as B
+  }
 
 @JvmName("orEmpty")
 @Suppress(
@@ -223,16 +218,13 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.foldMap(arg1: Monoid<B>, arg2: Function1<A
 )
 @Deprecated(
   "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "orEmpty(arg0, arg1)",
-  "arrow.core.Const.orEmpty"
-  ),
+  ReplaceWith("arg1.empty()"),
   DeprecationLevel.WARNING
 )
 fun <A> orEmpty(arg0: Applicative<Kind<ForConst, A>>, arg1: Monoid<A>): Const<A, A> =
-    arrow.core.Const
-   .foldable<A>()
-   .orEmpty<A>(arg0, arg1) as arrow.core.Const<A, A>
+  arrow.core.Const
+    .foldable<A>()
+    .orEmpty<A>(arg0, arg1) as arrow.core.Const<A, A>
 
 @JvmName("traverse_")
 @Suppress(
@@ -241,14 +233,7 @@ fun <A> orEmpty(arg0: Applicative<Kind<ForConst, A>>, arg1: Monoid<A>): Const<A,
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "traverse_(arg1, arg2)",
-  "arrow.core.traverse_"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
 fun <A, G, B> Kind<Kind<ForConst, A>, A>.traverse_(
   arg1: Applicative<G>,
   arg2: Function1<A, Kind<G, B>>
@@ -263,18 +248,11 @@ fun <A, G, B> Kind<Kind<ForConst, A>, A>.traverse_(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "sequence_(arg1)",
-  "arrow.core.sequence_"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
 fun <A, G> Kind<Kind<ForConst, A>, Kind<G, A>>.sequence_(arg1: Applicative<G>): Kind<G, Unit> =
-    arrow.core.Const.foldable<A>().run {
-  this@sequence_.sequence_<G, A>(arg1) as arrow.Kind<G, kotlin.Unit>
-}
+  arrow.core.Const.foldable<A>().run {
+    this@sequence_.sequence_<G, A>(arg1) as arrow.Kind<G, kotlin.Unit>
+  }
 
 @JvmName("find")
 @Suppress(
@@ -286,15 +264,15 @@ fun <A, G> Kind<Kind<ForConst, A>, Kind<G, A>>.sequence_(arg1: Applicative<G>): 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "find(arg1)",
-  "arrow.core.find"
+    "foldRight(Eval.now<Option<A>>(None)) { a, lb -> if (arg1(a)) Eval.now(Some(a)) else lb }.value()",
+    "arrow.core.foldRight"
   ),
   DeprecationLevel.WARNING
 )
 fun <A> Kind<Kind<ForConst, A>, A>.find(arg1: Function1<A, Boolean>): Option<A> =
-    arrow.core.Const.foldable<A>().run {
-  this@find.find<A>(arg1) as arrow.core.Option<A>
-}
+  arrow.core.Const.foldable<A>().run {
+    this@find.find<A>(arg1) as arrow.core.Option<A>
+  }
 
 @JvmName("exists")
 @Suppress(
@@ -306,15 +284,15 @@ fun <A> Kind<Kind<ForConst, A>, A>.find(arg1: Function1<A, Boolean>): Option<A> 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "exists(arg1)",
-  "arrow.core.exists"
+    "foldRight(Eval.False) { a, lb -> if (arg1(a)) Eval.True else lb }.value()",
+    "arrow.core.exists"
   ),
   DeprecationLevel.WARNING
 )
 fun <A> Kind<Kind<ForConst, A>, A>.exists(arg1: Function1<A, Boolean>): Boolean =
-    arrow.core.Const.foldable<A>().run {
-  this@exists.exists<A>(arg1) as kotlin.Boolean
-}
+  arrow.core.Const.foldable<A>().run {
+    this@exists.exists<A>(arg1) as kotlin.Boolean
+  }
 
 @JvmName("forAll")
 @Suppress(
@@ -326,15 +304,15 @@ fun <A> Kind<Kind<ForConst, A>, A>.exists(arg1: Function1<A, Boolean>): Boolean 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "forAll(arg1)",
-  "arrow.core.forAll"
+    "foldRight(Eval.True) { a, lb -> if (arg1(a)) lb else Eval.False }.value()",
+    "arrow.core.foldRight"
   ),
   DeprecationLevel.WARNING
 )
 fun <A> Kind<Kind<ForConst, A>, A>.forAll(arg1: Function1<A, Boolean>): Boolean =
-    arrow.core.Const.foldable<A>().run {
-  this@forAll.forAll<A>(arg1) as kotlin.Boolean
-}
+  arrow.core.Const.foldable<A>().run {
+    this@forAll.forAll<A>(arg1) as kotlin.Boolean
+  }
 
 @JvmName("all")
 @Suppress(
@@ -346,15 +324,15 @@ fun <A> Kind<Kind<ForConst, A>, A>.forAll(arg1: Function1<A, Boolean>): Boolean 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "all(arg1)",
-  "arrow.core.all"
+    "foldRight(Eval.True) { a, lb -> if (arg1(a)) lb else Eval.False }.value()",
+    "arrow.core.foldRight"
   ),
   DeprecationLevel.WARNING
 )
 fun <A> Kind<Kind<ForConst, A>, A>.all(arg1: Function1<A, Boolean>): Boolean =
-    arrow.core.Const.foldable<A>().run {
-  this@all.all<A>(arg1) as kotlin.Boolean
-}
+  arrow.core.Const.foldable<A>().run {
+    this@all.all<A>(arg1) as kotlin.Boolean
+  }
 
 @JvmName("isEmpty")
 @Suppress(
@@ -366,14 +344,15 @@ fun <A> Kind<Kind<ForConst, A>, A>.all(arg1: Function1<A, Boolean>): Boolean =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "isEmpty()",
-  "arrow.core.isEmpty"
+    "foldRight(Eval.True) { _, _ -> Eval.False }.value()",
+    "arrow.core.foldRight"
   ),
   DeprecationLevel.WARNING
 )
-fun <A> Kind<Kind<ForConst, A>, A>.isEmpty(): Boolean = arrow.core.Const.foldable<A>().run {
-  this@isEmpty.isEmpty<A>() as kotlin.Boolean
-}
+fun <A> Kind<Kind<ForConst, A>, A>.isEmpty(): Boolean =
+  arrow.core.Const.foldable<A>().run {
+    this@isEmpty.isEmpty<A>() as kotlin.Boolean
+  }
 
 @JvmName("nonEmpty")
 @Suppress(
@@ -385,14 +364,15 @@ fun <A> Kind<Kind<ForConst, A>, A>.isEmpty(): Boolean = arrow.core.Const.foldabl
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "nonEmpty()",
-  "arrow.core.nonEmpty"
+    "!foldRight(Eval.True) { _, _ -> Eval.False }.value()",
+    "arrow.core.foldRight"
   ),
   DeprecationLevel.WARNING
 )
-fun <A> Kind<Kind<ForConst, A>, A>.nonEmpty(): Boolean = arrow.core.Const.foldable<A>().run {
-  this@nonEmpty.nonEmpty<A>() as kotlin.Boolean
-}
+fun <A> Kind<Kind<ForConst, A>, A>.nonEmpty(): Boolean =
+  arrow.core.Const.foldable<A>().run {
+    this@nonEmpty.nonEmpty<A>() as kotlin.Boolean
+  }
 
 @JvmName("isNotEmpty")
 @Suppress(
@@ -404,8 +384,8 @@ fun <A> Kind<Kind<ForConst, A>, A>.nonEmpty(): Boolean = arrow.core.Const.foldab
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "isNotEmpty()",
-  "arrow.core.isNotEmpty"
+    "!foldRight(Eval.True) { _, _ -> Eval.False }.value()",
+    "arrow.core.foldRight"
   ),
   DeprecationLevel.WARNING
 )
@@ -423,15 +403,15 @@ fun <A> Kind<Kind<ForConst, A>, A>.isNotEmpty(): Boolean = arrow.core.Const.fold
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "size(arg1)",
-  "arrow.core.size"
+    "arg1.run { foldLeft(arg1.empty()) { 1 }",
+    "arrow.core.size"
   ),
   DeprecationLevel.WARNING
 )
 fun <A> Kind<Kind<ForConst, A>, A>.size(arg1: Monoid<Long>): Long =
-    arrow.core.Const.foldable<A>().run {
-  this@size.size<A>(arg1) as kotlin.Long
-}
+  arrow.core.Const.foldable<A>().run {
+    this@size.size<A>(arg1) as kotlin.Long
+  }
 
 @JvmName("foldMapA")
 @Suppress(
@@ -440,14 +420,7 @@ fun <A> Kind<Kind<ForConst, A>, A>.size(arg1: Monoid<Long>): Long =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "foldMapA(arg1, arg2, arg3)",
-  "arrow.core.foldMapA"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
 fun <A, G, B, AP : Applicative<G>, MO : Monoid<B>> Kind<Kind<ForConst, A>, A>.foldMapA(
   arg1: AP,
   arg2: MO,
@@ -463,14 +436,7 @@ fun <A, G, B, AP : Applicative<G>, MO : Monoid<B>> Kind<Kind<ForConst, A>, A>.fo
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "foldMapM(arg1, arg2, arg3)",
-  "arrow.core.foldMapM"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
 fun <A, G, B, MA : Monad<G>, MO : Monoid<B>> Kind<Kind<ForConst, A>, A>.foldMapM(
   arg1: MA,
   arg2: MO,
@@ -486,14 +452,7 @@ fun <A, G, B, MA : Monad<G>, MO : Monoid<B>> Kind<Kind<ForConst, A>, A>.foldMapM
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "foldM(arg1, arg2, arg3)",
-  "arrow.core.foldM"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
 fun <A, G, B> Kind<Kind<ForConst, A>, A>.foldM(
   arg1: Monad<G>,
   arg2: B,
@@ -512,14 +471,21 @@ fun <A, G, B> Kind<Kind<ForConst, A>, A>.foldM(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "get(arg1)",
-  "arrow.core.get"
+    "if (arg1 < 0L) None\n" +
+      "else foldLeft<A, Either<A, Long>>(0L.right()) { i, a ->\n" +
+      "        i.flatMap {\n" +
+      "          if (it == arg1) Left(a)\n" +
+      "          else Right(it + 1L)\n" +
+      "        }\n" +
+      "      }.swap().toOption()",
+    "arrow.core.foldLeft"
   ),
   DeprecationLevel.WARNING
 )
-fun <A> Kind<Kind<ForConst, A>, A>.get(arg1: Long): Option<A> = arrow.core.Const.foldable<A>().run {
-  this@get.get<A>(arg1) as arrow.core.Option<A>
-}
+fun <A> Kind<Kind<ForConst, A>, A>.get(arg1: Long): Option<A> =
+  arrow.core.Const.foldable<A>().run {
+    this@get.get<A>(arg1) as arrow.core.Option<A>
+  }
 
 @JvmName("firstOption")
 @Suppress(
@@ -531,8 +497,8 @@ fun <A> Kind<Kind<ForConst, A>, A>.get(arg1: Long): Option<A> = arrow.core.Const
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "firstOption()",
-  "arrow.core.firstOption"
+    "foldRight(Eval.now<Option<A>>(None)) { Eval.now(Some(a)) }.value()",
+    "arrow.core.foldRight"
   ),
   DeprecationLevel.WARNING
 )
@@ -550,15 +516,15 @@ fun <A> Kind<Kind<ForConst, A>, A>.firstOption(): Option<A> = arrow.core.Const.f
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "firstOption(arg1)",
-  "arrow.core.firstOption"
+    "foldRight(Eval.now<Option<A>>(None)) { a, lb -> if (arg1(a)) Eval.now(Some(a)) else lb }.value()",
+    "arrow.core.foldRight"
   ),
   DeprecationLevel.WARNING
 )
 fun <A> Kind<Kind<ForConst, A>, A>.firstOption(arg1: Function1<A, Boolean>): Option<A> =
-    arrow.core.Const.foldable<A>().run {
-  this@firstOption.firstOption<A>(arg1) as arrow.core.Option<A>
-}
+  arrow.core.Const.foldable<A>().run {
+    this@firstOption.firstOption<A>(arg1) as arrow.core.Option<A>
+  }
 
 @JvmName("firstOrNone")
 @Suppress(
@@ -570,8 +536,8 @@ fun <A> Kind<Kind<ForConst, A>, A>.firstOption(arg1: Function1<A, Boolean>): Opt
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "firstOrNone()",
-  "arrow.core.firstOrNone"
+    "foldRight(Eval.now<Option<A>>(None)) { Eval.now(Some(a)) }.value()",
+    "arrow.core.foldRight"
   ),
   DeprecationLevel.WARNING
 )
@@ -589,15 +555,15 @@ fun <A> Kind<Kind<ForConst, A>, A>.firstOrNone(): Option<A> = arrow.core.Const.f
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "firstOrNone(arg1)",
-  "arrow.core.firstOrNone"
+    "foldRight(Eval.now<Option<A>>(None)) { a, lb -> if (arg1(a)) Eval.now(Some(a)) else lb }.value()",
+    "arrow.core.foldRight"
   ),
   DeprecationLevel.WARNING
 )
 fun <A> Kind<Kind<ForConst, A>, A>.firstOrNone(arg1: Function1<A, Boolean>): Option<A> =
-    arrow.core.Const.foldable<A>().run {
-  this@firstOrNone.firstOrNone<A>(arg1) as arrow.core.Option<A>
-}
+  arrow.core.Const.foldable<A>().run {
+    this@firstOrNone.firstOrNone<A>(arg1) as arrow.core.Option<A>
+  }
 
 @JvmName("toList")
 @Suppress(
@@ -609,18 +575,23 @@ fun <A> Kind<Kind<ForConst, A>, A>.firstOrNone(arg1: Function1<A, Boolean>): Opt
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "toList()",
-  "arrow.core.toList"
+    "foldRight(Eval.now(emptyList<A>())) { v, acc -> acc.map { listOf(v) + it } }.value()",
+    "arrow.core.foldRight"
   ),
   DeprecationLevel.WARNING
 )
-fun <A> Kind<Kind<ForConst, A>, A>.toList(): List<A> = arrow.core.Const.foldable<A>().run {
-  this@toList.toList<A>() as kotlin.collections.List<A>
-}
+fun <A> Kind<Kind<ForConst, A>, A>.toList(): List<A> =
+  arrow.core.Const.foldable<A>().run {
+    this@toList.toList<A>() as kotlin.collections.List<A>
+  }
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated(
+  "Foldable typeclass is deprecated. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
+)
 inline fun <A> Companion.foldable(): ConstFoldable<A> = foldable_singleton as
-    arrow.core.extensions.ConstFoldable<A>
+  arrow.core.extensions.ConstFoldable<A>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/functor/ConstFunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/functor/ConstFunctor.kt
@@ -52,15 +52,15 @@ internal val functor_singleton: ConstFunctor<Any?> = object : ConstFunctor<Any?>
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg1)",
-  "arrow.core.map"
+    "map(arg1)",
+    "arrow.core.map"
   ),
   DeprecationLevel.WARNING
 )
 fun <A, B> Kind<Kind<ForConst, A>, A>.map(arg1: Function1<A, B>): Const<A, B> =
-    arrow.core.Const.functor<A>().run {
-  this@map.map(arg1) as arrow.core.Const<A, B>
-}
+  arrow.core.Const.functor<A>().run {
+    this@map.map(arg1) as arrow.core.Const<A, B>
+  }
 
 @JvmName("imap")
 @Suppress(
@@ -72,15 +72,15 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.map(arg1: Function1<A, B>): Const<A, B> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "imap(arg1, arg2)",
-  "arrow.core.imap"
+    "map(arg1)",
+    "arrow.core.map"
   ),
   DeprecationLevel.WARNING
 )
-fun <A, B> Kind<Kind<ForConst, A>, A>.imap(arg1: Function1<A, B>, arg2: Function1<B, A>): Const<A,
-    B> = arrow.core.Const.functor<A>().run {
-  this@imap.imap(arg1, arg2) as arrow.core.Const<A, B>
-}
+fun <A, B> Kind<Kind<ForConst, A>, A>.imap(arg1: Function1<A, B>, arg2: Function1<B, A>): Const<A, B> =
+  arrow.core.Const.functor<A>().run {
+    this@imap.imap(arg1, arg2) as arrow.core.Const<A, B>
+  }
 
 /**
  *  Lifts a function `A -> B` to the [F] structure returning a polymorphic function
@@ -113,18 +113,11 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.imap(arg1: Function1<A, B>, arg2: Function
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "lift(arg0)",
-  "arrow.core.Const.lift"
-  ),
-  DeprecationLevel.WARNING
-)
-fun <A, B> lift(arg0: Function1<A, B>): Function1<Kind<Kind<ForConst, A>, A>, Kind<Kind<ForConst,
-    A>, B>> = arrow.core.Const
-   .functor<A>()
-   .lift(arg0) as kotlin.Function1<arrow.Kind<arrow.Kind<arrow.core.ForConst, A>, A>,
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
+fun <A, B> lift(arg0: Function1<A, B>): Function1<Kind<Kind<ForConst, A>, A>, Kind<Kind<ForConst, A>, B>> =
+  arrow.core.Const
+    .functor<A>()
+    .lift(arg0) as kotlin.Function1<arrow.Kind<arrow.Kind<arrow.core.ForConst, A>, A>,
     arrow.Kind<arrow.Kind<arrow.core.ForConst, A>, B>>
 
 @JvmName("void")
@@ -137,14 +130,15 @@ fun <A, B> lift(arg0: Function1<A, B>): Function1<Kind<Kind<ForConst, A>, A>, Ki
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "void()",
-  "arrow.core.void"
+    "map { Unit }",
+    "arrow.core.map"
   ),
   DeprecationLevel.WARNING
 )
-fun <A> Kind<Kind<ForConst, A>, A>.void(): Const<A, Unit> = arrow.core.Const.functor<A>().run {
-  this@void.void() as arrow.core.Const<A, kotlin.Unit>
-}
+fun <A> Kind<Kind<ForConst, A>, A>.void(): Const<A, Unit> =
+  arrow.core.Const.functor<A>().run {
+    this@void.void() as arrow.core.Const<A, kotlin.Unit>
+  }
 
 /**
  *  Applies [f] to an [A] inside [F] and returns the [F] structure with a tuple of the [A] value and the
@@ -180,15 +174,15 @@ fun <A> Kind<Kind<ForConst, A>, A>.void(): Const<A, Unit> = arrow.core.Const.fun
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "fproduct(arg1)",
-  "arrow.core.fproduct"
+    "map { a -> Tuple2(a, f(a)) }",
+    "arrow.core.map"
   ),
   DeprecationLevel.WARNING
 )
 fun <A, B> Kind<Kind<ForConst, A>, A>.fproduct(arg1: Function1<A, B>): Const<A, Tuple2<A, B>> =
-    arrow.core.Const.functor<A>().run {
-  this@fproduct.fproduct(arg1) as arrow.core.Const<A, arrow.core.Tuple2<A, B>>
-}
+  arrow.core.Const.functor<A>().run {
+    this@fproduct.fproduct(arg1) as arrow.core.Const<A, arrow.core.Tuple2<A, B>>
+  }
 
 /**
  *  Replaces [A] inside [F] with [B] resulting in a Kind<F, B>
@@ -223,15 +217,15 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.fproduct(arg1: Function1<A, B>): Const<A, 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapConst(arg1)",
-  "arrow.core.mapConst"
+    "map { arg1 }",
+    "arrow.core.map"
   ),
   DeprecationLevel.WARNING
 )
 fun <A, B> Kind<Kind<ForConst, A>, A>.mapConst(arg1: B): Const<A, B> =
-    arrow.core.Const.functor<A>().run {
-  this@mapConst.mapConst(arg1) as arrow.core.Const<A, B>
-}
+  arrow.core.Const.functor<A>().run {
+    this@mapConst.mapConst(arg1) as arrow.core.Const<A, B>
+  }
 
 /**
  *  Replaces the [B] value inside [F] with [A] resulting in a Kind<F, A>
@@ -246,15 +240,15 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.mapConst(arg1: B): Const<A, B> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapConst(arg1)",
-  "arrow.core.mapConst"
+    "map { this }",
+    "arrow.core.map"
   ),
   DeprecationLevel.WARNING
 )
 fun <A, B> A.mapConst(arg1: Kind<Kind<ForConst, A>, B>): Const<A, A> =
-    arrow.core.Const.functor<A>().run {
-  this@mapConst.mapConst(arg1) as arrow.core.Const<A, A>
-}
+  arrow.core.Const.functor<A>().run {
+    this@mapConst.mapConst(arg1) as arrow.core.Const<A, A>
+  }
 
 /**
  *  Pairs [B] with [A] returning a Kind<F, Tuple2<B, A>>
@@ -289,15 +283,15 @@ fun <A, B> A.mapConst(arg1: Kind<Kind<ForConst, A>, B>): Const<A, A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupleLeft(arg1)",
-  "arrow.core.tupleLeft"
+    "map { a -> Tuple2(arg1, a) }",
+    "arrow.core.map"
   ),
   DeprecationLevel.WARNING
 )
 fun <A, B> Kind<Kind<ForConst, A>, A>.tupleLeft(arg1: B): Const<A, Tuple2<B, A>> =
-    arrow.core.Const.functor<A>().run {
-  this@tupleLeft.tupleLeft(arg1) as arrow.core.Const<A, arrow.core.Tuple2<B, A>>
-}
+  arrow.core.Const.functor<A>().run {
+    this@tupleLeft.tupleLeft(arg1) as arrow.core.Const<A, arrow.core.Tuple2<B, A>>
+  }
 
 /**
  *  Pairs [A] with [B] returning a Kind<F, Tuple2<A, B>>
@@ -332,15 +326,15 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.tupleLeft(arg1: B): Const<A, Tuple2<B, A>>
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupleRight(arg1)",
-  "arrow.core.tupleRight"
+    "map { a -> Tuple2(a, arg1) }",
+    "arrow.core.map"
   ),
   DeprecationLevel.WARNING
 )
 fun <A, B> Kind<Kind<ForConst, A>, A>.tupleRight(arg1: B): Const<A, Tuple2<A, B>> =
-    arrow.core.Const.functor<A>().run {
-  this@tupleRight.tupleRight(arg1) as arrow.core.Const<A, arrow.core.Tuple2<A, B>>
-}
+  arrow.core.Const.functor<A>().run {
+    this@tupleRight.tupleRight(arg1) as arrow.core.Const<A, arrow.core.Tuple2<A, B>>
+  }
 
 /**
  *  Given [A] is a sub type of [B], re-type this value from Kind<F, A> to Kind<F, B>
@@ -376,19 +370,21 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.tupleRight(arg1: B): Const<A, Tuple2<A, B>
 )
 @Deprecated(
   "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "widen()",
-  "arrow.core.widen"
-  ),
+  ReplaceWith("this"),
   DeprecationLevel.WARNING
 )
-fun <A, B> Kind<Kind<ForConst, A>, A>.widen(): Const<A, B> = arrow.core.Const.functor<A>().run {
-  this@widen.widen() as arrow.core.Const<A, B>
-}
+fun <A, B> Kind<Kind<ForConst, A>, A>.widen(): Const<A, B> =
+  arrow.core.Const.functor<A>().run {
+    this@widen.widen() as arrow.core.Const<A, B>
+  }
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated(
+  "Functor typeclass is deprecated. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
+)
 inline fun <A> Companion.functor(): ConstFunctor<A> = functor_singleton as
-    arrow.core.extensions.ConstFunctor<A>
+  arrow.core.extensions.ConstFunctor<A>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/hash/ConstHash.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/hash/ConstHash.kt
@@ -19,14 +19,15 @@ import kotlin.jvm.JvmName
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "hash(HA)",
-  "arrow.core.hash"
+    "hash(HA)",
+    "arrow.core.hash"
   ),
   DeprecationLevel.WARNING
 )
-fun <A, T> Const<A, T>.hash(HA: Hash<A>): Int = arrow.core.Const.hash<A, T>(HA).run {
-  this@hash.hash() as kotlin.Int
-}
+fun <A, T> Const<A, T>.hash(HA: Hash<A>): Int =
+  arrow.core.Const.hash<A, T>(HA).run {
+    this@hash.hash() as kotlin.Int
+  }
 
 @Suppress(
   "UNCHECKED_CAST",
@@ -36,5 +37,6 @@ fun <A, T> Const<A, T>.hash(HA: Hash<A>): Int = arrow.core.Const.hash<A, T>(HA).
   "Hash typeclass is deprecated. Use concrete methods on Const",
   level = DeprecationLevel.WARNING
 )
-inline fun <A, T> Companion.hash(HA: Hash<A>): ConstHash<A, T> = object :
-    arrow.core.extensions.ConstHash<A, T> { override fun HA(): arrow.typeclasses.Hash<A> = HA }
+inline fun <A, T> Companion.hash(HA: Hash<A>): ConstHash<A, T> = object : arrow.core.extensions.ConstHash<A, T> {
+  override fun HA(): arrow.typeclasses.Hash<A> = HA
+}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/hash/ConstHash.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/hash/ConstHash.kt
@@ -32,5 +32,9 @@ fun <A, T> Const<A, T>.hash(HA: Hash<A>): Int = arrow.core.Const.hash<A, T>(HA).
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated(
+  "Hash typeclass is deprecated. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
+)
 inline fun <A, T> Companion.hash(HA: Hash<A>): ConstHash<A, T> = object :
     arrow.core.extensions.ConstHash<A, T> { override fun HA(): arrow.typeclasses.Hash<A> = HA }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/invariant/ConstInvariant.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/invariant/ConstInvariant.kt
@@ -28,8 +28,8 @@ internal val invariant_singleton: ConstInvariant<Any?> = object : ConstInvariant
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "imap(arg1, arg2)",
-  "arrow.core.imap"
+  "retag()",
+  "arrow.core.retag"
   ),
   DeprecationLevel.WARNING
 )
@@ -41,6 +41,10 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.imap(arg1: Function1<A, B>, arg2: Function
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Invariant typeclass is deprecated. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
 )
 inline fun <A> Companion.invariant(): ConstInvariant<A> = invariant_singleton as
     arrow.core.extensions.ConstInvariant<A>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/invariant/ConstInvariant.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/invariant/ConstInvariant.kt
@@ -28,15 +28,15 @@ internal val invariant_singleton: ConstInvariant<Any?> = object : ConstInvariant
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "retag()",
-  "arrow.core.retag"
+    "retag()",
+    "arrow.core.retag"
   ),
   DeprecationLevel.WARNING
 )
-fun <A, B> Kind<Kind<ForConst, A>, A>.imap(arg1: Function1<A, B>, arg2: Function1<B, A>): Const<A,
-    B> = arrow.core.Const.invariant<A>().run {
-  this@imap.imap<A, B>(arg1, arg2) as arrow.core.Const<A, B>
-}
+fun <A, B> Kind<Kind<ForConst, A>, A>.imap(arg1: Function1<A, B>, arg2: Function1<B, A>): Const<A, B> =
+  arrow.core.Const.invariant<A>().run {
+    this@imap.imap<A, B>(arg1, arg2) as arrow.core.Const<A, B>
+  }
 
 @Suppress(
   "UNCHECKED_CAST",
@@ -47,4 +47,4 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.imap(arg1: Function1<A, B>, arg2: Function
   level = DeprecationLevel.WARNING
 )
 inline fun <A> Companion.invariant(): ConstInvariant<A> = invariant_singleton as
-    arrow.core.extensions.ConstInvariant<A>
+  arrow.core.extensions.ConstInvariant<A>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/monoid/ConstMonoid.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/monoid/ConstMonoid.kt
@@ -21,16 +21,13 @@ import kotlin.jvm.JvmName
 )
 @Deprecated(
   "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "combineAll(MA)",
-  "arrow.core.combineAll"
-  ),
+  ReplaceWith("if (isEmpty()) MA.empty() else reduce { a, b -> a.combine(b) }"),
   DeprecationLevel.WARNING
 )
 fun <A, T> Collection<Kind<Kind<ForConst, A>, T>>.combineAll(MA: Monoid<A>): Const<A, T> =
-    arrow.core.Const.monoid<A, T>(MA).run {
-  this@combineAll.combineAll() as arrow.core.Const<A, T>
-}
+  arrow.core.Const.monoid<A, T>(MA).run {
+    this@combineAll.combineAll() as arrow.core.Const<A, T>
+  }
 
 @JvmName("combineAll")
 @Suppress(
@@ -41,20 +38,22 @@ fun <A, T> Collection<Kind<Kind<ForConst, A>, T>>.combineAll(MA: Monoid<A>): Con
 )
 @Deprecated(
   "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "combineAll(MA, arg0)",
-  "arrow.core.Const.combineAll"
-  ),
+  ReplaceWith("if (arg0.isEmpty()) MA.empty() else arg0.reduce { a, b -> a.combine(b) }"),
   DeprecationLevel.WARNING
 )
 fun <A, T> combineAll(MA: Monoid<A>, arg0: List<Kind<Kind<ForConst, A>, T>>): Const<A, T> =
-    arrow.core.Const
-   .monoid<A, T>(MA)
-   .combineAll(arg0) as arrow.core.Const<A, T>
+  arrow.core.Const
+    .monoid<A, T>(MA)
+    .combineAll(arg0) as arrow.core.Const<A, T>
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-inline fun <A, T> Companion.monoid(MA: Monoid<A>): ConstMonoid<A, T> = object :
-    arrow.core.extensions.ConstMonoid<A, T> { override fun MA(): arrow.typeclasses.Monoid<A> = MA }
+@Deprecated(
+  "Monoid typeclass is deprecated. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
+)
+inline fun <A, T> Companion.monoid(MA: Monoid<A>): ConstMonoid<A, T> = object : arrow.core.extensions.ConstMonoid<A, T> {
+  override fun MA(): arrow.typeclasses.Monoid<A> = MA
+}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/order/ConstOrder.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/order/ConstOrder.kt
@@ -21,7 +21,7 @@ import kotlin.jvm.JvmName
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "compare(ORD, arg1)",
+    "compare(ORD, arg1).toInt()",
     "arrow.core.compare"
   ),
   DeprecationLevel.WARNING

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/order/ConstOrder.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/order/ConstOrder.kt
@@ -21,15 +21,15 @@ import kotlin.jvm.JvmName
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "compareTo(ORD, arg1)",
-  "arrow.core.compareTo"
+    "compare(ORD, arg1)",
+    "arrow.core.compare"
   ),
   DeprecationLevel.WARNING
 )
-fun <A, T> Const<A, T>.compareTo(ORD: Order<A>, arg1: Const<A, T>): Int = arrow.core.Const.order<A,
-    T>(ORD).run {
-  this@compareTo.compareTo(arg1) as kotlin.Int
-}
+fun <A, T> Const<A, T>.compareTo(ORD: Order<A>, arg1: Const<A, T>): Int =
+  arrow.core.Const.order<A, T>(ORD).run {
+    this@compareTo.compareTo(arg1) as kotlin.Int
+  }
 
 @JvmName("eqv")
 @Suppress(
@@ -41,15 +41,15 @@ fun <A, T> Const<A, T>.compareTo(ORD: Order<A>, arg1: Const<A, T>): Int = arrow.
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "eqv(ORD, arg1)",
-  "arrow.core.eqv"
+    "eqv(ORD, arg1)",
+    "arrow.core.eqv"
   ),
   DeprecationLevel.WARNING
 )
-fun <A, T> Const<A, T>.eqv(ORD: Order<A>, arg1: Const<A, T>): Boolean = arrow.core.Const.order<A,
-    T>(ORD).run {
-  this@eqv.eqv(arg1) as kotlin.Boolean
-}
+fun <A, T> Const<A, T>.eqv(ORD: Order<A>, arg1: Const<A, T>): Boolean =
+  arrow.core.Const.order<A, T>(ORD).run {
+    this@eqv.eqv(arg1) as kotlin.Boolean
+  }
 
 @JvmName("lt")
 @Suppress(
@@ -61,15 +61,15 @@ fun <A, T> Const<A, T>.eqv(ORD: Order<A>, arg1: Const<A, T>): Boolean = arrow.co
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "lt(ORD, arg1)",
-  "arrow.core.lt"
+    "compare(ORD, arg1) == LT",
+    "arrow.core.compare"
   ),
   DeprecationLevel.WARNING
 )
-fun <A, T> Const<A, T>.lt(ORD: Order<A>, arg1: Const<A, T>): Boolean = arrow.core.Const.order<A,
-    T>(ORD).run {
-  this@lt.lt(arg1) as kotlin.Boolean
-}
+fun <A, T> Const<A, T>.lt(ORD: Order<A>, arg1: Const<A, T>): Boolean =
+  arrow.core.Const.order<A, T>(ORD).run {
+    this@lt.lt(arg1) as kotlin.Boolean
+  }
 
 @JvmName("lte")
 @Suppress(
@@ -81,15 +81,15 @@ fun <A, T> Const<A, T>.lt(ORD: Order<A>, arg1: Const<A, T>): Boolean = arrow.cor
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "lte(ORD, arg1)",
-  "arrow.core.lte"
+    "compare(ORD, arg1) != GT",
+    "arrow.core.compare"
   ),
   DeprecationLevel.WARNING
 )
-fun <A, T> Const<A, T>.lte(ORD: Order<A>, arg1: Const<A, T>): Boolean = arrow.core.Const.order<A,
-    T>(ORD).run {
-  this@lte.lte(arg1) as kotlin.Boolean
-}
+fun <A, T> Const<A, T>.lte(ORD: Order<A>, arg1: Const<A, T>): Boolean =
+  arrow.core.Const.order<A, T>(ORD).run {
+    this@lte.lte(arg1) as kotlin.Boolean
+  }
 
 @JvmName("gt")
 @Suppress(
@@ -101,15 +101,15 @@ fun <A, T> Const<A, T>.lte(ORD: Order<A>, arg1: Const<A, T>): Boolean = arrow.co
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "gt(ORD, arg1)",
-  "arrow.core.gt"
+    "compare(ORD, arg1) == GT",
+    "arrow.core.compare"
   ),
   DeprecationLevel.WARNING
 )
-fun <A, T> Const<A, T>.gt(ORD: Order<A>, arg1: Const<A, T>): Boolean = arrow.core.Const.order<A,
-    T>(ORD).run {
-  this@gt.gt(arg1) as kotlin.Boolean
-}
+fun <A, T> Const<A, T>.gt(ORD: Order<A>, arg1: Const<A, T>): Boolean =
+  arrow.core.Const.order<A, T>(ORD).run {
+    this@gt.gt(arg1) as kotlin.Boolean
+  }
 
 @JvmName("gte")
 @Suppress(
@@ -121,15 +121,15 @@ fun <A, T> Const<A, T>.gt(ORD: Order<A>, arg1: Const<A, T>): Boolean = arrow.cor
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "gte(ORD, arg1)",
-  "arrow.core.gte"
+    "compare(ORD, arg1) != LT",
+    "arrow.core.compare"
   ),
   DeprecationLevel.WARNING
 )
-fun <A, T> Const<A, T>.gte(ORD: Order<A>, arg1: Const<A, T>): Boolean = arrow.core.Const.order<A,
-    T>(ORD).run {
-  this@gte.gte(arg1) as kotlin.Boolean
-}
+fun <A, T> Const<A, T>.gte(ORD: Order<A>, arg1: Const<A, T>): Boolean =
+  arrow.core.Const.order<A, T>(ORD).run {
+    this@gte.gte(arg1) as kotlin.Boolean
+  }
 
 @JvmName("max")
 @Suppress(
@@ -141,15 +141,15 @@ fun <A, T> Const<A, T>.gte(ORD: Order<A>, arg1: Const<A, T>): Boolean = arrow.co
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "max(ORD, arg1)",
-  "arrow.core.max"
+    "if (compare(ORD, arg1) == GT) this else arg1",
+    "arrow.core.compare"
   ),
   DeprecationLevel.WARNING
 )
 fun <A, T> Const<A, T>.max(ORD: Order<A>, arg1: Const<A, T>): Const<A, T> =
-    arrow.core.Const.order<A, T>(ORD).run {
-  this@max.max(arg1) as arrow.core.Const<A, T>
-}
+  arrow.core.Const.order<A, T>(ORD).run {
+    this@max.max(arg1) as arrow.core.Const<A, T>
+  }
 
 @JvmName("min")
 @Suppress(
@@ -161,15 +161,15 @@ fun <A, T> Const<A, T>.max(ORD: Order<A>, arg1: Const<A, T>): Const<A, T> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "min(ORD, arg1)",
-  "arrow.core.min"
+    "if (compare(ORD, arg1) == LT) this else arg1",
+    "arrow.core.compare"
   ),
   DeprecationLevel.WARNING
 )
 fun <A, T> Const<A, T>.min(ORD: Order<A>, arg1: Const<A, T>): Const<A, T> =
-    arrow.core.Const.order<A, T>(ORD).run {
-  this@min.min(arg1) as arrow.core.Const<A, T>
-}
+  arrow.core.Const.order<A, T>(ORD).run {
+    this@min.min(arg1) as arrow.core.Const<A, T>
+  }
 
 @JvmName("sort")
 @Suppress(
@@ -181,19 +181,24 @@ fun <A, T> Const<A, T>.min(ORD: Order<A>, arg1: Const<A, T>): Const<A, T> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "sort(ORD, arg1)",
-  "arrow.core.sort"
+    "if (compare(ORD, arg1) != LT) Tuple2(this, arg1) else Tuple2(arg1, this)",
+    "arrow.core.compare"
   ),
   DeprecationLevel.WARNING
 )
 fun <A, T> Const<A, T>.sort(ORD: Order<A>, arg1: Const<A, T>): Tuple2<Const<A, T>, Const<A, T>> =
-    arrow.core.Const.order<A, T>(ORD).run {
-  this@sort.sort(arg1) as arrow.core.Tuple2<arrow.core.Const<A, T>, arrow.core.Const<A, T>>
-}
+  arrow.core.Const.order<A, T>(ORD).run {
+    this@sort.sort(arg1) as arrow.core.Tuple2<arrow.core.Const<A, T>, arrow.core.Const<A, T>>
+  }
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-inline fun <A, T> Companion.order(ORD: Order<A>): ConstOrder<A, T> = object :
-    arrow.core.extensions.ConstOrder<A, T> { override fun ORD(): arrow.typeclasses.Order<A> = ORD }
+@Deprecated(
+  "Order typeclass is deprecated. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
+)
+inline fun <A, T> Companion.order(ORD: Order<A>): ConstOrder<A, T> = object : arrow.core.extensions.ConstOrder<A, T> {
+  override fun ORD(): arrow.typeclasses.Order<A> = ORD
+}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/semigroup/ConstSemigroup.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/semigroup/ConstSemigroup.kt
@@ -20,15 +20,15 @@ import kotlin.jvm.JvmName
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "combine(SA, arg1)",
-  "arrow.core.combine"
+    "combine(SA, arg1)",
+    "arrow.core.combine"
   ),
   DeprecationLevel.WARNING
 )
-fun <A, T> Kind<Kind<ForConst, A>, T>.combine(SA: Semigroup<A>, arg1: Kind<Kind<ForConst, A>, T>):
-    Const<A, T> = arrow.core.Const.semigroup<A, T>(SA).run {
-  this@combine.combine(arg1) as arrow.core.Const<A, T>
-}
+fun <A, T> Kind<Kind<ForConst, A>, T>.combine(SA: Semigroup<A>, arg1: Kind<Kind<ForConst, A>, T>): Const<A, T> =
+  arrow.core.Const.semigroup<A, T>(SA).run {
+    this@combine.combine(arg1) as arrow.core.Const<A, T>
+  }
 
 @JvmName("plus")
 @Suppress(
@@ -40,15 +40,15 @@ fun <A, T> Kind<Kind<ForConst, A>, T>.combine(SA: Semigroup<A>, arg1: Kind<Kind<
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "plus(SA, arg1)",
-  "arrow.core.plus"
+    "combine(SA, arg1)",
+    "arrow.core.combine"
   ),
   DeprecationLevel.WARNING
 )
-fun <A, T> Kind<Kind<ForConst, A>, T>.plus(SA: Semigroup<A>, arg1: Kind<Kind<ForConst, A>, T>):
-    Const<A, T> = arrow.core.Const.semigroup<A, T>(SA).run {
-  this@plus.plus(arg1) as arrow.core.Const<A, T>
-}
+fun <A, T> Kind<Kind<ForConst, A>, T>.plus(SA: Semigroup<A>, arg1: Kind<Kind<ForConst, A>, T>): Const<A, T> =
+  arrow.core.Const.semigroup<A, T>(SA).run {
+    this@plus.plus(arg1) as arrow.core.Const<A, T>
+  }
 
 @JvmName("maybeCombine")
 @Suppress(
@@ -60,22 +60,29 @@ fun <A, T> Kind<Kind<ForConst, A>, T>.plus(SA: Semigroup<A>, arg1: Kind<Kind<For
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "maybeCombine(SA, arg1)",
-  "arrow.core.maybeCombine"
+    "Option.fromNullable(arg1).fold({ this }, { combine(it) })",
+    "arrow.core.combine"
   ),
   DeprecationLevel.WARNING
 )
 fun <A, T> Kind<Kind<ForConst, A>, T>.maybeCombine(
   SA: Semigroup<A>,
   arg1: Kind<Kind<ForConst, A>, T>
-): Const<A, T> = arrow.core.Const.semigroup<A, T>(SA).run {
-  this@maybeCombine.maybeCombine(arg1) as arrow.core.Const<A, T>
-}
+): Const<A, T> =
+  arrow.core.Const.semigroup<A, T>(SA).run {
+    this@maybeCombine.maybeCombine(arg1) as arrow.core.Const<A, T>
+  }
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-inline fun <A, T> Companion.semigroup(SA: Semigroup<A>): ConstSemigroup<A, T> = object :
-    arrow.core.extensions.ConstSemigroup<A, T> { override fun SA(): arrow.typeclasses.Semigroup<A> =
-    SA }
+@Deprecated(
+  "Semigroup typeclass is deprecated. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
+)
+inline fun <A, T> Companion.semigroup(SA: Semigroup<A>): ConstSemigroup<A, T> =
+  object : arrow.core.extensions.ConstSemigroup<A, T> {
+    override fun SA(): arrow.typeclasses.Semigroup<A> =
+      SA
+  }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/show/ConstShow.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/show/ConstShow.kt
@@ -9,5 +9,11 @@ import kotlin.Suppress
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-inline fun <A, T> Companion.show(SA: Show<A>): ConstShow<A, T> = object :
-    arrow.core.extensions.ConstShow<A, T> { override fun SA(): arrow.typeclasses.Show<A> = SA }
+@Deprecated(
+  "Show typeclass is deprecated. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
+)
+inline fun <A, T> Companion.show(SA: Show<A>): ConstShow<A, T> =
+  object : arrow.core.extensions.ConstShow<A, T> {
+    override fun SA(): arrow.typeclasses.Show<A> = SA
+  }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/traverse/ConstTraverse.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/traverse/ConstTraverse.kt
@@ -27,21 +27,14 @@ internal val traverse_singleton: ConstTraverse<Any?> = object : ConstTraverse<An
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "traverse(arg1, arg2)",
-  "arrow.core.traverse"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
 fun <X, G, A, B> Kind<Kind<ForConst, X>, A>.traverse(
   arg1: Applicative<G>,
   arg2: Function1<A, Kind<G, B>>
-): Kind<G, Kind<Kind<ForConst, X>, B>> = arrow.core.Const.traverse<X>().run {
-  this@traverse.traverse<G, A, B>(arg1, arg2) as arrow.Kind<G,
-    arrow.Kind<arrow.Kind<arrow.core.ForConst, X>, B>>
-}
+): Kind<G, Kind<Kind<ForConst, X>, B>> =
+  arrow.core.Const.traverse<X>().run {
+    this@traverse.traverse<G, A, B>(arg1, arg2) as arrow.Kind<G, arrow.Kind<arrow.Kind<arrow.core.ForConst, X>, B>>
+  }
 
 @JvmName("sequence")
 @Suppress(
@@ -50,19 +43,11 @@ fun <X, G, A, B> Kind<Kind<ForConst, X>, A>.traverse(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "sequence(arg1)",
-  "arrow.core.sequence"
-  ),
-  DeprecationLevel.WARNING
-)
-fun <X, G, A> Kind<Kind<ForConst, X>, Kind<G, A>>.sequence(arg1: Applicative<G>): Kind<G,
-    Kind<Kind<ForConst, X>, A>> = arrow.core.Const.traverse<X>().run {
-  this@sequence.sequence<G, A>(arg1) as arrow.Kind<G, arrow.Kind<arrow.Kind<arrow.core.ForConst, X>,
-    A>>
-}
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
+fun <X, G, A> Kind<Kind<ForConst, X>, Kind<G, A>>.sequence(arg1: Applicative<G>): Kind<G, Kind<Kind<ForConst, X>, A>> =
+  arrow.core.Const.traverse<X>().run {
+    this@sequence.sequence<G, A>(arg1) as arrow.Kind<G, arrow.Kind<arrow.Kind<arrow.core.ForConst, X>, A>>
+  }
 
 @JvmName("map")
 @Suppress(
@@ -74,15 +59,15 @@ fun <X, G, A> Kind<Kind<ForConst, X>, Kind<G, A>>.sequence(arg1: Applicative<G>)
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg1)",
-  "arrow.core.map"
+    "map(arg1)",
+    "arrow.core.map"
   ),
   DeprecationLevel.WARNING
 )
 fun <X, A, B> Kind<Kind<ForConst, X>, A>.map(arg1: Function1<A, B>): Const<X, B> =
-    arrow.core.Const.traverse<X>().run {
-  this@map.map<A, B>(arg1) as arrow.core.Const<X, B>
-}
+  arrow.core.Const.traverse<X>().run {
+    this@map.map<A, B>(arg1) as arrow.core.Const<X, B>
+  }
 
 @JvmName("flatTraverse")
 @Suppress(
@@ -91,26 +76,23 @@ fun <X, A, B> Kind<Kind<ForConst, X>, A>.map(arg1: Function1<A, B>): Const<X, B>
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "flatTraverse(arg1, arg2, arg3)",
-  "arrow.core.flatTraverse"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
 fun <X, G, A, B> Kind<Kind<ForConst, X>, A>.flatTraverse(
   arg1: Monad<Kind<ForConst, X>>,
   arg2: Applicative<G>,
   arg3: Function1<A, Kind<G, Kind<Kind<ForConst, X>, B>>>
-): Kind<G, Kind<Kind<ForConst, X>, B>> = arrow.core.Const.traverse<X>().run {
-  this@flatTraverse.flatTraverse<G, A, B>(arg1, arg2, arg3) as arrow.Kind<G,
-    arrow.Kind<arrow.Kind<arrow.core.ForConst, X>, B>>
-}
+): Kind<G, Kind<Kind<ForConst, X>, B>> =
+  arrow.core.Const.traverse<X>().run {
+    this@flatTraverse.flatTraverse<G, A, B>(arg1, arg2, arg3) as arrow.Kind<G, arrow.Kind<arrow.Kind<arrow.core.ForConst, X>, B>>
+  }
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated(
+  "Traverse typeclass is deprecated. Use concrete methods on Const",
+  level = DeprecationLevel.WARNING
+)
 inline fun <X> Companion.traverse(): ConstTraverse<X> = traverse_singleton as
-    arrow.core.extensions.ConstTraverse<X>
+  arrow.core.extensions.ConstTraverse<X>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/traverseFilter/ConstTraverseFilter.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/traverseFilter/ConstTraverseFilter.kt
@@ -20,8 +20,8 @@ import kotlin.jvm.JvmName
  * cached extension
  */
 @PublishedApi()
-internal val traverseFilter_singleton: ConstTraverseFilter<Any?> = object :
-    ConstTraverseFilter<Any?> {}
+internal val traverseFilter_singleton: ConstTraverseFilter<Any?> =
+  object : ConstTraverseFilter<Any?> {}
 
 @JvmName("traverseFilter")
 @Suppress(
@@ -30,22 +30,14 @@ internal val traverseFilter_singleton: ConstTraverseFilter<Any?> = object :
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "traverseFilter(arg1, arg2)",
-  "arrow.core.traverseFilter"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
 fun <X, G, A, B> Kind<Kind<ForConst, X>, A>.traverseFilter(
   arg1: Applicative<G>,
   arg2: Function1<A, Kind<G, Option<B>>>
 ): Kind<G, Kind<Kind<ForConst, X>, B>> =
-    arrow.core.Const.traverseFilter<X>().run {
-  this@traverseFilter.traverseFilter<G, A, B>(arg1, arg2) as arrow.Kind<G,
-    arrow.Kind<arrow.Kind<arrow.core.ForConst, X>, B>>
-}
+  arrow.core.Const.traverseFilter<X>().run {
+    this@traverseFilter.traverseFilter<G, A, B>(arg1, arg2) as arrow.Kind<G, arrow.Kind<arrow.Kind<arrow.core.ForConst, X>, B>>
+  }
 
 @JvmName("filterMap")
 @Suppress(
@@ -54,18 +46,11 @@ fun <X, G, A, B> Kind<Kind<ForConst, X>, A>.traverseFilter(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "filterMap(arg1)",
-  "arrow.core.filterMap"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
 fun <X, A, B> Kind<Kind<ForConst, X>, A>.filterMap(arg1: Function1<A, Option<B>>): Const<X, B> =
-    arrow.core.Const.traverseFilter<X>().run {
-  this@filterMap.filterMap<A, B>(arg1) as arrow.core.Const<X, B>
-}
+  arrow.core.Const.traverseFilter<X>().run {
+    this@filterMap.filterMap<A, B>(arg1) as arrow.core.Const<X, B>
+  }
 
 @JvmName("filterA")
 @Suppress(
@@ -74,22 +59,15 @@ fun <X, A, B> Kind<Kind<ForConst, X>, A>.filterMap(arg1: Function1<A, Option<B>>
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "filterA(arg1, arg2)",
-  "arrow.core.filterA"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
 fun <X, G, A> Kind<Kind<ForConst, X>, A>.filterA(
   arg1: Function1<A, Kind<G, Boolean>>,
   arg2: Applicative<G>
 ): Kind<G, Kind<Kind<ForConst, X>, A>> =
-    arrow.core.Const.traverseFilter<X>().run {
-  this@filterA.filterA<G, A>(arg1, arg2) as arrow.Kind<G, arrow.Kind<arrow.Kind<arrow.core.ForConst,
-    X>, A>>
-}
+  arrow.core.Const.traverseFilter<X>().run {
+    this@filterA.filterA<G, A>(arg1, arg2) as arrow.Kind<G, arrow.Kind<arrow.Kind<arrow.core.ForConst,
+      X>, A>>
+  }
 
 @JvmName("filter")
 @Suppress(
@@ -98,18 +76,11 @@ fun <X, G, A> Kind<Kind<ForConst, X>, A>.filterA(
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "filter(arg1)",
-  "arrow.core.filter"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
 fun <X, A> Kind<Kind<ForConst, X>, A>.filter(arg1: Function1<A, Boolean>): Const<X, A> =
-    arrow.core.Const.traverseFilter<X>().run {
-  this@filter.filter<A>(arg1) as arrow.core.Const<X, A>
-}
+  arrow.core.Const.traverseFilter<X>().run {
+    this@filter.filter<A>(arg1) as arrow.core.Const<X, A>
+  }
 
 @JvmName("traverseFilterIsInstance")
 @Suppress(
@@ -118,26 +89,20 @@ fun <X, A> Kind<Kind<ForConst, X>, A>.filter(arg1: Function1<A, Boolean>): Const
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "traverseFilterIsInstance(arg1, arg2)",
-  "arrow.core.traverseFilterIsInstance"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
 fun <X, G, A, B> Kind<Kind<ForConst, X>, A>.traverseFilterIsInstance(
   arg1: Applicative<G>,
   arg2: Class<B>
 ): Kind<G, Kind<Kind<ForConst, X>, B>> =
-    arrow.core.Const.traverseFilter<X>().run {
-  this@traverseFilterIsInstance.traverseFilterIsInstance<G, A, B>(arg1, arg2) as arrow.Kind<G,
-    arrow.Kind<arrow.Kind<arrow.core.ForConst, X>, B>>
-}
+  arrow.core.Const.traverseFilter<X>().run {
+    this@traverseFilterIsInstance.traverseFilterIsInstance<G, A, B>(arg1, arg2) as arrow.Kind<G,
+      arrow.Kind<arrow.Kind<arrow.core.ForConst, X>, B>>
+  }
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated("Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0")
 inline fun <X> Companion.traverseFilter(): ConstTraverseFilter<X> = traverseFilter_singleton as
-    arrow.core.extensions.ConstTraverseFilter<X>
+  arrow.core.extensions.ConstTraverseFilter<X>


### PR DESCRIPTION
Remove extension and higherkind annotations for Const:
- [x] ConstApplicative
- [x] ConstApply
- [x] ConstContravariant
- [x] ConstDivideInstance
- [x] ConstDivisibleInstance
- [x] ConstEq
- [x] ConstEqk
- [x] ConstFoldable
- [x] ConstFunctor
- [x] ConstHash
- [x] ConstInvariant
- [x] ConstMonoid
- [x] ConstOrder
- [x] ConstSemigroup
- [x] ConstShow
- [x] ConstTraverse
- [x] ConstTraverseFilter