### PR TITLE
CU-cn28ya Deprecate @higherkind & @extension for Ior 

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
@@ -631,6 +631,27 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
       { a, b -> Validated.mapN(SA, fa(a), fb(b)) { aa, c -> Both(aa, c) } }
     )
 
+  inline fun <C> crosswalk(fa: (B) -> Iterable<C>): List<Ior<A, C>> =
+    fold(
+      { emptyList() },
+      { b -> fa(b).map { Right(it) } },
+      { a, b -> fa(b).map { Both(a, it) }}
+    )
+
+  inline fun <K, V> crosswalkMap(fa: (B) -> Map<K, V>): Map<K, Ior<A, V>> =
+    fold(
+      { emptyMap() },
+      { b -> fa(b).mapValues { Right(it.value) } },
+      { a, b -> fa(b).mapValues { Both(a, it.value) }}
+    )
+
+  inline fun <A, B, C> crosswalkNull(ior: Ior<A, B>, fa: (B) -> C?): Ior<A, C>? =
+    ior.fold(
+      { a -> Left(a) },
+      { b -> fa(b)?.let { Right(it) } },
+      { a, b -> fa(b)?.let { Both(a, it) }}
+    )
+
   /**
    *  Applies [f] to an [B] inside [Ior] and returns the [Ior] structure with a pair of the [B] value and the
    *  computed [C] value as result of applying [f]

--- a/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
@@ -744,6 +744,9 @@ fun <A, B> Ior<A, B>.eqv(EQA: Eq<A>, EQB: Eq<B>, b: Ior<A, B>): Boolean = when (
   }
 }
 
+fun <A, B> Ior<A, B>.neqv(EQA: Eq<A>, EQB: Eq<B>, b: Ior<A, B>): Boolean =
+  !eqv(EQA, EQB, b)
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun <A, B> Ior<A, Ior<A, B>>.flatten(SA: Semigroup<A>): Ior<A, B> =
   flatMap(SA, ::identity)
@@ -813,6 +816,9 @@ fun <A, B, C> Ior<A, B>.zip(SA: Semigroup<A>, fb: Ior<A, C>): Ior<A, Pair<B, C>>
 fun <A, B, C, Z> Ior<A, B>.zipEval(SA: Semigroup<A>, other: Eval<Ior<A, C>>, f: (B, C) -> Z): Eval<Ior<A, Z>> =
   other.map {zip(SA, it).map { a -> f(a.first, a.second) }}
 
+fun <A, B> Eq.Companion.ior(EQA: Eq<A>, EQB: Eq<B>): Eq<Ior<A, B>> =
+  IorEq(EQA, EQB)
+
 fun <A, B> Hash.Companion.ior(HA: Hash<A>, HB: Hash<B>): Hash<Ior<A, B>> =
   IorHash(HA, HB)
 
@@ -824,6 +830,14 @@ fun <A, B> Semigroup.Companion.ior(SA: Semigroup<A>, SB: Semigroup<B>): Semigrou
 
 fun <A, B> Show.Companion.ior(SA: Show<A>, SB: Show<B>): Show<Ior<A, B>> =
   IorShow(SA, SB)
+
+private class IorEq<A, B>(
+  private val EQA: Eq<A>,
+  private val EQB: Eq<B>
+) : Eq<Ior<A, B>> {
+  override fun Ior<A, B>.eqv(b: Ior<A, B>): Boolean =
+    eqv(EQA, EQB, b)
+}
 
 private class IorHash<A, B>(
   private val HA: Hash<A>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
@@ -20,14 +20,6 @@ inline fun <A, B> IorOf<A, B>.fix(): Ior<A, B> =
 
 typealias IorNel<A, B> = Ior<Nel<A>, B>
 
-class ForIor private constructor() { companion object }
-typealias IorOf<A, B> = arrow.Kind2<ForIor, A, B>
-typealias IorPartialOf<A> = arrow.Kind<ForIor, A>
-
-@Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
-inline fun <A, B> IorOf<A, B>.fix(): Ior<A, B> =
-  this as Ior<A, B>
-
 /**
  * Port of https://github.com/typelevel/cats/blob/v0.9.0/core/src/main/scala/cats/data/Ior.scala
  *

--- a/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
@@ -616,7 +616,7 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
     fb: (B) -> Iterable<D>
   ): List<Ior<C, D>> =
     fold(
-      { a  -> fa(a).map { it.leftIor() } },
+      { a -> fa(a).map { it.leftIor() } },
       { b -> fb(b).map { it.rightIor() } },
       { a, b -> fa(a).align(fb(b)) }
   )

--- a/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
@@ -146,6 +146,134 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
 
     fun <A, B> bothNel(a: A, b: B): IorNel<A, B> = Both(NonEmptyList.of(a), b)
 
+    inline fun <A, B, C, D> mapN(
+      SA: Semigroup<A>,
+      b: Ior<A, B>,
+      c: Ior<A, C>,
+      map: (B, C) -> D
+    ): Ior<A, D> =
+      mapN(SA, b, c, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit) { b, c, _, _, _, _, _, _, _, _ -> map(b, c) }
+
+    inline fun <A, B, C, D, E> mapN(
+      SA: Semigroup<A>,
+      b: Ior<A, B>,
+      c: Ior<A, C>,
+      d: Ior<A, D>,
+      map: (B, C, D) -> E
+    ): Ior<A, E> =
+      mapN(SA, b, c, d, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit) { b, c, d, _, _, _, _, _, _, _ -> map(b, c, d) }
+
+    inline fun <A, B, C, D, E, F> mapN(
+      SA: Semigroup<A>,
+      b: Ior<A, B>,
+      c: Ior<A, C>,
+      d: Ior<A, D>,
+      e: Ior<A, E>,
+      map: (B, C, D, E) -> F
+    ): Ior<A, F> =
+      mapN(SA, b, c, d, e, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit) { b, c, d, e, _, _, _, _, _, _ -> map(b, c, d, e) }
+
+    inline fun <A, B, C, D, E, F, G> mapN(
+      SA: Semigroup<A>,
+      b: Ior<A, B>,
+      c: Ior<A, C>,
+      d: Ior<A, D>,
+      e: Ior<A, E>,
+      f: Ior<A, F>,
+      map: (B, C, D, E, F) -> G
+    ): Ior<A, G> =
+      mapN(SA, b, c, d, e, f, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit) { b, c, d, e, f, _, _, _, _, _ -> map(b, c, d, e, f) }
+
+    inline fun <A, B, C, D, E, F, G, H> mapN(
+      SA: Semigroup<A>,
+      b: Ior<A, B>,
+      c: Ior<A, C>,
+      d: Ior<A, D>,
+      e: Ior<A, E>,
+      f: Ior<A, F>,
+      g: Ior<A, G>,
+      map: (B, C, D, E, F, G) -> H
+    ): Ior<A, H> =
+      mapN(SA, b, c, d, e, f, g, Ior.unit, Ior.unit, Ior.unit, Ior.unit) { b, c, d, e, f, g, _, _, _, _ -> map(b, c, d, e, f, g) }
+
+    inline fun <A, B, C, D, E, F, G, H, I> mapN(
+      SA: Semigroup<A>,
+      b: Ior<A, B>,
+      c: Ior<A, C>,
+      d: Ior<A, D>,
+      e: Ior<A, E>,
+      f: Ior<A, F>,
+      g: Ior<A, G>,
+      h: Ior<A, H>,
+      map: (B, C, D, E, F, G, H) -> I
+    ): Ior<A, I> =
+      mapN(SA, b, c, d, e, f, g, h, Ior.unit, Ior.unit, Ior.unit) { b, c, d, e, f, g, h, _, _, _ -> map(b, c, d, e, f, g, h) }
+
+    inline fun <A, B, C, D, E, F, G, H, I, J> mapN(
+      SA: Semigroup<A>,
+      b: Ior<A, B>,
+      c: Ior<A, C>,
+      d: Ior<A, D>,
+      e: Ior<A, E>,
+      f: Ior<A, F>,
+      g: Ior<A, G>,
+      h: Ior<A, H>,
+      i: Ior<A, I>,
+      map: (B, C, D, E, F, G, H, I) -> J
+    ): Ior<A, J> =
+      mapN(SA, b, c, d, e, f, g, h, i, Ior.unit, Ior.unit) { b, c, d, e, f, g, h, i, _, _ -> map(b, c, d, e, f, g, h, i) }
+
+    inline fun <A, B, C, D, E, F, G, H, I, J, K> mapN(
+      SA: Semigroup<A>,
+      b: Ior<A, B>,
+      c: Ior<A, C>,
+      d: Ior<A, D>,
+      e: Ior<A, E>,
+      f: Ior<A, F>,
+      g: Ior<A, G>,
+      h: Ior<A, H>,
+      i: Ior<A, I>,
+      j: Ior<A, J>,
+      map: (B, C, D, E, F, G, H, I, J) -> K
+    ): Ior<A, K> =
+      mapN(SA, b, c, d, e, f, g, h, i, j, Ior.unit) { b, c, d, e, f, g, h, i, j, _ -> map(b, c, d, e, f, g, h, i, j) }
+
+    inline fun <A, B, C, D, E, F, G, H, I, J, K, L> mapN(
+      SA: Semigroup<A>,
+      b: Ior<A, B>,
+      c: Ior<A, C>,
+      d: Ior<A, D>,
+      e: Ior<A, E>,
+      f: Ior<A, F>,
+      g: Ior<A, G>,
+      h: Ior<A, H>,
+      i: Ior<A, I>,
+      j: Ior<A, J>,
+      k: Ior<A, K>,
+      map: (B, C, D, E, F, G, H, I, J, K) -> L
+    ): Ior<A, L> =
+      b.flatMap(SA) { bb ->
+        c.flatMap(SA) { cc ->
+          d.flatMap(SA) { dd ->
+            e.flatMap(SA) { ee ->
+              f.flatMap(SA) { ff ->
+                g.flatMap(SA) { gg ->
+                  h.flatMap(SA) { hh ->
+                    i.flatMap(SA) { ii ->
+                      j.flatMap(SA) { jj ->
+                        k.map { kk ->
+                          map(bb, cc, dd, ee, ff, gg, hh, ii, jj, kk)
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
     val unit: Ior<Nothing, Unit> = Right(Unit)
 
     fun <L> unit(): Ior<L, Unit> = unit
@@ -487,6 +615,9 @@ inline fun <A, B, D> Ior<A, B>.flatMap(SG: Semigroup<A>, f: (B) -> Ior<A, D>): I
 fun <A, B, D> Ior<A, B>.ap(SG: Semigroup<A>, ff: IorOf<A, (B) -> D>): Ior<A, D> =
   flatMap(SG) { a -> ff.fix().map { f -> f(a) } }
 
+fun <A, B, D> Ior<A, B>.ap(SG: Semigroup<A>, ff: Eval<Ior<A, (B) -> D>>): Eval<Ior<A, D>> =
+  ff.map { ap(SG, it) }
+
 inline fun <A, B> Ior<A, B>.getOrElse(default: () -> B): B =
   fold({ default() }, ::identity, { _, b -> b })
 
@@ -523,8 +654,11 @@ fun <A, B> Ior<A, B>.replicate(SA: Semigroup<A>, n: Int, MB: Monoid<B>): Ior<A, 
     )
   }
 
-fun <E, A, B, Z> Ior<E, A>.zip(SE: Semigroup<E>, fb: Ior<E, B>, f: (A, B) -> Z): Ior<E, Z> =
-  ap(SE, fb.map { b: B -> { a: A -> f(a, b) } })
+fun <A, B, C, Z> Ior<A, B>.zip(SA: Semigroup<A>, fb: Ior<A, C>, f: (B, C) -> Z): Ior<A, Z> =
+  ap(SA, fb.map { c: C -> { b: B -> f(b, c) } })
 
-fun <E, A, B> Ior<E, A>.zip(SE: Semigroup<E>, fb: Ior<E, B>): Ior<E, Pair<A, B>> =
-  zip(SE, fb, ::Pair)
+fun <A, B, C> Ior<A, B>.zip(SA: Semigroup<A>, fb: Ior<A, C>): Ior<A, Pair<B, C>> =
+  zip(SA, fb, ::Pair)
+
+fun <A, B, C, Z> Ior<A, B>.zipEval(SA: Semigroup<A>, other: Eval<Ior<A, C>>, f: (B, C) -> Z): Eval<Ior<A, Z>> =
+  other.map {zip(SA, it).map { a -> f(a.first, a.second) }}

--- a/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
@@ -662,3 +662,14 @@ fun <A, B, C> Ior<A, B>.zip(SA: Semigroup<A>, fb: Ior<A, C>): Ior<A, Pair<B, C>>
 
 fun <A, B, C, Z> Ior<A, B>.zipEval(SA: Semigroup<A>, other: Eval<Ior<A, C>>, f: (B, C) -> Z): Eval<Ior<A, Z>> =
   other.map {zip(SA, it).map { a -> f(a.first, a.second) }}
+
+fun <A, B> Show.Companion.ior(SA: Show<A>, SB: Show<B>): Show<Ior<A, B>> =
+  IorShow(SA, SB)
+
+private class IorShow<A, B>(
+  private val SA: Show<A>,
+  private val SB: Show<B>
+) : Show<Ior<A, B>> {
+  override fun Ior<A, B>.show(): String =
+    show(SA, SB)
+}

--- a/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
@@ -950,27 +950,6 @@ fun <A, B> Ior<A, B>.combine(SA: Semigroup<A>, SB: Semigroup<B>, other: Ior<A, B
     }
   }
 
-fun <A, B> Ior<A, B>.eqv(b: Ior<A, B>): Boolean = when (this) {
-  is Ior.Left -> when (b) {
-    is Ior.Both -> false
-    is Ior.Right -> false
-    is Ior.Left -> value == b.value
-  }
-  is Ior.Both -> when (b) {
-    is Ior.Left -> false
-    is Ior.Both -> leftValue == b.leftValue && rightValue == b.rightValue
-    is Ior.Right -> false
-  }
-  is Ior.Right -> when (b) {
-    is Ior.Left -> false
-    is Ior.Both -> false
-    is Ior.Right -> value == b.value
-  }
-}
-
-fun <A, B> Ior<A, B>.neqv(b: Ior<A, B>): Boolean =
-  !eqv(b)
-
 @Suppress("NOTHING_TO_INLINE")
 inline fun <A, B> Ior<A, Ior<A, B>>.flatten(SA: Semigroup<A>): Ior<A, B> =
   flatMap(SA, ::identity)

--- a/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
@@ -887,7 +887,7 @@ inline fun <A, B, D> Ior<A, B>.flatMap(SG: Semigroup<A>, f: (B) -> Ior<A, D>): I
 fun <A, B, D> Ior<A, B>.ap(SG: Semigroup<A>, ff: IorOf<A, (B) -> D>): Ior<A, D> =
   flatMap(SG) { a -> ff.fix().map { f -> f(a) } }
 
-fun <A, B, D> Ior<A, B>.ap(SG: Semigroup<A>, ff: Eval<Ior<A, (B) -> D>>): Eval<Ior<A, D>> =
+fun <A, B, D> Ior<A, B>.apEval(SG: Semigroup<A>, ff: Eval<Ior<A, (B) -> D>>): Eval<Ior<A, D>> =
   ff.map { ap(SG, it) }
 
 inline fun <A, B> Ior<A, B>.getOrElse(default: () -> B): B =

--- a/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
@@ -4,6 +4,7 @@ import arrow.Kind
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Semigroup
+import arrow.typeclasses.Show
 
 @Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
 class ForIor private constructor() { companion object }
@@ -631,6 +632,23 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
 
     override fun toString(): String = "Both(${ leftValue.toString() }, ${ rightValue.toString() })"
   }
+
+  @Deprecated(
+    "Show typeclass is deprecated, and will be removed in 0.13.0. Please use the toString method instead.",
+    ReplaceWith(
+      "toString()"
+    ),
+    DeprecationLevel.WARNING
+  )
+  fun show(SL: Show<A>, SR: Show<B>): String = fold(
+    {
+      "Left(${SL.run { it.show() }})"
+    },
+    {
+      "Right(${SR.run { it.show() }})"
+    },
+    { a, b -> "Both(${SL.run { a.show() }}, ${SR.run { b.show() }})" }
+  )
 
   inline fun <C, D> bicrosswalk(
     fa: (A) -> Iterable<C>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
@@ -177,7 +177,7 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
       SA: Semigroup<A>,
       b: Ior<A, B>,
       c: Ior<A, C>,
-      map: (B, C) -> D
+      crossinline map: (B, C) -> D
     ): Ior<A, D> =
       mapN(SA, b, c, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit) { b, c, _, _, _, _, _, _, _, _ -> map(b, c) }
 
@@ -186,7 +186,7 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
       b: Ior<A, B>,
       c: Ior<A, C>,
       d: Ior<A, D>,
-      map: (B, C, D) -> E
+      crossinline map: (B, C, D) -> E
     ): Ior<A, E> =
       mapN(SA, b, c, d, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit) { b, c, d, _, _, _, _, _, _, _ -> map(b, c, d) }
 
@@ -196,7 +196,7 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
       c: Ior<A, C>,
       d: Ior<A, D>,
       e: Ior<A, E>,
-      map: (B, C, D, E) -> F
+      crossinline map: (B, C, D, E) -> F
     ): Ior<A, F> =
       mapN(SA, b, c, d, e, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit) { b, c, d, e, _, _, _, _, _, _ -> map(b, c, d, e) }
 
@@ -207,7 +207,7 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
       d: Ior<A, D>,
       e: Ior<A, E>,
       f: Ior<A, F>,
-      map: (B, C, D, E, F) -> G
+      crossinline map: (B, C, D, E, F) -> G
     ): Ior<A, G> =
       mapN(SA, b, c, d, e, f, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit) { b, c, d, e, f, _, _, _, _, _ -> map(b, c, d, e, f) }
 
@@ -219,7 +219,7 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
       e: Ior<A, E>,
       f: Ior<A, F>,
       g: Ior<A, G>,
-      map: (B, C, D, E, F, G) -> H
+      crossinline map: (B, C, D, E, F, G) -> H
     ): Ior<A, H> =
       mapN(SA, b, c, d, e, f, g, Ior.unit, Ior.unit, Ior.unit, Ior.unit) { b, c, d, e, f, g, _, _, _, _ -> map(b, c, d, e, f, g) }
 
@@ -232,7 +232,7 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
       f: Ior<A, F>,
       g: Ior<A, G>,
       h: Ior<A, H>,
-      map: (B, C, D, E, F, G, H) -> I
+      crossinline map: (B, C, D, E, F, G, H) -> I
     ): Ior<A, I> =
       mapN(SA, b, c, d, e, f, g, h, Ior.unit, Ior.unit, Ior.unit) { b, c, d, e, f, g, h, _, _, _ -> map(b, c, d, e, f, g, h) }
 
@@ -246,7 +246,7 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
       g: Ior<A, G>,
       h: Ior<A, H>,
       i: Ior<A, I>,
-      map: (B, C, D, E, F, G, H, I) -> J
+      crossinline map: (B, C, D, E, F, G, H, I) -> J
     ): Ior<A, J> =
       mapN(SA, b, c, d, e, f, g, h, i, Ior.unit, Ior.unit) { b, c, d, e, f, g, h, i, _, _ -> map(b, c, d, e, f, g, h, i) }
 
@@ -261,7 +261,7 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
       h: Ior<A, H>,
       i: Ior<A, I>,
       j: Ior<A, J>,
-      map: (B, C, D, E, F, G, H, I, J) -> K
+      crossinline map: (B, C, D, E, F, G, H, I, J) -> K
     ): Ior<A, K> =
       mapN(SA, b, c, d, e, f, g, h, i, j, Ior.unit) { b, c, d, e, f, g, h, i, j, _ -> map(b, c, d, e, f, g, h, i, j) }
 
@@ -277,29 +277,29 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
       i: Ior<A, I>,
       j: Ior<A, J>,
       k: Ior<A, K>,
-      map: (B, C, D, E, F, G, H, I, J, K) -> L
-    ): Ior<A, L> = TODO()
-//      b.flatMap(SA) { bb ->
-//        c.flatMap(SA) { cc ->
-//          d.flatMap(SA) { dd ->
-//            e.flatMap(SA) { ee ->
-//              f.flatMap(SA) { ff ->
-//                g.flatMap(SA) { gg ->
-//                  h.flatMap(SA) { hh ->
-//                    i.flatMap(SA) { ii ->
-//                      j.flatMap(SA) { jj ->
-//                        k.map { kk ->
-//                          map(bb, cc, dd, ee, ff, gg, hh, ii, jj, kk)
-//                        }
-//                      }
-//                    }
-//                  }
-//                }
-//              }
-//            }
-//          }
-//        }
-//      }
+      crossinline map: (B, C, D, E, F, G, H, I, J, K) -> L
+    ): Ior<A, L> =
+      b.flatMap1(SA) { bb ->
+        c.flatMap1(SA) { cc ->
+          d.flatMap1(SA) { dd ->
+            e.flatMap1(SA) { ee ->
+              f.flatMap1(SA) { ff ->
+                g.flatMap1(SA) { gg ->
+                  h.flatMap1(SA) { hh ->
+                    i.flatMap1(SA) { ii ->
+                      j.flatMap1(SA) { jj ->
+                        k.map { kk ->
+                          map(bb, cc, dd, ee, ff, gg, hh, ii, jj, kk)
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
 
     val unit: Ior<Nothing, Unit> = Right(Unit)
 
@@ -854,6 +854,10 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
   fun void(): Ior<A, Unit> =
     mapConst(Unit)
 }
+
+@PublishedApi()
+internal fun <A, B, D> Ior<A, B>.flatMap1(SG: Semigroup<A>, f: (B) -> Ior<A, D>): Ior<A, D> =
+  flatMap(SG, f)
 
 /**
  * Binds the given function across [Ior.Right].

--- a/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
@@ -346,6 +346,10 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
   inline fun <C> bifoldRight(c: Eval<C>, f: (A, Eval<C>) -> Eval<C>, g: (B, Eval<C>) -> Eval<C>): Eval<C> =
     fold({ f(it, c) }, { g(it, c) }, { a, b -> f(a, g(b, c)) })
 
+  inline fun <C> bifoldMap(MN: Monoid<C>, f: (A) -> C, g: (B) -> C): C = MN.run {
+    bifoldLeft(MN.empty(), { c, a -> c.combine(f(a)) }, { c, b -> c.combine(g(b)) })
+  }
+
   /**
    * The given function is applied if this is a [Right] or [Both] to `B`.
    *

--- a/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
@@ -172,7 +172,7 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
       SA: Semigroup<A>,
       b: Ior<A, B>,
       c: Ior<A, C>,
-      crossinline map: (B, C) -> D
+      map: (B, C) -> D
     ): Ior<A, D> =
       mapN(SA, b, c, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit) { b, c, _, _, _, _, _, _, _, _ -> map(b, c) }
 
@@ -181,7 +181,7 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
       b: Ior<A, B>,
       c: Ior<A, C>,
       d: Ior<A, D>,
-      crossinline map: (B, C, D) -> E
+      map: (B, C, D) -> E
     ): Ior<A, E> =
       mapN(SA, b, c, d, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit) { b, c, d, _, _, _, _, _, _, _ -> map(b, c, d) }
 
@@ -191,7 +191,7 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
       c: Ior<A, C>,
       d: Ior<A, D>,
       e: Ior<A, E>,
-      crossinline map: (B, C, D, E) -> F
+      map: (B, C, D, E) -> F
     ): Ior<A, F> =
       mapN(SA, b, c, d, e, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit) { b, c, d, e, _, _, _, _, _, _ -> map(b, c, d, e) }
 
@@ -202,7 +202,7 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
       d: Ior<A, D>,
       e: Ior<A, E>,
       f: Ior<A, F>,
-      crossinline map: (B, C, D, E, F) -> G
+      map: (B, C, D, E, F) -> G
     ): Ior<A, G> =
       mapN(SA, b, c, d, e, f, Ior.unit, Ior.unit, Ior.unit, Ior.unit, Ior.unit) { b, c, d, e, f, _, _, _, _, _ -> map(b, c, d, e, f) }
 
@@ -214,7 +214,7 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
       e: Ior<A, E>,
       f: Ior<A, F>,
       g: Ior<A, G>,
-      crossinline map: (B, C, D, E, F, G) -> H
+      map: (B, C, D, E, F, G) -> H
     ): Ior<A, H> =
       mapN(SA, b, c, d, e, f, g, Ior.unit, Ior.unit, Ior.unit, Ior.unit) { b, c, d, e, f, g, _, _, _, _ -> map(b, c, d, e, f, g) }
 
@@ -227,7 +227,7 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
       f: Ior<A, F>,
       g: Ior<A, G>,
       h: Ior<A, H>,
-      crossinline map: (B, C, D, E, F, G, H) -> I
+      map: (B, C, D, E, F, G, H) -> I
     ): Ior<A, I> =
       mapN(SA, b, c, d, e, f, g, h, Ior.unit, Ior.unit, Ior.unit) { b, c, d, e, f, g, h, _, _, _ -> map(b, c, d, e, f, g, h) }
 
@@ -241,7 +241,7 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
       g: Ior<A, G>,
       h: Ior<A, H>,
       i: Ior<A, I>,
-      crossinline map: (B, C, D, E, F, G, H, I) -> J
+      map: (B, C, D, E, F, G, H, I) -> J
     ): Ior<A, J> =
       mapN(SA, b, c, d, e, f, g, h, i, Ior.unit, Ior.unit) { b, c, d, e, f, g, h, i, _, _ -> map(b, c, d, e, f, g, h, i) }
 
@@ -256,7 +256,7 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
       h: Ior<A, H>,
       i: Ior<A, I>,
       j: Ior<A, J>,
-      crossinline map: (B, C, D, E, F, G, H, I, J) -> K
+      map: (B, C, D, E, F, G, H, I, J) -> K
     ): Ior<A, K> =
       mapN(SA, b, c, d, e, f, g, h, i, j, Ior.unit) { b, c, d, e, f, g, h, i, j, _ -> map(b, c, d, e, f, g, h, i, j) }
 
@@ -272,28 +272,42 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
       i: Ior<A, I>,
       j: Ior<A, J>,
       k: Ior<A, K>,
-      crossinline map: (B, C, D, E, F, G, H, I, J, K) -> L
+      map: (B, C, D, E, F, G, H, I, J, K) -> L
     ): Ior<A, L> =
-      b.flatMap1(SA) { bb ->
-        c.flatMap1(SA) { cc ->
-          d.flatMap1(SA) { dd ->
-            e.flatMap1(SA) { ee ->
-              f.flatMap1(SA) { ff ->
-                g.flatMap1(SA) { gg ->
-                  h.flatMap1(SA) { hh ->
-                    i.flatMap1(SA) { ii ->
-                      j.flatMap1(SA) { jj ->
-                        k.map { kk ->
-                          map(bb, cc, dd, ee, ff, gg, hh, ii, jj, kk)
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
+      if (b is Right && c is Right && d is Right && e is Right && f is Right && g is Right && h is Right && i is Right && j is Right && k is Right) {
+        Right(map(b.value, c.value, d.value, e.value, f.value, g.value, h.value, i.value, j.value, k.value))
+      } else if (b is Both && c is Both && d is Both && e is Both && f is Both && g is Both && h is Both && i is Both && j is Both && k is Both) {
+        SA.run {
+          Both(
+            b.leftValue.combine(c.leftValue).combine(d.leftValue).combine(e.leftValue).combine(f.leftValue)
+              .combine(g.leftValue).combine(h.leftValue).combine(i.leftValue).combine(j.leftValue).combine(k.leftValue),
+            map(
+              b.rightValue,
+              c.rightValue,
+              d.rightValue,
+              e.rightValue,
+              f.rightValue,
+              g.rightValue,
+              h.rightValue,
+              i.rightValue,
+              j.rightValue,
+              k.rightValue
+            )
+          )
         }
+      } else SA.run {
+        var accumulatedLeft: A? = null
+        accumulatedLeft = if (b is Left) b.value.maybeCombine(accumulatedLeft) else accumulatedLeft
+        accumulatedLeft = if (c is Left) c.value.maybeCombine(accumulatedLeft) else accumulatedLeft
+        accumulatedLeft = if (d is Left) d.value.maybeCombine(accumulatedLeft) else accumulatedLeft
+        accumulatedLeft = if (e is Left) e.value.maybeCombine(accumulatedLeft) else accumulatedLeft
+        accumulatedLeft = if (f is Left) f.value.maybeCombine(accumulatedLeft) else accumulatedLeft
+        accumulatedLeft = if (g is Left) g.value.maybeCombine(accumulatedLeft) else accumulatedLeft
+        accumulatedLeft = if (h is Left) h.value.maybeCombine(accumulatedLeft) else accumulatedLeft
+        accumulatedLeft = if (i is Left) i.value.maybeCombine(accumulatedLeft) else accumulatedLeft
+        accumulatedLeft = if (j is Left) j.value.maybeCombine(accumulatedLeft) else accumulatedLeft
+        accumulatedLeft = if (j is Left) j.value.maybeCombine(accumulatedLeft) else accumulatedLeft
+        Left(accumulatedLeft!!)
       }
 
     val unit: Ior<Nothing, Unit> = Right(Unit)
@@ -828,10 +842,6 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
     mapConst(Unit)
 }
 
-@PublishedApi()
-internal fun <A, B, D> Ior<A, B>.flatMap1(SG: Semigroup<A>, f: (B) -> Ior<A, D>): Ior<A, D> =
-  flatMap(SG, f)
-
 /**
  * Binds the given function across [Ior.Right].
  *
@@ -936,7 +946,7 @@ fun <A, B> Ior<A, B>.eqv(b: Ior<A, B>): Boolean = when (this) {
   is Ior.Right -> when (b) {
     is Ior.Left -> false
     is Ior.Both -> false
-    is Ior.Right -> value ==  b.value
+    is Ior.Right -> value == b.value
   }
 }
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
@@ -1,10 +1,21 @@
 package arrow.core
 
 import arrow.Kind
-import arrow.higherkind
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
+
+@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
+class ForIor private constructor() { companion object }
+@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
+typealias IorOf<A, B> = arrow.Kind2<ForIor, A, B>
+@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
+typealias IorPartialOf<A> = arrow.Kind<ForIor, A>
+
+@Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
+@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
+inline fun <A, B> IorOf<A, B>.fix(): Ior<A, B> =
+  this as Ior<A, B>
 
 typealias IorNel<A, B> = Ior<Nel<A>, B>
 
@@ -27,7 +38,6 @@ typealias IorNel<A, B> = Ior<Nel<A>, B>
  * values, regardless of whether the `B` values appear in a [Ior.Right] or a [Ior.Both].
  * The isomorphic Either form can be accessed via the [unwrap] method.
  */
-@higherkind
 sealed class Ior<out A, out B> : IorOf<A, B> {
 
   /**

--- a/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
@@ -945,36 +945,6 @@ fun <A, B> Ior<A, B>.combine(SA: Semigroup<A>, SB: Semigroup<B>, other: Ior<A, B
     }
   }
 
-fun <A, B> Ior<A, B>.compare(OA: Order<A>, OB: Order<B>, b: Ior<A, B>): Ordering = fold(
-  { a1 -> b.fold({ a2 -> OA.run { a1.compare(a2) } }, { LT }, { _, _ -> LT }) },
-  { b1 -> b.fold({ GT }, { b2 -> OB.run { b1.compare(b2) } }, { _, _ -> LT }) },
-  { a1, b1 -> b.fold({ GT }, { GT }, { a2, b2 -> OA.run { a1.compare(a2) } + OB.run { b1.compare(b2) } }) }
-)
-
-fun <A, B> Ior<A, B>.compareTo(OA: Order<A>, OB: Order<B>, b: Ior<A, B>): Int =
-  compare(OA, OB, b).toInt()
-
-fun <A, B> Ior<A, B>.lt(OA: Order<A>, OB: Order<B>, b: Ior<A, B>): Boolean =
-  compare(OA, OB, b) == LT
-
-fun <A, B> Ior<A, B>.lte(OA: Order<A>, OB: Order<B>, b: Ior<A, B>): Boolean =
-  compare(OA, OB, b) != GT
-
-fun <A, B> Ior<A, B>.gt(OA: Order<A>, OB: Order<B>, b: Ior<A, B>): Boolean =
-  compare(OA, OB, b) == GT
-
-fun <A, B> Ior<A, B>.gte(OA: Order<A>, OB: Order<B>, b: Ior<A, B>): Boolean =
-  compare(OA, OB, b) != LT
-
-fun <A, B> Ior<A, B>.max(OA: Order<A>, OB: Order<B>, b: Ior<A, B>): Ior<A, B> =
-  if (gt(OA, OB, b)) this else b
-
-fun <A, B> Ior<A, B>.min(OA: Order<A>, OB: Order<B>, b: Ior<A, B>): Ior<A, B> =
-  if (lt(OA, OB, b)) this else b
-
-fun <A, B> Ior<A, B>.sort(OA: Order<A>, OB: Order<B>, b: Ior<A, B>): Pair<Ior<A, B>, Ior<A, B>> =
-  if (gte(OA, OB, b)) this to b else b to this
-
 fun <A, B> Ior<A, B>.eqv(EQA: Eq<A>, EQB: Eq<B>, b: Ior<A, B>): Boolean = when (this) {
   is Ior.Left -> when (b) {
     is Ior.Both -> false
@@ -1087,47 +1057,8 @@ fun <A, B, C> Ior<A, B>.zip(SA: Semigroup<A>, fb: Ior<A, C>): Ior<A, Pair<B, C>>
 fun <A, B, C, Z> Ior<A, B>.zipEval(SA: Semigroup<A>, other: Eval<Ior<A, C>>, f: (B, C) -> Z): Eval<Ior<A, Z>> =
   other.map {zip(SA, it).map { a -> f(a.first, a.second) }}
 
-fun <A, B> Eq.Companion.ior(EQA: Eq<A>, EQB: Eq<B>): Eq<Ior<A, B>> =
-  IorEq(EQA, EQB)
-
-fun <A, B> Hash.Companion.ior(HA: Hash<A>, HB: Hash<B>): Hash<Ior<A, B>> =
-  IorHash(HA, HB)
-
-fun <A, B> Order.Companion.ior(OA: Order<A>, OB: Order<B>): Order<Ior<A, B>> =
-  IorOrder(OA, OB)
-
 fun <A, B> Semigroup.Companion.ior(SA: Semigroup<A>, SB: Semigroup<B>): Semigroup<Ior<A, B>> =
   IorSemigroup(SA, SB)
-
-fun <A, B> Show.Companion.ior(SA: Show<A>, SB: Show<B>): Show<Ior<A, B>> =
-  IorShow(SA, SB)
-
-private class IorEq<A, B>(
-  private val EQA: Eq<A>,
-  private val EQB: Eq<B>
-) : Eq<Ior<A, B>> {
-  override fun Ior<A, B>.eqv(b: Ior<A, B>): Boolean =
-    eqv(EQA, EQB, b)
-}
-
-private class IorHash<A, B>(
-  private val HA: Hash<A>,
-  private val HB: Hash<B>
-) : Hash<Ior<A, B>> {
-  override fun Ior<A, B>.hash(): Int =
-    hash(HA, HB)
-
-  override fun Ior<A, B>.hashWithSalt(salt: Int): Int =
-    hashWithSalt(HA, HB, salt)
-}
-
-private class IorOrder<A, B>(
-  private val OA: Order<A>,
-  private val OB: Order<B>
-) : Order<Ior<A, B>> {
-  override fun Ior<A, B>.compare(b: Ior<A, B>): Ordering =
-    compare(OA, OB, b)
-}
 
 private class IorSemigroup<A, B>(
   private val SGA: Semigroup<A>,
@@ -1139,12 +1070,4 @@ private class IorSemigroup<A, B>(
 
   override fun Ior<A, B>.maybeCombine(b: Ior<A, B>?): Ior<A, B> =
     b?.let { combine(SGA, SGB, it) } ?: this
-}
-
-private class IorShow<A, B>(
-  private val SA: Show<A>,
-  private val SB: Show<B>
-) : Show<Ior<A, B>> {
-  override fun Ior<A, B>.show(): String =
-    show(SA, SB)
 }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior.kt
@@ -226,7 +226,15 @@ interface IorEqK2 : EqK2<ForIor> {
 interface IorShow<L, R> : Show<Ior<L, R>> {
   fun SL(): Show<L>
   fun SR(): Show<R>
-  override fun Ior<L, R>.show(): String = show(SL(), SR())
+  override fun Ior<L, R>.show(): String = fold(
+    {
+      "Left(${SL().run { it.show() }})"
+    },
+    {
+      "Right(${SR().run { it.show() }})"
+    },
+    { a, b -> "Both(${SL().run { a.show() }}, ${SR().run { b.show() }})" }
+  )
 }
 
 @extension

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior.kt
@@ -18,7 +18,6 @@ import arrow.core.fix
 import arrow.core.flatMap
 import arrow.core.leftIor
 import arrow.core.rightIor
-import arrow.extension
 import arrow.typeclasses.Align
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Apply
@@ -42,7 +41,6 @@ import arrow.typeclasses.Traverse
 import arrow.typeclasses.hashWithSalt
 import arrow.undocumented
 
-@extension
 interface IorSemigroup<L, R> : Semigroup<Ior<L, R>> {
 
   fun SGL(): Semigroup<L>
@@ -72,19 +70,16 @@ interface IorSemigroup<L, R> : Semigroup<Ior<L, R>> {
     }
 }
 
-@extension
 @undocumented
 interface IorFunctor<L> : Functor<IorPartialOf<L>> {
   override fun <A, B> Kind<IorPartialOf<L>, A>.map(f: (A) -> B): Ior<L, B> = fix().map(f)
 }
 
-@extension
 interface IorBifunctor : Bifunctor<ForIor> {
   override fun <A, B, C, D> Kind2<ForIor, A, B>.bimap(fl: (A) -> C, fr: (B) -> D): Kind2<ForIor, C, D> =
     fix().bimap(fl, fr)
 }
 
-@extension
 interface IorApply<L> : Apply<IorPartialOf<L>>, IorFunctor<L> {
 
   fun SL(): Semigroup<L>
@@ -110,7 +105,6 @@ interface IorApply<L> : Apply<IorPartialOf<L>>, IorFunctor<L> {
     })
 }
 
-@extension
 interface IorApplicative<L> : Applicative<IorPartialOf<L>>, IorApply<L> {
 
   override fun SL(): Semigroup<L>
@@ -123,7 +117,6 @@ interface IorApplicative<L> : Applicative<IorPartialOf<L>>, IorApply<L> {
     fix().ap(SL(), ff)
 }
 
-@extension
 interface IorMonad<L> : Monad<IorPartialOf<L>>, IorApplicative<L> {
 
   override fun SL(): Semigroup<L>
@@ -140,7 +133,6 @@ interface IorMonad<L> : Monad<IorPartialOf<L>>, IorApplicative<L> {
     Ior.tailRecM(a, f, SL())
 }
 
-@extension
 interface IorFoldable<L> : Foldable<IorPartialOf<L>> {
 
   override fun <B, C> Kind<IorPartialOf<L>, B>.foldLeft(b: C, f: (C, B) -> C): C = fix().foldLeft(b, f)
@@ -149,14 +141,12 @@ interface IorFoldable<L> : Foldable<IorPartialOf<L>> {
     fix().foldRight(lb, f)
 }
 
-@extension
 interface IorTraverse<L> : Traverse<IorPartialOf<L>>, IorFoldable<L> {
 
   override fun <G, B, C> IorOf<L, B>.traverse(AP: Applicative<G>, f: (B) -> Kind<G, C>): Kind<G, Ior<L, C>> =
     fix().traverse(AP, f)
 }
 
-@extension
 interface IorBifoldable : Bifoldable<ForIor> {
   override fun <A, B, C> IorOf<A, B>.bifoldLeft(c: C, f: (C, A) -> C, g: (C, B) -> C): C =
     fix().bifoldLeft(c, f, g)
@@ -165,7 +155,6 @@ interface IorBifoldable : Bifoldable<ForIor> {
     fix().bifoldRight(c, f, g)
 }
 
-@extension
 interface IorBitraverse : Bitraverse<ForIor>, IorBifoldable {
   override fun <G, A, B, C, D> IorOf<A, B>.bitraverse(AP: Applicative<G>, f: (A) -> Kind<G, C>, g: (B) -> Kind<G, D>): Kind<G, IorOf<C, D>> =
     fix().let {
@@ -176,7 +165,6 @@ interface IorBitraverse : Bitraverse<ForIor>, IorBifoldable {
     }
 }
 
-@extension
 interface IorEq<L, R> : Eq<Ior<L, R>> {
 
   fun EQL(): Eq<L>
@@ -202,7 +190,6 @@ interface IorEq<L, R> : Eq<Ior<L, R>> {
   }
 }
 
-@extension
 interface IorEqK<A> : EqK<IorPartialOf<A>> {
   fun EQA(): Eq<A>
 
@@ -212,7 +199,6 @@ interface IorEqK<A> : EqK<IorPartialOf<A>> {
     }
 }
 
-@extension
 interface IorEqK2 : EqK2<ForIor> {
   override fun <A, B> Kind2<ForIor, A, B>.eqK(other: Kind2<ForIor, A, B>, EQA: Eq<A>, EQB: Eq<B>): Boolean =
     (this.fix() to other.fix()).let {
@@ -222,14 +208,12 @@ interface IorEqK2 : EqK2<ForIor> {
     }
 }
 
-@extension
 interface IorShow<L, R> : Show<Ior<L, R>> {
   fun SL(): Show<L>
   fun SR(): Show<R>
   override fun Ior<L, R>.show(): String = show(SL(), SR())
 }
 
-@extension
 interface IorHash<L, R> : Hash<Ior<L, R>> {
 
   fun HL(): Hash<L>
@@ -242,7 +226,6 @@ interface IorHash<L, R> : Hash<Ior<L, R>> {
   }
 }
 
-@extension
 interface IorOrder<L, R> : Order<Ior<L, R>> {
   fun OL(): Order<L>
   fun OR(): Order<R>
@@ -258,7 +241,6 @@ interface IorOrder<L, R> : Order<Ior<L, R>> {
 fun <L, R> Ior.Companion.fx(SL: Semigroup<L>, c: suspend MonadSyntax<IorPartialOf<L>>.() -> R): Ior<L, R> =
   Ior.monad(SL).fx.monad(c).fix()
 
-@extension
 interface IorCrosswalk<L> : Crosswalk<IorPartialOf<L>>, IorFunctor<L>, IorFoldable<L> {
   override fun <F, A, B> crosswalk(ALIGN: Align<F>, a: Kind<IorPartialOf<L>, A>, fa: (A) -> Kind<F, B>): Kind<F, Kind<IorPartialOf<L>, B>> {
     return when (val ior = a.fix()) {
@@ -269,7 +251,6 @@ interface IorCrosswalk<L> : Crosswalk<IorPartialOf<L>>, IorFunctor<L>, IorFoldab
   }
 }
 
-@extension
 interface IorBicrosswalk : Bicrosswalk<ForIor>, IorBifunctor, IorBifoldable {
   override fun <F, A, B, C, D> bicrosswalk(
     ALIGN: Align<F>,

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior.kt
@@ -226,15 +226,7 @@ interface IorEqK2 : EqK2<ForIor> {
 interface IorShow<L, R> : Show<Ior<L, R>> {
   fun SL(): Show<L>
   fun SR(): Show<R>
-  override fun Ior<L, R>.show(): String = fold(
-    {
-      "Left(${SL().run { it.show() }})"
-    },
-    {
-      "Right(${SR().run { it.show() }})"
-    },
-    { a, b -> "Both(${SL().run { a.show() }}, ${SR().run { b.show() }})" }
-  )
+  override fun Ior<L, R>.show(): String = show(SL(), SR())
 }
 
 @extension

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior.kt
@@ -39,8 +39,12 @@ import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
 import arrow.typeclasses.Traverse
 import arrow.typeclasses.hashWithSalt
-import arrow.undocumented
 
+@Deprecated(
+  "Typeclass instance have been moved to the companion object of the typeclass.",
+  ReplaceWith("Semigroup.ior()", "arrow.core.ior", "arrow.typeclasses.Semigroup"),
+  DeprecationLevel.WARNING
+)
 interface IorSemigroup<L, R> : Semigroup<Ior<L, R>> {
 
   fun SGL(): Semigroup<L>
@@ -70,16 +74,27 @@ interface IorSemigroup<L, R> : Semigroup<Ior<L, R>> {
     }
 }
 
-@undocumented
+@Deprecated(
+  message = "Functor typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
+)
 interface IorFunctor<L> : Functor<IorPartialOf<L>> {
   override fun <A, B> Kind<IorPartialOf<L>, A>.map(f: (A) -> B): Ior<L, B> = fix().map(f)
 }
 
+@Deprecated(
+  message = "Bifunctor typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
+)
 interface IorBifunctor : Bifunctor<ForIor> {
   override fun <A, B, C, D> Kind2<ForIor, A, B>.bimap(fl: (A) -> C, fr: (B) -> D): Kind2<ForIor, C, D> =
     fix().bimap(fl, fr)
 }
 
+@Deprecated(
+  message = "Apply typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
+)
 interface IorApply<L> : Apply<IorPartialOf<L>>, IorFunctor<L> {
 
   fun SL(): Semigroup<L>
@@ -105,6 +120,10 @@ interface IorApply<L> : Apply<IorPartialOf<L>>, IorFunctor<L> {
     })
 }
 
+@Deprecated(
+  message = "Applicative typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
+)
 interface IorApplicative<L> : Applicative<IorPartialOf<L>>, IorApply<L> {
 
   override fun SL(): Semigroup<L>
@@ -117,6 +136,10 @@ interface IorApplicative<L> : Applicative<IorPartialOf<L>>, IorApply<L> {
     fix().ap(SL(), ff)
 }
 
+@Deprecated(
+  message = "Monad typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
+)
 interface IorMonad<L> : Monad<IorPartialOf<L>>, IorApplicative<L> {
 
   override fun SL(): Semigroup<L>
@@ -133,6 +156,10 @@ interface IorMonad<L> : Monad<IorPartialOf<L>>, IorApplicative<L> {
     Ior.tailRecM(a, f, SL())
 }
 
+@Deprecated(
+  message = "Foldable typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
+)
 interface IorFoldable<L> : Foldable<IorPartialOf<L>> {
 
   override fun <B, C> Kind<IorPartialOf<L>, B>.foldLeft(b: C, f: (C, B) -> C): C = fix().foldLeft(b, f)
@@ -141,12 +168,20 @@ interface IorFoldable<L> : Foldable<IorPartialOf<L>> {
     fix().foldRight(lb, f)
 }
 
+@Deprecated(
+  message = "Traverse typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
+)
 interface IorTraverse<L> : Traverse<IorPartialOf<L>>, IorFoldable<L> {
 
   override fun <G, B, C> IorOf<L, B>.traverse(AP: Applicative<G>, f: (B) -> Kind<G, C>): Kind<G, Ior<L, C>> =
     fix().traverse(AP, f)
 }
 
+@Deprecated(
+  message = "Bifoldable typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
+)
 interface IorBifoldable : Bifoldable<ForIor> {
   override fun <A, B, C> IorOf<A, B>.bifoldLeft(c: C, f: (C, A) -> C, g: (C, B) -> C): C =
     fix().bifoldLeft(c, f, g)
@@ -155,6 +190,10 @@ interface IorBifoldable : Bifoldable<ForIor> {
     fix().bifoldRight(c, f, g)
 }
 
+@Deprecated(
+  message = "Bitraverse typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
+)
 interface IorBitraverse : Bitraverse<ForIor>, IorBifoldable {
   override fun <G, A, B, C, D> IorOf<A, B>.bitraverse(AP: Applicative<G>, f: (A) -> Kind<G, C>, g: (B) -> Kind<G, D>): Kind<G, IorOf<C, D>> =
     fix().let {
@@ -165,6 +204,10 @@ interface IorBitraverse : Bitraverse<ForIor>, IorBifoldable {
     }
 }
 
+@Deprecated(
+  message = "Eq typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
+)
 interface IorEq<L, R> : Eq<Ior<L, R>> {
 
   fun EQL(): Eq<L>
@@ -190,6 +233,10 @@ interface IorEq<L, R> : Eq<Ior<L, R>> {
   }
 }
 
+@Deprecated(
+  message = "EqK typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
+)
 interface IorEqK<A> : EqK<IorPartialOf<A>> {
   fun EQA(): Eq<A>
 
@@ -199,6 +246,10 @@ interface IorEqK<A> : EqK<IorPartialOf<A>> {
     }
 }
 
+@Deprecated(
+  message = "EqK2 typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
+)
 interface IorEqK2 : EqK2<ForIor> {
   override fun <A, B> Kind2<ForIor, A, B>.eqK(other: Kind2<ForIor, A, B>, EQA: Eq<A>, EQB: Eq<B>): Boolean =
     (this.fix() to other.fix()).let {
@@ -208,12 +259,20 @@ interface IorEqK2 : EqK2<ForIor> {
     }
 }
 
+@Deprecated(
+  message = "Show typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
+)
 interface IorShow<L, R> : Show<Ior<L, R>> {
   fun SL(): Show<L>
   fun SR(): Show<R>
   override fun Ior<L, R>.show(): String = show(SL(), SR())
 }
 
+@Deprecated(
+  message = "Hash typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
+)
 interface IorHash<L, R> : Hash<Ior<L, R>> {
 
   fun HL(): Hash<L>
@@ -226,6 +285,10 @@ interface IorHash<L, R> : Hash<Ior<L, R>> {
   }
 }
 
+@Deprecated(
+  message = "Order typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
+)
 interface IorOrder<L, R> : Order<Ior<L, R>> {
   fun OL(): Order<L>
   fun OR(): Order<R>
@@ -241,6 +304,10 @@ interface IorOrder<L, R> : Order<Ior<L, R>> {
 fun <L, R> Ior.Companion.fx(SL: Semigroup<L>, c: suspend MonadSyntax<IorPartialOf<L>>.() -> R): Ior<L, R> =
   Ior.monad(SL).fx.monad(c).fix()
 
+@Deprecated(
+  message = "Crosswalk typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
+)
 interface IorCrosswalk<L> : Crosswalk<IorPartialOf<L>>, IorFunctor<L>, IorFoldable<L> {
   override fun <F, A, B> crosswalk(ALIGN: Align<F>, a: Kind<IorPartialOf<L>, A>, fa: (A) -> Kind<F, B>): Kind<F, Kind<IorPartialOf<L>, B>> {
     return when (val ior = a.fix()) {
@@ -251,6 +318,10 @@ interface IorCrosswalk<L> : Crosswalk<IorPartialOf<L>>, IorFunctor<L>, IorFoldab
   }
 }
 
+@Deprecated(
+  message = "Bicrosswalk typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
+)
 interface IorBicrosswalk : Bicrosswalk<ForIor>, IorBifunctor, IorBifoldable {
   override fun <F, A, B, C, D> bicrosswalk(
     ALIGN: Align<F>,

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/applicative/IorApplicative.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/applicative/IorApplicative.kt
@@ -7,13 +7,6 @@ import arrow.core.Ior.Companion
 import arrow.core.extensions.IorApplicative
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Semigroup
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.Int
-import kotlin.Suppress
-import kotlin.Unit
-import kotlin.collections.List
-import kotlin.jvm.JvmName
 
 @JvmName("just1")
 @Suppress(
@@ -25,8 +18,8 @@ import kotlin.jvm.JvmName
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "just(SL)",
-  "arrow.core.just"
+  "Ior.Right(this)",
+  "arrow.core.Ior"
   ),
   DeprecationLevel.WARNING
 )
@@ -44,8 +37,8 @@ fun <L, A> A.just(SL: Semigroup<L>): Ior<L, A> = arrow.core.Ior.applicative<L>(S
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "unit(SL)",
-  "arrow.core.Ior.unit"
+  "Ior.unit<L>()",
+  "arrow.core.Ior"
   ),
   DeprecationLevel.WARNING
 )
@@ -63,8 +56,7 @@ fun <L> unit(SL: Semigroup<L>): Ior<L, Unit> = arrow.core.Ior
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(SL, arg1)",
-  "arrow.core.map"
+  "map(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -119,6 +111,10 @@ fun <L, A> Kind<Kind<ForIor, L>, A>.replicate(
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Applicative typeclass is deprecated. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
 )
 inline fun <L> Companion.applicative(SL: Semigroup<L>): IorApplicative<L> = object :
     arrow.core.extensions.IorApplicative<L> { override fun SL(): arrow.typeclasses.Semigroup<L> = SL

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/apply/IorApply.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/apply/IorApply.kt
@@ -16,10 +16,6 @@ import arrow.core.Tuple8
 import arrow.core.Tuple9
 import arrow.core.extensions.IorApply
 import arrow.typeclasses.Semigroup
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 @JvmName("ap")
 @Suppress(
@@ -31,7 +27,7 @@ import kotlin.jvm.JvmName
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "ap(SL, arg1)",
+  "this.ap(SL, arg1)",
   "arrow.core.ap"
   ),
   DeprecationLevel.WARNING
@@ -53,7 +49,7 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.ap(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "apEval(SL, arg1)",
+  "this.apEval(SL, arg1)",
   "arrow.core.apEval"
   ),
   DeprecationLevel.WARNING
@@ -75,8 +71,8 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.apEval(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map2Eval(SL, arg1, arg2)",
-  "arrow.core.map2Eval"
+  "this.zipEval<L, A, B, Z>(SL, arg1) { a, b -> arg2(Tuple2(a, b)) }",
+  "arrow.core.zipEval"
   ),
   DeprecationLevel.WARNING
 )
@@ -99,8 +95,8 @@ fun <L, A, B, Z> Kind<Kind<ForIor, L>, A>.map2Eval(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(SL, arg0, arg1, arg2)",
-  "arrow.core.Ior.map"
+  "Ior.mapN(SL, arg0, arg1) { a, b -> arg2(Tuple2(a, b))}",
+  "arrow.core.Ior", "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
 )
@@ -123,8 +119,8 @@ fun <L, A, B, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(SL, arg0, arg1, arg2)",
-  "arrow.core.Ior.mapN"
+    "Ior.mapN(SL, arg0, arg1) { a, b -> arg2(Tuple2(a, b))}",
+    "arrow.core.Ior", "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
 )
@@ -147,8 +143,8 @@ fun <L, A, B, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(SL, arg0, arg1, arg2, arg3)",
-  "arrow.core.Ior.map"
+    "Ior.mapN(SL, arg0, arg1, arg2) { a, b, c -> arg3(Tuple3(a, b, c))}",
+    "arrow.core.Ior", "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
 )
@@ -172,8 +168,8 @@ fun <L, A, B, C, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(SL, arg0, arg1, arg2, arg3)",
-  "arrow.core.Ior.mapN"
+    "Ior.mapN(SL, arg0, arg1, arg2) { a, b, c -> arg3(Tuple3(a, b, c))}",
+    "arrow.core.Ior", "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
 )
@@ -197,8 +193,8 @@ fun <L, A, B, C, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(SL, arg0, arg1, arg2, arg3, arg4)",
-  "arrow.core.Ior.map"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3) { a, b, c, d -> arg4(Tuple4(a, b, c, d))}",
+    "arrow.core.Ior", "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
 )
@@ -223,8 +219,8 @@ fun <L, A, B, C, D, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(SL, arg0, arg1, arg2, arg3, arg4)",
-  "arrow.core.Ior.mapN"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3) { a, b, c, d -> arg4(Tuple4(a, b, c, d))}",
+    "arrow.core.Ior", "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
 )
@@ -249,8 +245,8 @@ fun <L, A, B, C, D, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(SL, arg0, arg1, arg2, arg3, arg4, arg5)",
-  "arrow.core.Ior.map"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e))}",
+    "arrow.core.Ior", "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
 )
@@ -276,8 +272,8 @@ fun <L, A, B, C, D, E, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5)",
-  "arrow.core.Ior.mapN"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e))}",
+    "arrow.core.Ior", "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
 )
@@ -303,8 +299,8 @@ fun <L, A, B, C, D, E, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-  "arrow.core.Ior.map"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> arg6(Tuple6(a, b, c, d, e, f))}",
+    "arrow.core.Ior", "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
 )
@@ -331,8 +327,8 @@ fun <L, A, B, C, D, E, FF, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-  "arrow.core.Ior.mapN"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> arg6(Tuple6(a, b, c, d, e, f))}",
+    "arrow.core.Ior", "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
 )
@@ -359,8 +355,8 @@ fun <L, A, B, C, D, E, FF, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-  "arrow.core.Ior.map"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> arg7(Tuple7(a, b, c, d, e, f, g))}",
+    "arrow.core.Ior", "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
 )
@@ -389,8 +385,8 @@ fun <L, A, B, C, D, E, FF, G, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-  "arrow.core.Ior.mapN"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> arg7(Tuple7(a, b, c, d, e, f, g))}",
+    "arrow.core.Ior", "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
 )
@@ -419,8 +415,8 @@ fun <L, A, B, C, D, E, FF, G, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-  "arrow.core.Ior.map"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> arg8(Tuple8(a, b, c, d, e, f, g, h))}",
+    "arrow.core.Ior", "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
 )
@@ -450,8 +446,8 @@ fun <L, A, B, C, D, E, FF, G, H, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-  "arrow.core.Ior.mapN"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> arg8(Tuple8(a, b, c, d, e, f, g, h))}",
+    "arrow.core.Ior", "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
 )
@@ -481,8 +477,8 @@ fun <L, A, B, C, D, E, FF, G, H, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-  "arrow.core.Ior.map"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, f, g, h, i -> arg9(Tuple9(a, b, c, d, e, f, g, h, i))}",
+    "arrow.core.Ior", "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
 )
@@ -513,8 +509,8 @@ fun <L, A, B, C, D, E, FF, G, H, I, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-  "arrow.core.Ior.mapN"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, f, g, h, i -> arg9(Tuple9(a, b, c, d, e, f, g, h, i))}",
+    "arrow.core.Ior", "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
 )
@@ -545,8 +541,8 @@ fun <L, A, B, C, D, E, FF, G, H, I, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)",
-  "arrow.core.Ior.map"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, f, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, f, g, h, i, j))}",
+    "arrow.core.Ior", "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
 )
@@ -578,8 +574,8 @@ fun <L, A, B, C, D, E, FF, G, H, I, J, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)",
-  "arrow.core.Ior.mapN"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, f, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, f, g, h, i, j))}",
+    "arrow.core.Ior", "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
 )
@@ -611,8 +607,8 @@ fun <L, A, B, C, D, E, FF, G, H, I, J, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map2(SL, arg1, arg2)",
-  "arrow.core.map2"
+    "this.zip(SL, arg1) { a, b -> arg2(Tuple2(a, b)) }",
+    "arrow.core.Tuple2", "arrow.core.zip"
   ),
   DeprecationLevel.WARNING
 )
@@ -634,8 +630,8 @@ fun <L, A, B, Z> Kind<Kind<ForIor, L>, A>.map2(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(SL, arg1)",
-  "arrow.core.product"
+    "this.zip(SL, arg1)",
+    "arrow.core.zip"
   ),
   DeprecationLevel.WARNING
 )
@@ -654,8 +650,8 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.product(SL: Semigroup<L>, arg1: Kind<Kind
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(SL, arg1)",
-  "arrow.core.product"
+    "Ior.mapN(SL, this, arg1) { (a, b), z -> Tuple3(a, b, z) }",
+    "arrow.core.Ior", "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
 )
@@ -676,8 +672,8 @@ fun <L, A, B, Z> Kind<Kind<ForIor, L>, Tuple2<A, B>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(SL, arg1)",
-  "arrow.core.product"
+    "Ior.mapN(SL, this, arg1) { (a, b, c), z -> Tuple4(a, b, c, z) }",
+    "arrow.core.Ior", "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
 )
@@ -698,8 +694,8 @@ fun <L, A, B, C, Z> Kind<Kind<ForIor, L>, Tuple3<A, B, C>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(SL, arg1)",
-  "arrow.core.product"
+    "Ior.mapN(SL, this, arg1) { (a, b, c, d), z -> Tuple5(a, b, c, d, z) }",
+    "arrow.core.Ior", "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
 )
@@ -721,8 +717,8 @@ fun <L, A, B, C, D, Z> Kind<Kind<ForIor, L>, Tuple4<A, B, C, D>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(SL, arg1)",
-  "arrow.core.product"
+    "Ior.mapN(SL, this, arg1) { (a, b, c, d, e), z -> Tuple6(a, b, c, d, e, z) }",
+    "arrow.core.Ior", "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
 )
@@ -745,8 +741,8 @@ fun <L, A, B, C, D, E, Z> Kind<Kind<ForIor, L>, Tuple5<A, B, C, D, E>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(SL, arg1)",
-  "arrow.core.product"
+    "Ior.mapN(SL, this, arg1) { (a, b, c, d, e, f), z -> Tuple7(a, b, c, d, e, f, z) }",
+    "arrow.core.Ior", "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
 )
@@ -767,8 +763,8 @@ fun <L, A, B, C, D, E, FF, Z> Kind<Kind<ForIor, L>, Tuple6<A, B, C, D, E,
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(SL, arg1)",
-  "arrow.core.product"
+    "Ior.mapN(SL, this, arg1) { (a, b, c, d, e, f, g), z -> Tuple8(a, b, c, d, e, f, g, z) }",
+    "arrow.core.Ior", "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
 )
@@ -789,8 +785,8 @@ fun <L, A, B, C, D, E, FF, G, Z> Kind<Kind<ForIor, L>, Tuple7<A, B, C, D, E, FF,
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(SL, arg1)",
-  "arrow.core.product"
+    "Ior.mapN(SL, this, arg1) { (a, b, c, d, e, f, g, h), z -> Tuple9(a, b, c, d, e, f, g, h, z) }",
+    "arrow.core.Ior", "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
 )
@@ -811,8 +807,8 @@ fun <L, A, B, C, D, E, FF, G, H, Z> Kind<Kind<ForIor, L>, Tuple8<A, B, C, D, E, 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(SL, arg1)",
-  "arrow.core.product"
+    "Ior.mapN(SL, this, arg1) { (a, b, c, d, e, f, g, h, i), z -> Tuple10(a, b, c, d, e, f, g, h, i, z) }",
+    "arrow.core.Ior", "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
 )
@@ -833,8 +829,8 @@ fun <L, A, B, C, D, E, FF, G, H, I, Z> Kind<Kind<ForIor, L>, Tuple9<A, B, C, D, 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(SL, arg0, arg1)",
-  "arrow.core.Ior.tupled"
+    "Ior.mapN(SL, arg0, arg1) { a, b -> Tuple2(a, b) }",
+    "arrow.core.Ior", "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
 )
@@ -856,8 +852,8 @@ fun <L, A, B> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(SL, arg0, arg1)",
-  "arrow.core.Ior.tupledN"
+    "Ior.mapN(SL, arg0, arg1) { a, b -> Tuple2(a, b) }",
+    "arrow.core.Ior", "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
 )
@@ -879,8 +875,8 @@ fun <L, A, B> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(SL, arg0, arg1, arg2)",
-  "arrow.core.Ior.tupled"
+    "Ior.mapN(SL, arg0, arg1, arg2) { a, b, c -> Tuple3(a, b, c) }",
+    "arrow.core.Ior", "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
 )
@@ -903,8 +899,8 @@ fun <L, A, B, C> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(SL, arg0, arg1, arg2)",
-  "arrow.core.Ior.tupledN"
+    "Ior.mapN(SL, arg0, arg1, arg2) { a, b, c -> Tuple3(a, b, c) }",
+    "arrow.core.Ior", "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
 )
@@ -927,8 +923,8 @@ fun <L, A, B, C> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(SL, arg0, arg1, arg2, arg3)",
-  "arrow.core.Ior.tupled"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }",
+    "arrow.core.Ior", "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
 )
@@ -952,8 +948,8 @@ fun <L, A, B, C, D> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(SL, arg0, arg1, arg2, arg3)",
-  "arrow.core.Ior.tupledN"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }",
+    "arrow.core.Ior", "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
 )
@@ -977,8 +973,8 @@ fun <L, A, B, C, D> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(SL, arg0, arg1, arg2, arg3, arg4)",
-  "arrow.core.Ior.tupled"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }",
+    "arrow.core.Ior", "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
 )
@@ -1004,8 +1000,8 @@ fun <L, A, B, C, D, E> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(SL, arg0, arg1, arg2, arg3, arg4)",
-  "arrow.core.Ior.tupledN"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }",
+    "arrow.core.Ior", "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
 )
@@ -1031,8 +1027,8 @@ fun <L, A, B, C, D, E> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(SL, arg0, arg1, arg2, arg3, arg4, arg5)",
-  "arrow.core.Ior.tupled"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> Tuple6(a, b, c, d, e, f) }",
+    "arrow.core.Ior", "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
 )
@@ -1059,8 +1055,8 @@ fun <L, A, B, C, D, E, FF> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(SL, arg0, arg1, arg2, arg3, arg4, arg5)",
-  "arrow.core.Ior.tupledN"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> Tuple6(a, b, c, d, e, f) }",
+    "arrow.core.Ior", "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
 )
@@ -1087,8 +1083,8 @@ fun <L, A, B, C, D, E, FF> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-  "arrow.core.Ior.tupled"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> Tuple7(a, b, c, d, e, f, g) }",
+    "arrow.core.Ior", "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
 )
@@ -1116,8 +1112,8 @@ fun <L, A, B, C, D, E, FF, G> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-  "arrow.core.Ior.tupledN"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> Tuple7(a, b, c, d, e, f, g) }",
+    "arrow.core.Ior", "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
 )
@@ -1145,8 +1141,8 @@ fun <L, A, B, C, D, E, FF, G> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-  "arrow.core.Ior.tupled"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> Tuple8(a, b, c, d, e, f, g, h) }",
+    "arrow.core.Ior", "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
 )
@@ -1175,8 +1171,8 @@ fun <L, A, B, C, D, E, FF, G, H> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-  "arrow.core.Ior.tupledN"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> Tuple8(a, b, c, d, e, f, g, h) }",
+    "arrow.core.Ior", "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
 )
@@ -1205,8 +1201,8 @@ fun <L, A, B, C, D, E, FF, G, H> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-  "arrow.core.Ior.tupled"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, f, g, h, i -> Tuple9(a, b, c, d, e, f, g, h, i) }",
+    "arrow.core.Ior", "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
 )
@@ -1236,8 +1232,8 @@ fun <L, A, B, C, D, E, FF, G, H, I> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-  "arrow.core.Ior.tupledN"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, f, g, h, i -> Tuple9(a, b, c, d, e, f, g, h, i) }",
+    "arrow.core.Ior", "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
 )
@@ -1267,8 +1263,8 @@ fun <L, A, B, C, D, E, FF, G, H, I> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-  "arrow.core.Ior.tupled"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, f, g, h, i, j -> Tuple10(a, b, c, d, e, f, g, h, i, j) }",
+    "arrow.core.Ior", "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
 )
@@ -1300,8 +1296,8 @@ fun <L, A, B, C, D, E, FF, G, H, I, J> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-  "arrow.core.Ior.tupledN"
+    "Ior.mapN(SL, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, f, g, h, i, j -> Tuple10(a, b, c, d, e, f, g, h, i, j) }",
+    "arrow.core.Ior", "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
 )
@@ -1333,7 +1329,7 @@ fun <L, A, B, C, D, E, FF, G, H, I, J> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "followedBy(SL, arg1)",
+  "this.flatMap(SL) { arg1 }",
   "arrow.core.followedBy"
   ),
   DeprecationLevel.WARNING
@@ -1353,8 +1349,8 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.followedBy(SL: Semigroup<L>, arg1: Kind<K
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "apTap(SL, arg1)",
-  "arrow.core.apTap"
+  "Ior.mapN(SL, this, arg1) { left, _ -> left }",
+  "arrow.core.Ior"
   ),
   DeprecationLevel.WARNING
 )
@@ -1366,6 +1362,10 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.apTap(SL: Semigroup<L>, arg1: Kind<Kind<F
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Apply typeclass is deprecated. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
 )
 inline fun <L> Companion.apply(SL: Semigroup<L>): IorApply<L> = object :
     arrow.core.extensions.IorApply<L> { override fun SL(): arrow.typeclasses.Semigroup<L> = SL }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/apply/IorApply.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/apply/IorApply.kt
@@ -72,7 +72,7 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.apEval(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
   "this.zipEval<L, A, B, Z>(SL, arg1) { a, b -> arg2(Tuple2(a, b)) }",
-  "arrow.core.zipEval"
+  "arrow.core.zipEval", "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
 )

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/bicrosswalk/IorBicrosswalk.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/bicrosswalk/IorBicrosswalk.kt
@@ -5,11 +5,6 @@ import arrow.core.ForIor
 import arrow.core.Ior.Companion
 import arrow.core.extensions.IorBicrosswalk
 import arrow.typeclasses.Align
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -26,12 +21,8 @@ internal val bicrosswalk_singleton: IorBicrosswalk = object : arrow.core.extensi
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "bicrosswalk(arg0, arg1, arg2, arg3)",
-  "arrow.core.Ior.bicrosswalk"
-  ),
-  DeprecationLevel.WARNING
+  "extension kinded projected functions are deprecated. Replace with bicrosswalk, bicrosswalkMap or bicrosswalkNull from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <F, A, B, C, D> bicrosswalk(
   arg0: Align<F>,
@@ -51,12 +42,8 @@ fun <F, A, B, C, D> bicrosswalk(
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "bisequenceL(arg0, arg1)",
-  "arrow.core.Ior.bisequenceL"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated. Replace with bisequence, bisequenceEither or bisequenceValidated from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <F, A, B> bisequenceL(arg0: Align<F>, arg1: Kind<Kind<ForIor, Kind<F, A>>, Kind<F, B>>): Kind<F,
     Kind<Kind<ForIor, A>, B>> = arrow.core.Ior
@@ -67,5 +54,9 @@ fun <F, A, B> bisequenceL(arg0: Align<F>, arg1: Kind<Kind<ForIor, Kind<F, A>>, K
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Bicrosswalk typeclass is deprecated. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.bicrosswalk(): IorBicrosswalk = bicrosswalk_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/bifoldable/IorBifoldable.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/bifoldable/IorBifoldable.kt
@@ -6,12 +6,6 @@ import arrow.core.ForIor
 import arrow.core.Ior.Companion
 import arrow.core.extensions.IorBifoldable
 import arrow.typeclasses.Monoid
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.Function2
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -29,8 +23,7 @@ internal val bifoldable_singleton: IorBifoldable = object : arrow.core.extension
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "bifoldLeft(arg1, arg2, arg3)",
-  "arrow.core.bifoldLeft"
+  "this.bifoldLeft(arg1, arg2, arg3)"
   ),
   DeprecationLevel.WARNING
 )
@@ -52,8 +45,7 @@ fun <A, B, C> Kind<Kind<ForIor, A>, B>.bifoldLeft(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "bifoldRight(arg1, arg2, arg3)",
-  "arrow.core.bifoldRight"
+  "this.bifoldRight(arg1, arg2, arg3)"
   ),
   DeprecationLevel.WARNING
 )
@@ -75,8 +67,7 @@ fun <A, B, C> Kind<Kind<ForIor, A>, B>.bifoldRight(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "bifoldMap(arg1, arg2, arg3)",
-  "arrow.core.bifoldMap"
+  "this.bifoldMap(arg1, arg2, arg3)"
   ),
   DeprecationLevel.WARNING
 )
@@ -91,5 +82,9 @@ fun <A, B, C> Kind<Kind<ForIor, A>, B>.bifoldMap(
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Bifoldable typeclass is deprecated. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.bifoldable(): IorBifoldable = bifoldable_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/bifunctor/IorBifunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/bifunctor/IorBifunctor.kt
@@ -7,11 +7,6 @@ import arrow.core.Ior.Companion
 import arrow.core.extensions.IorBifunctor
 import arrow.typeclasses.Conested
 import arrow.typeclasses.Functor
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -29,8 +24,7 @@ internal val bifunctor_singleton: IorBifunctor = object : arrow.core.extensions.
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "bimap(arg1, arg2)",
-  "arrow.core.bimap"
+  "this.bimap(arg1, arg2)"
   ),
   DeprecationLevel.WARNING
 )
@@ -49,8 +43,8 @@ fun <A, B, C, D> Kind<Kind<ForIor, A>, B>.bimap(arg1: Function1<A, C>, arg2: Fun
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "lift(arg0, arg1)",
-  "arrow.core.Ior.lift"
+  "Ior.lift(arg0, arg1)",
+  "arrow.core.Ior"
   ),
   DeprecationLevel.WARNING
 )
@@ -70,8 +64,7 @@ fun <A, B, C, D> lift(arg0: Function1<A, C>, arg1: Function1<B, D>): Function1<K
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapLeft(arg1)",
-  "arrow.core.mapLeft"
+  "this.mapLeft(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -88,12 +81,8 @@ fun <A, B, C> Kind<Kind<ForIor, A>, B>.mapLeft(arg1: Function1<A, C>): Ior<C, B>
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "rightFunctor()",
-  "arrow.core.Ior.rightFunctor"
-  ),
-  DeprecationLevel.WARNING
+  "Functor typeclass is deprecated. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
 )
 fun <X> rightFunctor(): Functor<Kind<ForIor, X>> = arrow.core.Ior
    .bifunctor()
@@ -107,12 +96,8 @@ fun <X> rightFunctor(): Functor<Kind<ForIor, X>> = arrow.core.Ior
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "leftFunctor()",
-  "arrow.core.Ior.leftFunctor"
-  ),
-  DeprecationLevel.WARNING
+  "Functor typeclass is deprecated. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
 )
 fun <X> leftFunctor(): Functor<Conested<ForIor, X>> = arrow.core.Ior
    .bifunctor()
@@ -128,7 +113,7 @@ fun <X> leftFunctor(): Functor<Conested<ForIor, X>> = arrow.core.Ior
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "leftWiden()",
+  "this.leftWiden()",
   "arrow.core.leftWiden"
   ),
   DeprecationLevel.WARNING
@@ -141,5 +126,9 @@ fun <AA, B, A : AA> Kind<Kind<ForIor, A>, B>.leftWiden(): Ior<AA, B> =
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Bifunctor typeclass is deprecated. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.bifunctor(): IorBifunctor = bifunctor_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/bitraverse/IorBitraverse.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/bitraverse/IorBitraverse.kt
@@ -6,11 +6,6 @@ import arrow.core.Ior
 import arrow.core.Ior.Companion
 import arrow.core.extensions.IorBitraverse
 import arrow.typeclasses.Applicative
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -26,12 +21,8 @@ internal val bitraverse_singleton: IorBitraverse = object : arrow.core.extension
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "bitraverse(arg1, arg2, arg3)",
-  "arrow.core.bitraverse"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated. Replace with bitraverse, bitraverseEither or bitraverseValidated from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <G, A, B, C, D> Kind<Kind<ForIor, A>, B>.bitraverse(
   arg1: Applicative<G>,
@@ -50,12 +41,8 @@ fun <G, A, B, C, D> Kind<Kind<ForIor, A>, B>.bitraverse(
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "bisequence(arg1)",
-  "arrow.core.bisequence"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated. Replace with bisequence, bisequenceEither or bisequenceValidated from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <G, A, B> Kind<Kind<ForIor, Kind<G, A>>, Kind<G, B>>.bisequence(arg1: Applicative<G>): Kind<G,
     Kind<Kind<ForIor, A>, B>> = arrow.core.Ior.bitraverse().run {
@@ -73,8 +60,7 @@ fun <G, A, B> Kind<Kind<ForIor, Kind<G, A>>, Kind<G, B>>.bisequence(arg1: Applic
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "bimap(arg1, arg2)",
-  "arrow.core.bimap"
+  "this.bimap(arg1, arg2)"
   ),
   DeprecationLevel.WARNING
 )
@@ -86,5 +72,9 @@ fun <A, B, C, D> Kind<Kind<ForIor, A>, B>.bimap(arg1: Function1<A, C>, arg2: Fun
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Bitraverse typeclass is deprecated. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.bitraverse(): IorBitraverse = bitraverse_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/crosswalk/IorCrosswalk.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/crosswalk/IorCrosswalk.kt
@@ -5,12 +5,6 @@ import arrow.core.ForIor
 import arrow.core.Ior.Companion
 import arrow.core.extensions.IorCrosswalk
 import arrow.typeclasses.Align
-import kotlin.Any
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -26,12 +20,8 @@ internal val crosswalk_singleton: IorCrosswalk<Any?> = object : IorCrosswalk<Any
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "crosswalk(arg0, arg1, arg2)",
-  "arrow.core.Ior.crosswalk"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated. Replace with crosswalk, crosswalkMap or crosswalkNull from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <L, F, A, B> crosswalk(
   arg0: Align<F>,
@@ -50,12 +40,8 @@ fun <L, F, A, B> crosswalk(
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "sequenceL(arg0, arg1)",
-  "arrow.core.Ior.sequenceL"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated. Replace with sequence, sequenceEither or sequenceValidated from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <L, F, A> sequenceL(arg0: Align<F>, arg1: Kind<Kind<ForIor, L>, Kind<F, A>>): Kind<F,
     Kind<Kind<ForIor, L>, A>> = arrow.core.Ior
@@ -65,6 +51,10 @@ fun <L, F, A> sequenceL(arg0: Align<F>, arg1: Kind<Kind<ForIor, L>, Kind<F, A>>)
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Crosswalk typeclass is deprecated. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
 )
 inline fun <L> Companion.crosswalk(): IorCrosswalk<L> = crosswalk_singleton as
     arrow.core.extensions.IorCrosswalk<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/eq/IorEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/eq/IorEq.kt
@@ -15,8 +15,8 @@ import arrow.typeclasses.Eq
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "this.neqv(EQL, EQR, arg1)",
-  "arrow.core.neqv"
+    "this.compareTo(arg1) != 0",
+    "arrow.core.compareTo"
   ),
   DeprecationLevel.WARNING
 )
@@ -33,12 +33,8 @@ fun <L, R> Ior<L, R>.neqv(
   "NOTHING_TO_INLINE"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "Eq.ior(EQL, EQR)",
-    "arrow.core.ior", "arrow.typeclasses.Eq"
-  ),
-  DeprecationLevel.WARNING
+  "Eq typeclass is deprecated. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
 )
 inline fun <L, R> Companion.eq(EQL: Eq<L>, EQR: Eq<R>): IorEq<L, R> = object :
     arrow.core.extensions.IorEq<L, R> { override fun EQL(): arrow.typeclasses.Eq<L> = EQL

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/eq/IorEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/eq/IorEq.kt
@@ -4,10 +4,6 @@ import arrow.core.Ior
 import arrow.core.Ior.Companion
 import arrow.core.extensions.IorEq
 import arrow.typeclasses.Eq
-import kotlin.Boolean
-import kotlin.Deprecated
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 @JvmName("neqv")
 @Suppress(
@@ -19,7 +15,7 @@ import kotlin.jvm.JvmName
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "neqv(EQL, EQR, arg1)",
+  "this.neqv(EQL, EQR, arg1)",
   "arrow.core.neqv"
   ),
   DeprecationLevel.WARNING
@@ -35,6 +31,14 @@ fun <L, R> Ior<L, R>.neqv(
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "@extension kinded projected functions are deprecated",
+  ReplaceWith(
+    "Eq.ior(EQL, EQR)",
+    "arrow.core.ior", "arrow.typeclasses.Eq"
+  ),
+  DeprecationLevel.WARNING
 )
 inline fun <L, R> Companion.eq(EQL: Eq<L>, EQR: Eq<R>): IorEq<L, R> = object :
     arrow.core.extensions.IorEq<L, R> { override fun EQL(): arrow.typeclasses.Eq<L> = EQL

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/eqK/IorEqK.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/eqK/IorEqK.kt
@@ -15,6 +15,9 @@ import arrow.typeclasses.Eq
 )
 @Deprecated(
   "Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0",
+  ReplaceWith(
+    "this.eqv(arg1)"
+  ),
   level = DeprecationLevel.WARNING
 )
 fun <A> Kind<Kind<ForIor, A>, A>.eqK(

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/eqK/IorEqK.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/eqK/IorEqK.kt
@@ -5,10 +5,6 @@ import arrow.core.ForIor
 import arrow.core.Ior.Companion
 import arrow.core.extensions.IorEqK
 import arrow.typeclasses.Eq
-import kotlin.Boolean
-import kotlin.Deprecated
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 @JvmName("eqK")
 @Suppress(
@@ -18,12 +14,8 @@ import kotlin.jvm.JvmName
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "eqK(EQA, arg1, arg2)",
-  "arrow.core.eqK"
-  ),
-  DeprecationLevel.WARNING
+  "Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0",
+  level = DeprecationLevel.WARNING
 )
 fun <A> Kind<Kind<ForIor, A>, A>.eqK(
   EQA: Eq<A>,
@@ -41,12 +33,8 @@ fun <A> Kind<Kind<ForIor, A>, A>.eqK(
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "liftEq(EQA, arg0)",
-  "arrow.core.Ior.liftEq"
-  ),
-  DeprecationLevel.WARNING
+  "Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0",
+  level = DeprecationLevel.WARNING
 )
 fun <A> liftEq(EQA: Eq<A>, arg0: Eq<A>): Eq<Kind<Kind<ForIor, A>, A>> = arrow.core.Ior
    .eqK<A>(EQA)
@@ -55,6 +43,10 @@ fun <A> liftEq(EQA: Eq<A>, arg0: Eq<A>): Eq<Kind<Kind<ForIor, A>, A>> = arrow.co
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0",
+  level = DeprecationLevel.WARNING
 )
 inline fun <A> Companion.eqK(EQA: Eq<A>): IorEqK<A> = object : arrow.core.extensions.IorEqK<A> {
     override fun EQA(): arrow.typeclasses.Eq<A> = EQA }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/eqK2/IorEqK2.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/eqK2/IorEqK2.kt
@@ -21,6 +21,9 @@ internal val eqK2_singleton: IorEqK2 = object : arrow.core.extensions.IorEqK2 {}
 )
 @Deprecated(
   "Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0",
+  ReplaceWith(
+    "this.eqv(arg1)"
+  ),
   level = DeprecationLevel.WARNING
 )
 fun <A, B> Kind<Kind<ForIor, A>, B>.eqK(

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/eqK2/IorEqK2.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/eqK2/IorEqK2.kt
@@ -5,11 +5,6 @@ import arrow.core.ForIor
 import arrow.core.Ior.Companion
 import arrow.core.extensions.IorEqK2
 import arrow.typeclasses.Eq
-import kotlin.Boolean
-import kotlin.Deprecated
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -25,12 +20,8 @@ internal val eqK2_singleton: IorEqK2 = object : arrow.core.extensions.IorEqK2 {}
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "eqK(arg1, arg2, arg3)",
-  "arrow.core.eqK"
-  ),
-  DeprecationLevel.WARNING
+  "Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0",
+  level = DeprecationLevel.WARNING
 )
 fun <A, B> Kind<Kind<ForIor, A>, B>.eqK(
   arg1: Kind<Kind<ForIor, A>, B>,
@@ -48,12 +39,8 @@ fun <A, B> Kind<Kind<ForIor, A>, B>.eqK(
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "liftEq(arg0, arg1)",
-  "arrow.core.Ior.liftEq"
-  ),
-  DeprecationLevel.WARNING
+  "Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0",
+  level = DeprecationLevel.WARNING
 )
 fun <A, B> liftEq(arg0: Eq<A>, arg1: Eq<B>): Eq<Kind<Kind<ForIor, A>, B>> = arrow.core.Ior
    .eqK2()
@@ -63,5 +50,9 @@ fun <A, B> liftEq(arg0: Eq<A>, arg1: Eq<B>): Eq<Kind<Kind<ForIor, A>, B>> = arro
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.eqK2(): IorEqK2 = eqK2_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/foldable/IorFoldable.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/foldable/IorFoldable.kt
@@ -10,17 +10,6 @@ import arrow.core.extensions.IorFoldable
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Monad
 import arrow.typeclasses.Monoid
-import kotlin.Any
-import kotlin.Boolean
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.Function2
-import kotlin.Long
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.Unit
-import kotlin.collections.List
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -38,8 +27,7 @@ internal val foldable_singleton: IorFoldable<Any?> = object : IorFoldable<Any?> 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "foldLeft(arg1, arg2)",
-  "arrow.core.foldLeft"
+  "this.foldLeft(arg1, arg2)"
   ),
   DeprecationLevel.WARNING
 )
@@ -58,8 +46,7 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.foldLeft(arg1: B, arg2: Function2<B, A, B
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "foldRight(arg1, arg2)",
-  "arrow.core.foldRight"
+  "this.foldRight(arg1, arg2)"
   ),
   DeprecationLevel.WARNING
 )
@@ -80,8 +67,7 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.foldRight(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "fold(arg1)",
-  "arrow.core.fold"
+  "this.fold({ arg1.empty() }, { it }, { _, b -> b })",
   ),
   DeprecationLevel.WARNING
 )
@@ -99,8 +85,8 @@ fun <L, A> Kind<Kind<ForIor, L>, A>.fold(arg1: Monoid<A>): A = arrow.core.Ior.fo
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "reduceLeftToOption(arg1, arg2)",
-  "arrow.core.reduceLeftToOption"
+    "Option.fromNullable(this.map(arg1).orNull())",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -121,8 +107,8 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.reduceLeftToOption(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "reduceRightToOption(arg1, arg2)",
-  "arrow.core.reduceRightToOption"
+    "Eval.now(Option.fromNullable(this.map(arg1).orNull()))",
+    "arrow.core.Eval", "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -144,8 +130,8 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.reduceRightToOption(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "reduceLeftOption(arg1)",
-  "arrow.core.reduceLeftOption"
+    "Option.fromNullable(this.orNull())",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -164,8 +150,8 @@ fun <L, A> Kind<Kind<ForIor, L>, A>.reduceLeftOption(arg1: Function2<A, A, A>): 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "reduceRightOption(arg1)",
-  "arrow.core.reduceRightOption"
+    "Eval.now(Option.fromNullable(this.orNull()))",
+    "arrow.core.Eval", "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -184,8 +170,7 @@ fun <L, A> Kind<Kind<ForIor, L>, A>.reduceRightOption(arg1: Function2<A, Eval<A>
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "combineAll(arg1)",
-  "arrow.core.combineAll"
+  "this.fold({ arg1.empty() }, { it }, { _, b -> b })"
   ),
   DeprecationLevel.WARNING
 )
@@ -204,8 +189,7 @@ fun <L, A> Kind<Kind<ForIor, L>, A>.combineAll(arg1: Monoid<A>): A =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "foldMap(arg1, arg2)",
-  "arrow.core.foldMap"
+  "this.foldMap(arg1, arg2)"
   ),
   DeprecationLevel.WARNING
 )
@@ -224,8 +208,8 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.foldMap(arg1: Monoid<B>, arg2: Function1<
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "orEmpty(arg0, arg1)",
-  "arrow.core.Ior.orEmpty"
+  "Ior.Right(arg1.empty)",
+  "arrow.core.Ior"
   ),
   DeprecationLevel.WARNING
 )
@@ -241,12 +225,8 @@ fun <L, A> orEmpty(arg0: Applicative<Kind<ForIor, L>>, arg1: Monoid<A>): Ior<L, 
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "traverse_(arg1, arg2)",
-  "arrow.core.traverse_"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated. Replace with traverse_, traverseEither_ or traverseValidated_ from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <L, G, A, B> Kind<Kind<ForIor, L>, A>.traverse_(
   arg1: Applicative<G>,
@@ -263,12 +243,8 @@ fun <L, G, A, B> Kind<Kind<ForIor, L>, A>.traverse_(
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "sequence_(arg1)",
-  "arrow.core.sequence_"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated. Replace with sequence_, sequenceEither_ or sequenceValidated_ from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <L, G, A> Kind<Kind<ForIor, L>, Kind<G, A>>.sequence_(arg1: Applicative<G>): Kind<G, Unit> =
     arrow.core.Ior.foldable<L>().run {
@@ -285,8 +261,8 @@ fun <L, G, A> Kind<Kind<ForIor, L>, Kind<G, A>>.sequence_(arg1: Applicative<G>):
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "find(arg1)",
-  "arrow.core.find"
+    "Option.fromNullable(this.findOrNull(arg1))",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -305,8 +281,7 @@ fun <L, A> Kind<Kind<ForIor, L>, A>.find(arg1: Function1<A, Boolean>): Option<A>
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "exists(arg1)",
-  "arrow.core.exists"
+  "this.exists(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -325,8 +300,7 @@ fun <L, A> Kind<Kind<ForIor, L>, A>.exists(arg1: Function1<A, Boolean>): Boolean
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "forAll(arg1)",
-  "arrow.core.forAll"
+  "this.all(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -345,8 +319,7 @@ fun <L, A> Kind<Kind<ForIor, L>, A>.forAll(arg1: Function1<A, Boolean>): Boolean
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "all(arg1)",
-  "arrow.core.all"
+  "this.all(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -365,8 +338,7 @@ fun <L, A> Kind<Kind<ForIor, L>, A>.all(arg1: Function1<A, Boolean>): Boolean =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "isEmpty()",
-  "arrow.core.isEmpty"
+  "this.isEmpty()"
   ),
   DeprecationLevel.WARNING
 )
@@ -384,8 +356,7 @@ fun <L, A> Kind<Kind<ForIor, L>, A>.isEmpty(): Boolean = arrow.core.Ior.foldable
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "nonEmpty()",
-  "arrow.core.nonEmpty"
+    "this.isNotEmpty()"
   ),
   DeprecationLevel.WARNING
 )
@@ -403,8 +374,7 @@ fun <L, A> Kind<Kind<ForIor, L>, A>.nonEmpty(): Boolean = arrow.core.Ior.foldabl
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "isNotEmpty()",
-  "arrow.core.isNotEmpty"
+    "this.isNotEmpty()"
   ),
   DeprecationLevel.WARNING
 )
@@ -422,8 +392,7 @@ fun <L, A> Kind<Kind<ForIor, L>, A>.isNotEmpty(): Boolean = arrow.core.Ior.folda
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "size(arg1)",
-  "arrow.core.size"
+  "this.fold({ 0 }, { 1 }, { 1 })"
   ),
   DeprecationLevel.WARNING
 )
@@ -440,12 +409,8 @@ fun <L, A> Kind<Kind<ForIor, L>, A>.size(arg1: Monoid<Long>): Long =
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "foldMapA(arg1, arg2, arg3)",
-  "arrow.core.foldMapA"
-  ),
-  DeprecationLevel.WARNING
+  "Applicative typeclass is deprecated. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
 )
 fun <L, G, A, B, AP : Applicative<G>, MO : Monoid<B>> Kind<Kind<ForIor, L>, A>.foldMapA(
   arg1: AP,
@@ -463,12 +428,8 @@ fun <L, G, A, B, AP : Applicative<G>, MO : Monoid<B>> Kind<Kind<ForIor, L>, A>.f
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "foldMapM(arg1, arg2, arg3)",
-  "arrow.core.foldMapM"
-  ),
-  DeprecationLevel.WARNING
+  "Monad typeclass is deprecated. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
 )
 fun <L, G, A, B, MA : Monad<G>, MO : Monoid<B>> Kind<Kind<ForIor, L>, A>.foldMapM(
   arg1: MA,
@@ -486,12 +447,8 @@ fun <L, G, A, B, MA : Monad<G>, MO : Monoid<B>> Kind<Kind<ForIor, L>, A>.foldMap
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "foldM(arg1, arg2, arg3)",
-  "arrow.core.foldM"
-  ),
-  DeprecationLevel.WARNING
+  "Monad typeclass is deprecated. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
 )
 fun <L, G, A, B> Kind<Kind<ForIor, L>, A>.foldM(
   arg1: Monad<G>,
@@ -511,8 +468,8 @@ fun <L, G, A, B> Kind<Kind<ForIor, L>, A>.foldM(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "get(arg1)",
-  "arrow.core.get"
+    "if (arg1 == 0L) this.fold({ None }, { Some(it) }, { _, b -> Some(b) }) else None",
+    "arrow.core.None", "arrow.core.Some"
   ),
   DeprecationLevel.WARNING
 )
@@ -530,8 +487,8 @@ fun <L, A> Kind<Kind<ForIor, L>, A>.get(arg1: Long): Option<A> = arrow.core.Ior.
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "firstOption()",
-  "arrow.core.firstOption"
+    "Option.fromNullable(this.orNull())",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -549,8 +506,8 @@ fun <L, A> Kind<Kind<ForIor, L>, A>.firstOption(): Option<A> = arrow.core.Ior.fo
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "firstOption(arg1)",
-  "arrow.core.firstOption"
+    "Option.fromNullable(this.findOrNull(arg1))",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -569,8 +526,8 @@ fun <L, A> Kind<Kind<ForIor, L>, A>.firstOption(arg1: Function1<A, Boolean>): Op
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "firstOrNone()",
-  "arrow.core.firstOrNone"
+    "Option.fromNullable(this.orNull())",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -588,8 +545,8 @@ fun <L, A> Kind<Kind<ForIor, L>, A>.firstOrNone(): Option<A> = arrow.core.Ior.fo
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "firstOrNone(arg1)",
-  "arrow.core.firstOrNone"
+    "Option.fromNullable(this.findOrNull(arg1))",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -608,8 +565,7 @@ fun <L, A> Kind<Kind<ForIor, L>, A>.firstOrNone(arg1: Function1<A, Boolean>): Op
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "toList()",
-  "arrow.core.toList"
+  "listOfNotNull(this.orNull())"
   ),
   DeprecationLevel.WARNING
 )
@@ -620,6 +576,10 @@ fun <L, A> Kind<Kind<ForIor, L>, A>.toList(): List<A> = arrow.core.Ior.foldable<
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Foldable typeclass is deprecated. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
 )
 inline fun <L> Companion.foldable(): IorFoldable<L> = foldable_singleton as
     arrow.core.extensions.IorFoldable<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/functor/IorFunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/functor/IorFunctor.kt
@@ -6,13 +6,6 @@ import arrow.core.Ior
 import arrow.core.Ior.Companion
 import arrow.core.Tuple2
 import arrow.core.extensions.IorFunctor
-import kotlin.Any
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.Unit
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -30,8 +23,7 @@ internal val functor_singleton: IorFunctor<Any?> = object : IorFunctor<Any?> {}
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg1)",
-  "arrow.core.map"
+  "this.map(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -50,8 +42,7 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.map(arg1: Function1<A, B>): Ior<L, B> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "imap(arg1, arg2)",
-  "arrow.core.imap"
+  "this.map(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -70,8 +61,8 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.imap(arg1: Function1<A, B>, arg2: Functio
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "lift(arg0)",
-  "arrow.core.Ior.lift"
+  "Ior.lift(arg0)",
+  "arrow.core.Ior"
   ),
   DeprecationLevel.WARNING
 )
@@ -91,8 +82,7 @@ fun <L, A, B> lift(arg0: Function1<A, B>): Function1<Kind<Kind<ForIor, L>, A>, K
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "void()",
-  "arrow.core.void"
+  "this.void()"
   ),
   DeprecationLevel.WARNING
 )
@@ -110,8 +100,7 @@ fun <L, A> Kind<Kind<ForIor, L>, A>.void(): Ior<L, Unit> = arrow.core.Ior.functo
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "fproduct(arg1)",
-  "arrow.core.fproduct"
+  "this.fproduct(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -130,8 +119,7 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.fproduct(arg1: Function1<A, B>): Ior<L, T
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapConst(arg1)",
-  "arrow.core.mapConst"
+  "this.mapConst(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -150,8 +138,7 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.mapConst(arg1: B): Ior<L, B> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapConst(arg1)",
-  "arrow.core.mapConst"
+  "arg1.mapConst(this)"
   ),
   DeprecationLevel.WARNING
 )
@@ -170,8 +157,7 @@ fun <L, A, B> A.mapConst(arg1: Kind<Kind<ForIor, L>, B>): Ior<L, A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupleLeft(arg1)",
-  "arrow.core.tupleLeft"
+  "this.tupleLeft(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -190,8 +176,7 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.tupleLeft(arg1: B): Ior<L, Tuple2<B, A>> 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupleRight(arg1)",
-  "arrow.core.tupleRight"
+  "this.tupleRight(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -210,8 +195,8 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.tupleRight(arg1: B): Ior<L, Tuple2<A, B>>
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "widen()",
-  "arrow.core.widen"
+    "this.widen<L, B, A>()",
+    "arrow.core.widen"
   ),
   DeprecationLevel.WARNING
 )
@@ -222,6 +207,10 @@ fun <L, B, A : B> Kind<Kind<ForIor, L>, A>.widen(): Ior<L, B> = arrow.core.Ior.f
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Functor typeclass is deprecated. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
 )
 inline fun <L> Companion.functor(): IorFunctor<L> = functor_singleton as
     arrow.core.extensions.IorFunctor<L>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/hash/IorHash.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/hash/IorHash.kt
@@ -4,10 +4,6 @@ import arrow.core.Ior
 import arrow.core.Ior.Companion
 import arrow.core.extensions.IorHash
 import arrow.typeclasses.Hash
-import kotlin.Deprecated
-import kotlin.Int
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 @JvmName("hash")
 @Suppress(
@@ -19,7 +15,7 @@ import kotlin.jvm.JvmName
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "hash(HL, HR)",
+  "this.hash(HL, HR)",
   "arrow.core.hash"
   ),
   DeprecationLevel.WARNING
@@ -31,6 +27,14 @@ fun <L, R> Ior<L, R>.hash(HL: Hash<L>, HR: Hash<R>): Int = arrow.core.Ior.hash<L
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "@extension kinded projected functions are deprecated",
+  ReplaceWith(
+    "Hash.ior(HL, HR)",
+    "arrow.core.ior", "arrow.typeclasses.Hash"
+  ),
+  DeprecationLevel.WARNING
 )
 inline fun <L, R> Companion.hash(HL: Hash<L>, HR: Hash<R>): IorHash<L, R> = object :
     arrow.core.extensions.IorHash<L, R> { override fun HL(): arrow.typeclasses.Hash<L> = HL

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/hash/IorHash.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/hash/IorHash.kt
@@ -15,8 +15,7 @@ import arrow.typeclasses.Hash
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "this.hash(HL, HR)",
-  "arrow.core.hash"
+  "hashCode()"
   ),
   DeprecationLevel.WARNING
 )
@@ -29,12 +28,8 @@ fun <L, R> Ior<L, R>.hash(HL: Hash<L>, HR: Hash<R>): Int = arrow.core.Ior.hash<L
   "NOTHING_TO_INLINE"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "Hash.ior(HL, HR)",
-    "arrow.core.ior", "arrow.typeclasses.Hash"
-  ),
-  DeprecationLevel.WARNING
+  "Hash typeclass is deprecated. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
 )
 inline fun <L, R> Companion.hash(HL: Hash<L>, HR: Hash<R>): IorHash<L, R> = object :
     arrow.core.extensions.IorHash<L, R> { override fun HL(): arrow.typeclasses.Hash<L> = HL

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/monad/IorMonad.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/monad/IorMonad.kt
@@ -9,12 +9,6 @@ import arrow.core.Ior.Companion
 import arrow.core.Tuple2
 import arrow.core.extensions.IorMonad
 import arrow.typeclasses.Semigroup
-import kotlin.Boolean
-import kotlin.Deprecated
-import kotlin.Function0
-import kotlin.Function1
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 @JvmName("flatMap")
 @Suppress(
@@ -26,7 +20,7 @@ import kotlin.jvm.JvmName
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "flatMap(SL, arg1)",
+  "this.flatMap(SL, arg1)",
   "arrow.core.flatMap"
   ),
   DeprecationLevel.WARNING
@@ -48,8 +42,7 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.flatMap(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tailRecM(SL, arg0, arg1)",
-  "arrow.core.Ior.tailRecM"
+  "this.tailRecM(SL, arg0, arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -71,8 +64,7 @@ fun <L, A, B> tailRecM(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(SL, arg1)",
-  "arrow.core.map"
+  "this.map(SL, arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -94,7 +86,7 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.map(SL: Semigroup<L>, arg1: Function1<A, 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "ap(SL, arg1)",
+  "this.ap(SL, arg1)",
   "arrow.core.ap"
   ),
   DeprecationLevel.WARNING
@@ -116,7 +108,7 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.ap(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "flatten(SL)",
+  "this.flatten(SL)",
   "arrow.core.flatten"
   ),
   DeprecationLevel.WARNING
@@ -136,8 +128,8 @@ fun <L, A> Kind<Kind<ForIor, L>, Kind<Kind<ForIor, L>, A>>.flatten(SL: Semigroup
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "followedBy(SL, arg1)",
-  "arrow.core.followedBy"
+  "this.flatMap(SL) { arg1 }",
+  "arrow.core.flatMap"
   ),
   DeprecationLevel.WARNING
 )
@@ -156,8 +148,8 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.followedBy(SL: Semigroup<L>, arg1: Kind<K
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "apTap(SL, arg1)",
-  "arrow.core.apTap"
+  "Ior.mapN(SL, this, arg1) { left, _ -> left }",
+  "arrow.core.Ior"
   ),
   DeprecationLevel.WARNING
 )
@@ -176,8 +168,8 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.apTap(SL: Semigroup<L>, arg1: Kind<Kind<F
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "followedByEval(SL, arg1)",
-  "arrow.core.followedByEval"
+  "this.flatMap(SL) { arg1.value() }",
+  "arrow.core.flatMap"
   ),
   DeprecationLevel.WARNING
 )
@@ -198,8 +190,8 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.followedByEval(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "effectM(SL, arg1)",
-  "arrow.core.effectM"
+  "this.flatMap(SL) { a -> arg1(a).map { a } }",
+  "arrow.core.flatMap"
   ),
   DeprecationLevel.WARNING
 )
@@ -220,8 +212,8 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.effectM(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "flatTap(SL, arg1)",
-  "arrow.core.flatTap"
+  "this.flatMap { a -> arg1(a).map { a } }",
+  "arrow.core.flatMap"
   ),
   DeprecationLevel.WARNING
 )
@@ -242,8 +234,8 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.flatTap(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "productL(SL, arg1)",
-  "arrow.core.productL"
+  "this.flatMap { a -> arg1.map { a } }",
+  "arrow.core.flatMap"
   ),
   DeprecationLevel.WARNING
 )
@@ -262,8 +254,8 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.productL(SL: Semigroup<L>, arg1: Kind<Kin
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "forEffect(SL, arg1)",
-  "arrow.core.forEffect"
+  "this.flatMap { a -> arg1.map { a } }",
+  "arrow.core.flatMap"
   ),
   DeprecationLevel.WARNING
 )
@@ -282,8 +274,8 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.forEffect(SL: Semigroup<L>, arg1: Kind<Ki
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "productLEval(SL, arg1)",
-  "arrow.core.productLEval"
+  "this.flatMap { a -> arg1.value().map { a } }",
+  "arrow.core.flatMap"
   ),
   DeprecationLevel.WARNING
 )
@@ -304,8 +296,8 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.productLEval(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "forEffectEval(SL, arg1)",
-  "arrow.core.forEffectEval"
+  "this.flatMap { a -> arg1.value().map { a } }",
+  "arrow.core.flatMap"
   ),
   DeprecationLevel.WARNING
 )
@@ -326,7 +318,7 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.forEffectEval(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mproduct(SL, arg1)",
+  "this.mproduct(SL, arg1)",
   "arrow.core.mproduct"
   ),
   DeprecationLevel.WARNING
@@ -348,7 +340,7 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.mproduct(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "ifM(SL, arg1, arg2)",
+  "this.ifM(SL, arg1, arg2)",
   "arrow.core.ifM"
   ),
   DeprecationLevel.WARNING
@@ -371,7 +363,7 @@ fun <L, B> Kind<Kind<ForIor, L>, Boolean>.ifM(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "selectM(SL, arg1)",
+  "this.selectM(SL, arg1)",
   "arrow.core.selectM"
   ),
   DeprecationLevel.WARNING
@@ -393,8 +385,8 @@ fun <L, A, B> Kind<Kind<ForIor, L>, Either<A, B>>.selectM(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "select(SL, arg1)",
-  "arrow.core.select"
+    "this.selectM(SL, arg1)",
+    "arrow.core.selectM"
   ),
   DeprecationLevel.WARNING
 )
@@ -419,6 +411,10 @@ fun <L, A, B> Kind<Kind<ForIor, L>, Either<A, B>>.select(
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Monad typeclass is deprecated. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
 )
 inline fun <L> Companion.monad(SL: Semigroup<L>): IorMonad<L> = object :
     arrow.core.extensions.IorMonad<L> { override fun SL(): arrow.typeclasses.Semigroup<L> = SL }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/order/IorOrder.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/order/IorOrder.kt
@@ -16,8 +16,8 @@ import arrow.typeclasses.Order
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "this.compareTo(OL, OR, arg1)",
-  "arrow.core.compareTo"
+    "this.compareTo(arg1)",
+    "arrow.core.compareTo"
   ),
   DeprecationLevel.WARNING
 )
@@ -39,8 +39,8 @@ fun <L, R> Ior<L, R>.compareTo(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "this.eqv(OL, OR, arg1)",
-  "arrow.core.eqv"
+    "this.compareTo(arg1) == 0",
+    "arrow.core.compareTo"
   ),
   DeprecationLevel.WARNING
 )
@@ -62,8 +62,8 @@ fun <L, R> Ior<L, R>.eqv(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "this.lt(OL, OR, arg1)",
-  "arrow.core.lt"
+    "this < arg1",
+    "arrow.core.compareTo"
   ),
   DeprecationLevel.WARNING
 )
@@ -85,8 +85,8 @@ fun <L, R> Ior<L, R>.lt(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "this.lte(OL, OR, arg1)",
-  "arrow.core.lte"
+    "this <= arg1",
+    "arrow.core.compareTo"
   ),
   DeprecationLevel.WARNING
 )
@@ -108,8 +108,8 @@ fun <L, R> Ior<L, R>.lte(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "this.gt(OL, OR, arg1)",
-  "arrow.core.gt"
+    "this > arg1",
+    "arrow.core.compareTo"
   ),
   DeprecationLevel.WARNING
 )
@@ -131,8 +131,8 @@ fun <L, R> Ior<L, R>.gt(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "this.gte(OL, OR, arg1)",
-  "arrow.core.gte"
+    "this >= arg1",
+    "arrow.core.compareTo"
   ),
   DeprecationLevel.WARNING
 )
@@ -154,8 +154,8 @@ fun <L, R> Ior<L, R>.gte(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "this.max(OL, OR, arg1)",
-  "arrow.core.max"
+    "if (this > arg1) this else arg1",
+    "arrow.core.compareTo"
   ),
   DeprecationLevel.WARNING
 )
@@ -177,8 +177,8 @@ fun <L, R> Ior<L, R>.max(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "this.min(OL, OR, arg1)",
-  "arrow.core.min"
+    "if (this < arg1) this else arg1",
+    "arrow.core.compareTo"
   ),
   DeprecationLevel.WARNING
 )
@@ -200,8 +200,8 @@ fun <L, R> Ior<L, R>.min(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "this.sort(OL, OR, arg1)",
-  "arrow.core.sort"
+    "if (this < arg1) this toT arg1 else arg1 toT this",
+    "arrow.core.compareTo", "arrow.core.toT"
   ),
   DeprecationLevel.WARNING
 )
@@ -218,12 +218,8 @@ fun <L, R> Ior<L, R>.sort(
   "NOTHING_TO_INLINE"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "Order.ior(OL, OR)",
-    "arrow.core.ior", "arrow.typeclasses.Order"
-  ),
-  DeprecationLevel.WARNING
+  "Order typeclass is deprecated. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
 )
 inline fun <L, R> Companion.order(OL: Order<L>, OR: Order<R>): IorOrder<L, R> = object :
     arrow.core.extensions.IorOrder<L, R> { override fun OL(): arrow.typeclasses.Order<L> = OL

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/order/IorOrder.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/order/IorOrder.kt
@@ -5,11 +5,6 @@ import arrow.core.Ior.Companion
 import arrow.core.Tuple2
 import arrow.core.extensions.IorOrder
 import arrow.typeclasses.Order
-import kotlin.Boolean
-import kotlin.Deprecated
-import kotlin.Int
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 @JvmName("compareTo")
 @Suppress(
@@ -21,7 +16,7 @@ import kotlin.jvm.JvmName
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "compareTo(OL, OR, arg1)",
+  "this.compareTo(OL, OR, arg1)",
   "arrow.core.compareTo"
   ),
   DeprecationLevel.WARNING
@@ -44,7 +39,7 @@ fun <L, R> Ior<L, R>.compareTo(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "eqv(OL, OR, arg1)",
+  "this.eqv(OL, OR, arg1)",
   "arrow.core.eqv"
   ),
   DeprecationLevel.WARNING
@@ -67,7 +62,7 @@ fun <L, R> Ior<L, R>.eqv(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "lt(OL, OR, arg1)",
+  "this.lt(OL, OR, arg1)",
   "arrow.core.lt"
   ),
   DeprecationLevel.WARNING
@@ -90,7 +85,7 @@ fun <L, R> Ior<L, R>.lt(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "lte(OL, OR, arg1)",
+  "this.lte(OL, OR, arg1)",
   "arrow.core.lte"
   ),
   DeprecationLevel.WARNING
@@ -113,7 +108,7 @@ fun <L, R> Ior<L, R>.lte(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "gt(OL, OR, arg1)",
+  "this.gt(OL, OR, arg1)",
   "arrow.core.gt"
   ),
   DeprecationLevel.WARNING
@@ -136,7 +131,7 @@ fun <L, R> Ior<L, R>.gt(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "gte(OL, OR, arg1)",
+  "this.gte(OL, OR, arg1)",
   "arrow.core.gte"
   ),
   DeprecationLevel.WARNING
@@ -159,7 +154,7 @@ fun <L, R> Ior<L, R>.gte(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "max(OL, OR, arg1)",
+  "this.max(OL, OR, arg1)",
   "arrow.core.max"
   ),
   DeprecationLevel.WARNING
@@ -182,7 +177,7 @@ fun <L, R> Ior<L, R>.max(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "min(OL, OR, arg1)",
+  "this.min(OL, OR, arg1)",
   "arrow.core.min"
   ),
   DeprecationLevel.WARNING
@@ -205,7 +200,7 @@ fun <L, R> Ior<L, R>.min(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "sort(OL, OR, arg1)",
+  "this.sort(OL, OR, arg1)",
   "arrow.core.sort"
   ),
   DeprecationLevel.WARNING
@@ -221,6 +216,14 @@ fun <L, R> Ior<L, R>.sort(
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "@extension kinded projected functions are deprecated",
+  ReplaceWith(
+    "Order.ior(OL, OR)",
+    "arrow.core.ior", "arrow.typeclasses.Order"
+  ),
+  DeprecationLevel.WARNING
 )
 inline fun <L, R> Companion.order(OL: Order<L>, OR: Order<R>): IorOrder<L, R> = object :
     arrow.core.extensions.IorOrder<L, R> { override fun OL(): arrow.typeclasses.Order<L> = OL

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/semigroup/IorSemigroup.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/semigroup/IorSemigroup.kt
@@ -4,9 +4,6 @@ import arrow.core.Ior
 import arrow.core.Ior.Companion
 import arrow.core.extensions.IorSemigroup
 import arrow.typeclasses.Semigroup
-import kotlin.Deprecated
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 @JvmName("plus")
 @Suppress(
@@ -18,8 +15,8 @@ import kotlin.jvm.JvmName
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "plus(SGL, SGR, arg1)",
-  "arrow.core.plus"
+  "this.combine(SGL, SGR, arg1)",
+  "arrow.core.combine"
   ),
   DeprecationLevel.WARNING
 )
@@ -41,8 +38,8 @@ fun <L, R> Ior<L, R>.plus(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "maybeCombine(SGL, SGR, arg1)",
-  "arrow.core.maybeCombine"
+    "this.combine(SGL, SGR, arg1)",
+    "arrow.core.combine"
   ),
   DeprecationLevel.WARNING
 )
@@ -57,6 +54,14 @@ fun <L, R> Ior<L, R>.maybeCombine(
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "@extension kinded projected functions are deprecated",
+  ReplaceWith(
+    "Semigroup.ior(SGL, SGR)",
+    "arrow.core.ior", "arrow.typeclasses.Semigroup"
+  ),
+  DeprecationLevel.WARNING
 )
 inline fun <L, R> Companion.semigroup(SGL: Semigroup<L>, SGR: Semigroup<R>): IorSemigroup<L, R> =
     object : arrow.core.extensions.IorSemigroup<L, R> { override fun SGL():

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/show/IorShow.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/show/IorShow.kt
@@ -3,19 +3,14 @@ package arrow.core.extensions.ior.show
 import arrow.core.Ior.Companion
 import arrow.core.extensions.IorShow
 import arrow.typeclasses.Show
-import kotlin.Suppress
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "Show.ior(HL, HR)",
-    "arrow.core.ior", "arrow.typeclasses.Show"
-  ),
-  DeprecationLevel.WARNING
+  "Show typeclass is deprecated. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
 )
 inline fun <L, R> Companion.show(SL: Show<L>, SR: Show<R>): IorShow<L, R> = object :
     arrow.core.extensions.IorShow<L, R> { override fun SL(): arrow.typeclasses.Show<L> = SL

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/show/IorShow.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/show/IorShow.kt
@@ -9,6 +9,14 @@ import kotlin.Suppress
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated(
+  "@extension kinded projected functions are deprecated",
+  ReplaceWith(
+    "Show.ior(HL, HR)",
+    "arrow.core.ior", "arrow.typeclasses.Show"
+  ),
+  DeprecationLevel.WARNING
+)
 inline fun <L, R> Companion.show(SL: Show<L>, SR: Show<R>): IorShow<L, R> = object :
     arrow.core.extensions.IorShow<L, R> { override fun SL(): arrow.typeclasses.Show<L> = SL
 

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/traverse/IorTraverse.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/traverse/IorTraverse.kt
@@ -7,12 +7,6 @@ import arrow.core.Ior.Companion
 import arrow.core.extensions.IorTraverse
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Monad
-import kotlin.Any
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -28,12 +22,8 @@ internal val traverse_singleton: IorTraverse<Any?> = object : IorTraverse<Any?> 
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "traverse(arg1, arg2)",
-  "arrow.core.traverse"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated. Replace with traverse, traverseEither or traverseValidated from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <L, G, A, B> Kind<Kind<ForIor, L>, A>.traverse(
   arg1: Applicative<G>,
@@ -51,7 +41,7 @@ fun <L, G, A, B> Kind<Kind<ForIor, L>, A>.traverse(
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
+  "@extension kinded projected functions are deprecated. Replace with sequence, sequenceEither or sequenceValidated from arrow.core.*",
   ReplaceWith(
   "sequence(arg1)",
   "arrow.core.sequence"
@@ -74,8 +64,7 @@ fun <L, G, A> Kind<Kind<ForIor, L>, Kind<G, A>>.sequence(arg1: Applicative<G>): 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg1)",
-  "arrow.core.map"
+  "this.map(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -92,12 +81,8 @@ fun <L, A, B> Kind<Kind<ForIor, L>, A>.map(arg1: Function1<A, B>): Ior<L, B> =
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "flatTraverse(arg1, arg2, arg3)",
-  "arrow.core.flatTraverse"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated. Replace with flatTraverse, flatTraverseEither or flatTraverseValidated from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <L, G, A, B> Kind<Kind<ForIor, L>, A>.flatTraverse(
   arg1: Monad<Kind<ForIor, L>>,
@@ -111,6 +96,10 @@ fun <L, G, A, B> Kind<Kind<ForIor, L>, A>.flatTraverse(
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Traverse typeclass is deprecated. Use concrete methods on Ior",
+  level = DeprecationLevel.WARNING
 )
 inline fun <L> Companion.traverse(): IorTraverse<L> = traverse_singleton as
     arrow.core.extensions.IorTraverse<L>


### PR DESCRIPTION
- [x] Applicative
- [x] Apply
- [x] Bicrosswalk
- [x] Bifoldable
- [x] Bifunctor
- [x] Bitraverse
- [x] Crosswalk
- [x] Eq (EqK, EqK2)
- [x] Foldable
- [x] Functor
- [x] Hash
- [x] Monad
- [x] Order
- [x] Semigroup
- [x] Show
- [x] Traverse