### PR TITLE
CU-cn1pxw Deprecate AndThen and always use underneath `andThen` and `compose`.

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/AndThen.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/AndThen.kt
@@ -1,13 +1,41 @@
 package arrow.core
 
+@Deprecated(
+  "Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead",
+  level = DeprecationLevel.WARNING
+)
 class ForAndThen private constructor() { companion object }
+
+@Deprecated(
+  "Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead",
+  level = DeprecationLevel.WARNING
+)
 typealias AndThenOf<A, B> = arrow.Kind2<ForAndThen, A, B>
+
+@Deprecated(
+  "Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead",
+  level = DeprecationLevel.WARNING
+)
 typealias AndThenPartialOf<A> = arrow.Kind<ForAndThen, A>
+
+@Deprecated(
+  "Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead",
+  level = DeprecationLevel.WARNING
+)
 typealias AndThenKindedJ<A, B> = arrow.HkJ2<ForAndThen, A, B>
+
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
+@Deprecated(
+  "Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead",
+  level = DeprecationLevel.WARNING
+)
 inline fun <A, B> AndThenOf<A, B>.fix(): AndThen<A, B> =
   this as AndThen<A, B>
 
+@Deprecated(
+  "Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead",
+  level = DeprecationLevel.WARNING
+)
 operator fun <A, B> AndThenOf<A, B>.invoke(a: A): B = fix().invoke(a)
 
 /**
@@ -41,6 +69,10 @@ operator fun <A, B> AndThenOf<A, B>.invoke(a: A): B = fix().invoke(a)
  * ```
  *
  */
+@Deprecated(
+  "AndThen is becoming an internal data type that automatically tries to make andThen stack safe",
+  level = DeprecationLevel.WARNING
+)
 sealed class AndThen<A, B> : (A) -> B, AndThenOf<A, B> {
 
   private data class Single<A, B>(val f: (A) -> B, val index: Int) : AndThen<A, B>()
@@ -80,7 +112,7 @@ sealed class AndThen<A, B> : (A) -> B, AndThenOf<A, B> {
     when (this) {
       // Fusing calls up to a certain threshold
       is Single ->
-        if (index != maxStackDepthSize) Single(f andThen g, index + 1)
+        if (index != maxStackDepthSize) Single({ a: A -> g(this(a)) }, index + 1)
         else andThenF(AndThen(g))
       else -> andThenF(AndThen(g))
     }
@@ -90,11 +122,10 @@ sealed class AndThen<A, B> : (A) -> B, AndThenOf<A, B> {
    *
    * ```kotlin:ank:playground
    * import arrow.core.AndThen
-   * import arrow.core.extensions.list.foldable.foldLeft
    *
    * fun main(args: Array<String>) {
    *   //sampleStart
-   *   val f = (0..10000).toList().foldLeft(AndThen { i: Int -> i + 1 }) { acc, _ ->
+   *   val f = (0..10000).fold(AndThen { i: Int -> i + 1 }) { acc, _ ->
    *     acc.compose { it + 1 }
    *   }
    *
@@ -112,7 +143,7 @@ sealed class AndThen<A, B> : (A) -> B, AndThenOf<A, B> {
     when (this) {
       // Fusing calls up to a certain threshold
       is Single ->
-        if (index != maxStackDepthSize) Single(f compose g, index + 1)
+        if (index != maxStackDepthSize) Single({ c: C -> this(g(c)) }, index + 1)
         else composeF(AndThen(g))
       else -> composeF(AndThen(g))
     }

--- a/arrow-core-data/src/main/kotlin/arrow/core/predef.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/predef.kt
@@ -4,9 +4,11 @@ inline fun <A> identity(a: A): A = a
 
 inline fun <A, B, Z> ((A, B) -> Z).curry(): (A) -> (B) -> Z = { p1: A -> { p2: B -> this(p1, p2) } }
 
-inline infix fun <A, B, C> ((B) -> C).compose(crossinline f: (A) -> B): (A) -> C = { a: A -> this(f(a)) }
+infix fun <A, B, C> ((B) -> C).compose(f: (A) -> B): (A) -> C =
+  AndThen(this).compose(f)
 
-inline infix fun <A, B, C> ((A) -> B).andThen(crossinline g: (B) -> C): (A) -> C = { a: A -> g(this(a)) }
+infix fun <A, B, C> ((A) -> B).andThen(g: (B) -> C): (A) -> C =
+  AndThen(this).andThen(g)
 
 internal object ArrowCoreInternalException : RuntimeException(
   "Arrow-Core internal error. Please let us know and create a ticket at https://github.com/arrow-kt/arrow-core/issues/new/choose",

--- a/arrow-syntax/src/main/kotlin/arrow/syntax/function/AndThenN.kt
+++ b/arrow-syntax/src/main/kotlin/arrow/syntax/function/AndThenN.kt
@@ -1,0 +1,240 @@
+package arrow.syntax.function
+
+/**
+ * Establishes the maximum stack depth when fusing `andThen` or `compose` calls.
+ *
+ * The default is `128`, from which we substract one as an
+ * optimization. This default has been reached like this:
+ *
+ *  - according to official docs, the default stack size on 32-bits
+ *    Windows and Linux was 320 KB, whereas for 64-bits it is 1024 KB
+ *  - according to measurements chaining `Function1` references uses
+ *    approximately 32 bytes of stack space on a 64 bits system;
+ *    this could be lower if "compressed oops" is activated
+ *  - therefore a "map fusion" that goes 128 in stack depth can use
+ *    about 4 KB of stack space
+ */
+@PublishedApi
+internal const val maxStackDepthSize = 127
+
+@PublishedApi
+internal sealed class AndThen0<A> : () -> A {
+
+  @PublishedApi
+  internal data class Single<A>(val f: () -> A, val index: Int) : AndThen0<A>()
+
+  private data class Concat<A, B>(val left: AndThen0<A>, val right: AndThen1<A, B>) : AndThen0<B>() {
+    override fun toString(): String = "AndThen.Concat(...)"
+  }
+
+  fun <X> andThen(g: (A) -> X): AndThen0<X> =
+    when (this) {
+      // Fusing calls up to a certain threshold
+      is Single ->
+        if (index != maxStackDepthSize) Single({ g(f()) }, index + 1)
+        else andThenF(AndThen1(g))
+      else -> andThenF(AndThen1(g))
+    }
+
+  @Suppress("UNCHECKED_CAST")
+  override fun invoke(): A =
+    loop(this as AndThen0<Any?>, Unit, 0)
+
+  override fun toString(): String =
+    "AndThen0(...)"
+
+  companion object {
+
+    operator fun <A> invoke(f: () -> A): AndThen0<A> =
+      when (f) {
+        is AndThen0<A> -> f
+        else -> Single(f, 0)
+      }
+
+    @Suppress("UNCHECKED_CAST")
+    tailrec fun <A> loop(self: AndThen0<Any?>, current: Any?, joins: Int): A = when (self) {
+      is Single -> if (joins == 0) self.f() as A else loop(self.f() as AndThen0<Any?>, null, joins - 1)
+      is Concat<*, *> -> {
+        when (val oldLeft = self.left) {
+          is Single<*> -> {
+            val left = oldLeft as Single<Any?>
+            val newSelf = self.right as AndThen1<Any?, Any?>
+            AndThen1.loop(newSelf, left.f(), joins)
+          }
+          is Concat<*, *> -> loop(
+            rotateAccumulate(self.left as AndThen0<Any?>, self.right as AndThen1<Any?, Any?>),
+            current,
+            joins
+          )
+        }
+      }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    tailrec fun rotateAccumulate(
+      left: AndThen0<Any?>,
+      right: AndThen1<Any?, Any?>
+    ): AndThen0<Any?> = when (left) {
+      is Concat<*, *> -> rotateAccumulate(
+        left.left as AndThen0<Any?>,
+        (left.right as AndThen1<Any?, Any?>).andThenF(right)
+      )
+      is Single<*> -> left.andThenF(right)
+    }
+  }
+
+  fun <X> andThenF(right: AndThen1<A, X>): AndThen0<X> =
+    Concat(this, right)
+}
+
+@PublishedApi
+internal sealed class AndThen1<A, B> : (A) -> B {
+
+  private data class Single<A, B>(val f: (A) -> B, val index: Int) : AndThen1<A, B>()
+
+  private data class Concat<A, E, B>(val left: AndThen1<A, E>, val right: AndThen1<E, B>) : AndThen1<A, B>() {
+    override fun toString(): String = "AndThen.Concat(...)"
+  }
+
+  fun <X> andThen(g: (B) -> X): AndThen1<A, X> =
+    when (this) {
+      // Fusing calls up to a certain threshold
+      is Single ->
+        if (index != maxStackDepthSize) Single({ a: A -> g(this(a)) }, index + 1)
+        else andThenF(AndThen1(g))
+      else -> andThenF(AndThen1(g))
+    }
+
+  infix fun <C> compose(g: (C) -> A): AndThen1<C, B> =
+    when (this) {
+      // Fusing calls up to a certain threshold
+      is Single ->
+        if (index != maxStackDepthSize) Single({ c: C -> this(g(c)) }, index + 1)
+        else composeF(AndThen1(g))
+      else -> composeF(AndThen1(g))
+    }
+
+  @Suppress("UNCHECKED_CAST")
+  override fun invoke(a: A): B = loop(this as AndThen1<Any?, Any?>, a, 0)
+
+  override fun toString(): String = "AndThen(...)"
+
+  companion object {
+
+    operator fun <A, B> invoke(f: (A) -> B): AndThen1<A, B> =
+      when (f) {
+        is AndThen1<A, B> -> f
+        else -> Single(f, 0)
+      }
+
+    @Suppress("UNCHECKED_CAST")
+    tailrec fun <B> loop(self: AndThen1<Any?, Any?>, current: Any?, joins: Int): B = when (self) {
+      is Single -> if (joins == 0) self.f(current) as B else loop(self.f(current) as AndThen1<Any?, Any?>, null, joins - 1)
+      is Concat<*, *, *> -> {
+        when (val oldLeft = self.left) {
+          is Single<*, *> -> {
+            val left = oldLeft as Single<Any?, Any?>
+            val newSelf = self.right as AndThen1<Any?, Any?>
+            loop(newSelf, left.f(current), joins)
+          }
+          is Concat<*, *, *> -> loop(
+            rotateAccumulate(self.left as AndThen1<Any?, Any?>, self.right as AndThen1<Any?, Any?>),
+            current,
+            joins
+          )
+        }
+      }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    tailrec fun rotateAccumulate(
+      left: AndThen1<Any?, Any?>,
+      right: AndThen1<Any?, Any?>
+    ): AndThen1<Any?, Any?> = when (left) {
+      is Concat<*, *, *> -> rotateAccumulate(
+        left.left as AndThen1<Any?, Any?>,
+        (left.right as AndThen1<Any?, Any?>).andThenF(right)
+      )
+      is Single<*, *> -> left.andThenF(right)
+    }
+  }
+
+  fun <X> andThenF(right: AndThen1<B, X>): AndThen1<A, X> =
+    Concat(this, right)
+
+  fun <X> composeF(right: AndThen1<X, A>): AndThen1<X, B> =
+    Concat(right, this)
+}
+
+@PublishedApi
+internal sealed class AndThen2<A, B, C> : (A, B) -> C {
+
+  private data class Single<A, B, C>(val f: (A, B) -> C, val index: Int) : AndThen2<A, B, C>()
+
+  private data class Concat<A, E, B, C>(val left: AndThen2<A, E, B>, val right: AndThen1<B, C>) : AndThen2<A, E, C>() {
+    override fun toString(): String = "AndThen.Concat(...)"
+  }
+
+  fun <X> andThen(g: (C) -> X): AndThen2<A, B, X> =
+    when (this) {
+      // Fusing calls up to a certain threshold
+      is Single ->
+        if (index != maxStackDepthSize) Single({ a: A, b: B -> g(this(a, b)) }, index + 1)
+        else andThenF(AndThen1(g))
+      else -> andThenF(AndThen1(g))
+    }
+
+  @Suppress("UNCHECKED_CAST")
+  override fun invoke(a: A, b: B): C =
+    loop(this as AndThen2<Any?, Any?, Any?>, a, b, 0)
+
+  override fun toString(): String = "AndThen(...)"
+
+  companion object {
+
+    operator fun <A, B, C> invoke(f: (A, B) -> C): AndThen2<A, B, C> =
+      when (f) {
+        is AndThen2<A, B, C> -> f
+        else -> Single(f, 0)
+      }
+
+    @Suppress("UNCHECKED_CAST")
+    tailrec fun <C> loop(self: AndThen2<Any?, Any?, Any?>, currentA: Any?, currentB: Any?, joins: Int): C = when (self) {
+      is Single<*, *, *> -> {
+        val f = self.f as ((Any?, Any?) -> Any?)
+        if (joins == 0) f(currentA, currentB) as C
+        else loop(f(currentA, currentB) as AndThen2<Any?, Any?, Any?>, null, null, joins - 1)
+      }
+      is Concat<*, *, *, *> -> {
+        when (val oldLeft = self.left) {
+          is Single<*, *, *> -> {
+            val left = oldLeft as Single<Any?, Any?, Any?>
+            val newSelf = self.right as AndThen1<Any?, Any?>
+            AndThen1.loop(newSelf, left.f(currentA, currentB), joins)
+          }
+          is Concat<*, *, *, *> -> loop(
+            rotateAccumulate(self.left as AndThen2<Any?, Any?, Any?>, self.right as AndThen1<Any?, Any?>),
+            currentA,
+            currentB,
+            joins
+          )
+        }
+      }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    tailrec fun rotateAccumulate(
+      left: AndThen2<Any?, Any?, Any?>,
+      right: AndThen1<Any?, Any?>
+    ): AndThen2<Any?, Any?, Any?> = when (left) {
+      is Concat<*, *, *, *> -> rotateAccumulate(
+        left.left as AndThen2<Any?, Any?, Any?>,
+        (left.right as AndThen1<Any?, Any?>).andThenF(right)
+      )
+      is Single<*, *, *> -> left.andThenF(right)
+    }
+  }
+
+  fun <X> andThenF(right: AndThen1<C, X>): AndThen2<A, B, X> =
+    Concat(this, right)
+}

--- a/arrow-syntax/src/main/kotlin/arrow/syntax/function/composition.kt
+++ b/arrow-syntax/src/main/kotlin/arrow/syntax/function/composition.kt
@@ -1,15 +1,34 @@
 package arrow.syntax.function
 
-inline infix fun <P1, P2, IP, R> ((P1, P2) -> IP).andThen(crossinline f: (IP) -> R) = forwardCompose(f)
+infix fun <P1, P2, IP, R> ((P1, P2) -> IP).andThen(f: (IP) -> R): (P1, P2) -> R =
+  AndThen2(this).andThen(f)
 
-inline infix fun <P1, IP, R> ((P1) -> IP).andThen(crossinline f: (IP) -> R): (P1) -> R = forwardCompose(f)
+infix fun <P1, IP, R> ((P1) -> IP).andThen(f: (IP) -> R): (P1) -> R =
+  AndThen1(this).andThen(f)
 
-inline infix fun <IP, R> (() -> IP).andThen(crossinline f: (IP) -> R): () -> R = forwardCompose(f)
+infix fun <IP, R> (() -> IP).andThen(f: (IP) -> R): () -> R =
+  AndThen0(this).andThen(f)
 
-inline infix fun <P1, P2, IP, R> ((P1, P2) -> IP).forwardCompose(crossinline f: (IP) -> R) = { p1: P1, p2: P2 -> f(this(p1, p2)) }
+@Deprecated(
+  "Use andThen instead of forwardCompose.",
+  ReplaceWith("this andThen f", "arrow.syntax.function.andThen")
+)
+infix fun <P1, P2, IP, R> ((P1, P2) -> IP).forwardCompose(f: (IP) -> R) =
+  this andThen f
 
-inline infix fun <P1, IP, R> ((P1) -> IP).forwardCompose(crossinline f: (IP) -> R): (P1) -> R = { p1: P1 -> f(this(p1)) }
+@Deprecated(
+  "Use andThen instead of forwardCompose.",
+  ReplaceWith("this andThen f", "arrow.syntax.function.andThen")
+)
+infix fun <P1, IP, R> ((P1) -> IP).forwardCompose(f: (IP) -> R): (P1) -> R =
+  this andThen f
 
-inline infix fun <IP, R> (() -> IP).forwardCompose(crossinline f: (IP) -> R): () -> R = { f(this()) }
+@Deprecated(
+  "Use andThen instead of forwardCompose.",
+  ReplaceWith("this andThen f", "arrow.syntax.function.andThen")
+)
+infix fun <IP, R> (() -> IP).forwardCompose(f: (IP) -> R): () -> R =
+  this andThen f
 
-inline infix fun <IP, R, P1> ((IP) -> R).compose(crossinline f: (P1) -> IP): (P1) -> R = { p1: P1 -> this(f(p1)) }
+infix fun <IP, R, P1> ((IP) -> R).compose(f: (P1) -> IP): (P1) -> R =
+  AndThen1(this).compose(f)

--- a/arrow-syntax/src/test/kotlin/arrow/syntax/test/AndThenTests.kt
+++ b/arrow-syntax/src/test/kotlin/arrow/syntax/test/AndThenTests.kt
@@ -1,0 +1,144 @@
+package arrow.syntax.test
+
+import arrow.core.test.generators.functionAToB
+import arrow.syntax.function.andThen
+import arrow.syntax.function.compose
+import io.kotlintest.properties.Gen
+import io.kotlintest.properties.forAll
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.FreeSpec
+
+class AndThenTests : FreeSpec() {
+
+  init {
+    val count = 500000
+
+    "AndThen0" - {
+      "compose a chain of functions with andThen should be same with AndThen" {
+        forAll(Gen.int(), Gen.list(Gen.functionAToB<Int, Int>(Gen.int()))) { i, fs ->
+          val result = fs.fold({ i }) { acc, f ->
+            { f(acc()) }
+          }.invoke()
+
+          val expect = fs.fold({ i }) { acc, f ->
+            acc.andThen(f)
+          }.invoke()
+
+          result == expect
+        }
+      }
+
+      "compose a chain of function with compose should be same with AndThen" {
+        forAll(Gen.int(), Gen.list(Gen.functionAToB<Int, Int>(Gen.int()))) { i, fs ->
+          val result = fs.fold({ x: Int -> x }) { acc, f ->
+            { x: Int -> acc(f(x)) }
+          }.invoke(i)
+
+          val expect = fs.fold({ x: Int -> x }) { acc, b ->
+            acc.compose(b)
+          }.invoke(i)
+
+          result == expect
+        }
+      }
+
+      val count = 500000
+
+      "andThen is stack safe" {
+        val result = (0 until count).fold({ 0 }) { acc, _ ->
+          acc.andThen { it + 1 }
+        }.invoke()
+
+        result shouldBe count
+      }
+
+      "toString is stack safe" {
+        (0 until count).fold({ x: Int -> x }) { acc, _ ->
+          acc.compose { it + 1 }
+        }.toString() shouldBe "AndThen.Concat(...)"
+      }
+    }
+
+    "AndThen1" - {
+      "compose a chain of functions with andThen should be same with AndThen" {
+        forAll(Gen.int(), Gen.list(Gen.functionAToB<Int, Int>(Gen.int()))) { i, fs ->
+          val result = fs.fold({ x: Int -> x }) { acc, f ->
+            { x: Int -> f(acc(x)) }
+          }.invoke(i)
+
+          val expect = fs.fold({ x: Int -> x }) { acc, f ->
+            acc.andThen(f)
+          }.invoke(i)
+
+          result == expect
+        }
+      }
+
+      "compose a chain of function with compose should be same with AndThen" {
+        forAll(Gen.int(), Gen.list(Gen.functionAToB<Int, Int>(Gen.int()))) { i, fs ->
+          val result = fs.fold({ x: Int -> x }) { acc, f ->
+            { x: Int -> acc(f(x)) }
+          }.invoke(i)
+
+          val expect = fs.fold({ x: Int -> x }) { acc, b ->
+            acc.compose(b)
+          }.invoke(i)
+
+          result == expect
+        }
+      }
+
+      "andThen is stack safe" {
+        val result = (0 until count).fold({ x: Int -> x }) { acc, _ ->
+          acc.andThen { it + 1 }
+        }.invoke(0)
+
+        result shouldBe count
+      }
+
+      "compose is stack safe" {
+        val result = (0 until count).fold({ x: Int -> x }) { acc, _ ->
+          acc.compose { it + 1 }
+        }.invoke(0)
+
+        result shouldBe count
+      }
+
+      "toString is stack safe" {
+        (0 until count).fold({ x: Int -> x }) { acc, _ ->
+          acc.compose { it + 1 }
+        }.toString() shouldBe "AndThen.Concat(...)"
+      }
+    }
+
+    "AndThen2" - {
+      "compose a chain of functions with andThen should be same with AndThen" {
+        forAll(Gen.int(), Gen.int(), Gen.list(Gen.functionAToB<Int, Int>(Gen.int()))) { i, j, fs ->
+          val result = fs.fold({ x: Int, y: Int -> x + y }) { acc, f ->
+            { x: Int, y: Int -> f(acc(x, y)) }
+          }.invoke(i, j)
+
+          val expect = fs.fold({ x: Int, y: Int -> x + y }) { acc, f ->
+            acc.andThen(f)
+          }.invoke(i, j)
+
+          result == expect
+        }
+      }
+
+      "andThen is stack safe" {
+        val result = (0 until count).fold({ x: Int, y: Int -> x + y }) { acc, _ ->
+          acc.andThen { it + 1 }
+        }.invoke(0, 0)
+
+        result shouldBe count
+      }
+
+      "toString is stack safe" {
+        (0 until count).fold({ x: Int -> x }) { acc, _ ->
+          acc.compose { it + 1 }
+        }.toString() shouldBe "AndThen.Concat(...)"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR makes `AndThen` internal, and uses it under `andThen` and `compose` to automatically try and make them stack-safe.

The rationale of deprecating `AndThen` to make it `internal` is that `AndThen` cannot _guarantee_ stack-safety anyway. It makes the assumption that `val f: (A) -> B` is of depth `0`.
If `f` is not of depth `0`, it can still result in a stack-overflow.

`andThen` and `compose` are duplicated between `arrow-syntax`, and `arrow-core` but we might merge these two modules in the `0.13.0` release, at that point we can deprecate the `andThen` and `compose` in `arrow.core` in favor of `arrow.syntax.*` or the other way around.