### PR TITLE
Deprecate Show

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
@@ -4,6 +4,7 @@ import arrow.Kind
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 
 class ForConst private constructor() { companion object }
 typealias ConstOf<A, T> = arrow.Kind2<ForConst, A, T>
@@ -37,11 +38,12 @@ data class Const<A, out T>(private val value: A) : ConstOf<A, T> {
   fun value(): A =
     value
 
+  @Deprecated(ShowDeprecation)
   fun show(SA: Show<A>): String =
     "$Const(${SA.run { value.show() }})"
 
   override fun toString(): String =
-    show(Show.any())
+    "$Const($value)"
 }
 
 fun <A, T> ConstOf<A, T>.combine(SG: Semigroup<A>, that: ConstOf<A, T>): Const<A, T> =

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -1085,6 +1085,7 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
     }
   }
 
+  @Deprecated(ShowDeprecation)
   fun show(SL: Show<A>, SR: Show<B>): String = fold(
     { "Left(${SL.run { it.show() }})" },
     { "Right(${SR.run { it.show() }})" }

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -1063,7 +1063,7 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
     override val isLeft = true
     override val isRight = false
 
-    override fun toString(): String = show(Show.any(), Show.any())
+    override fun toString(): String = "Either.Left($a)"
 
     companion object {
       operator fun <A> invoke(a: A): Either<A, Nothing> = Left(a)
@@ -1078,7 +1078,7 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
     override val isLeft = false
     override val isRight = true
 
-    override fun toString(): String = show(Show.any(), Show.any())
+    override fun toString(): String = "Either.Right($b)"
 
     companion object {
       operator fun <B> invoke(b: B): Either<Nothing, B> = Right(b)
@@ -1086,12 +1086,13 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
   }
 
   fun show(SL: Show<A>, SR: Show<B>): String = fold(
-    {
-      "Left(${SL.run { it.show() }})"
-    },
-    {
-      "Right(${SR.run { it.show() }})"
-    }
+    { "Left(${SL.run { it.show() }})" },
+    { "Right(${SR.run { it.show() }})" }
+  )
+
+  override fun toString(): String = fold(
+    { "Either.Left($it)" },
+    { "Either.Right($it)" }
   )
 
   fun toValidatedNel(): ValidatedNel<A, B> =

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -10,6 +10,7 @@ import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import arrow.typeclasses.hashWithSalt
 
 @Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")

--- a/arrow-core-data/src/main/kotlin/arrow/core/Eval.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Eval.kt
@@ -290,6 +290,9 @@ sealed class Eval<out A> : EvalOf<A> {
   data class Now<out A>(val value: A) : Eval<A>() {
     override fun value(): A = value
     override fun memoize(): Eval<A> = this
+
+    override fun toString(): String =
+      "Eval.Now($value)"
   }
 
   /**
@@ -308,6 +311,9 @@ sealed class Eval<out A> : EvalOf<A> {
 
     override fun value(): A = value
     override fun memoize(): Eval<A> = this
+
+    override fun toString(): String =
+      "Eval.Later(f)"
   }
 
   /**
@@ -321,6 +327,9 @@ sealed class Eval<out A> : EvalOf<A> {
   data class Always<out A>(private val f: () -> A) : Eval<A>() {
     override fun value(): A = f()
     override fun memoize(): Eval<A> = Later(f)
+
+    override fun toString(): String =
+      "Eval.Always(f)"
   }
 
   /**
@@ -331,6 +340,9 @@ sealed class Eval<out A> : EvalOf<A> {
   data class Defer<out A>(val thunk: () -> Eval<A>) : Eval<A>() {
     override fun memoize(): Eval<A> = Memoize(this)
     override fun value(): A = collapse(this).value()
+
+    override fun toString(): String =
+      "Eval.Defer(thunk)"
   }
 
   /**
@@ -348,6 +360,9 @@ sealed class Eval<out A> : EvalOf<A> {
     abstract fun <S> run(s: S): Eval<A>
     override fun memoize(): Eval<A> = Memoize(this)
     override fun value(): A = evaluate(this)
+
+    override fun toString(): String =
+      "Eval.FlatMao(..)"
   }
 
   /**
@@ -363,7 +378,13 @@ sealed class Eval<out A> : EvalOf<A> {
     override fun value(): A = result.getOrElse {
       evaluate(eval).also { result = Some(it) }
     }
+
+    override fun toString(): String =
+      "Eval.Memoize($eval)"
   }
+
+  override fun toString(): String =
+    "Eval(...)"
 }
 
 fun <A, B> Iterator<A>.iterateRight(lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> {

--- a/arrow-core-data/src/main/kotlin/arrow/core/Eval.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Eval.kt
@@ -546,7 +546,7 @@ sealed class Eval<out A> : EvalOf<A> {
     override fun value(): A = evaluate(this)
 
     override fun toString(): String =
-      "Eval.FlatMao(..)"
+      "Eval.FlatMap(..)"
   }
 
   /**

--- a/arrow-core-data/src/main/kotlin/arrow/core/Iterable.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Iterable.kt
@@ -5,7 +5,6 @@ package arrow.core
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Semigroup
-import arrow.typeclasses.Show
 import kotlin.collections.foldRight as _foldRight
 
 inline fun <A, B> Iterable<A>.foldRight(initial: B, operation: (A, acc: B) -> B): B =
@@ -266,9 +265,6 @@ inline fun <A, B, C> Iterable<A>.rightPadZip(other: Iterable<B>, fa: (A, B?) -> 
  */
 fun <A, B> Iterable<A>.rightPadZip(other: Iterable<B>): List<Tuple2<A, B?>> =
   this.rightPadZip(other) { a, b -> a toT b }
-
-fun <A> Iterable<A>.show(SA: Show<A>): String = "[" +
-  joinToString(", ") { SA.run { it.show() } } + "]"
 
 @Suppress("UNCHECKED_CAST")
 private tailrec fun <A, B> go(

--- a/arrow-core-data/src/main/kotlin/arrow/core/List.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/List.kt
@@ -5,7 +5,6 @@ import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
 import arrow.typeclasses.Semigroup
-import arrow.typeclasses.Show
 import arrow.typeclasses.defaultSalt
 import arrow.typeclasses.hashWithSalt
 import kotlin.collections.plus as _plus
@@ -125,9 +124,3 @@ object ListMonoid : Monoid<List<Any?>> {
   override fun empty(): List<Any?> = emptyList()
   override fun List<Any?>.combine(b: List<Any?>): List<Any?> = this._plus(b)
 }
-
-fun <A> Show.Companion.list(SA: Show<A>): Show<List<A>> =
-  object : Show<List<A>> {
-    override fun List<A>.show(): String =
-      show(SA)
-  }

--- a/arrow-core-data/src/main/kotlin/arrow/core/ListK.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/ListK.kt
@@ -3,8 +3,11 @@ package arrow.core
 import arrow.Kind
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 
-class ForListK private constructor() { companion object }
+class ForListK private constructor() {
+  companion object
+}
 typealias ListKOf<A> = arrow.Kind<ForListK, A>
 
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
@@ -420,10 +423,13 @@ data class ListK<out A>(private val list: List<A>) : ListKOf<A>, List<A> by list
   ): ListK<Tuple2<A, B?>> =
     this.rightPadZip(other) { a, b -> a toT b }
 
-  fun show(SA: Show<A>): String = "[" +
-    list.joinToString(", ") { SA.run { it.show() } } + "]"
+  @Deprecated(ShowDeprecation)
+  fun show(SA: Show<A>): String = SA.run {
+    joinToString(prefix = "[", separator = ", ", postfix = "]") { it.show() }
+  }
 
-  override fun toString(): String = show(Show.any())
+  override fun toString(): String =
+   list.toString()
 
   companion object {
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/MapK.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/MapK.kt
@@ -3,6 +3,7 @@ package arrow.core
 import arrow.Kind
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 
 @Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
 class ForMapK private constructor() { companion object }
@@ -54,9 +55,11 @@ data class MapK<K, out A>(private val map: Map<K, A>) : MapKOf<K, A>, Map<K, A> 
     }.value()
   }
 
+  @Deprecated(ShowDeprecation)
   fun show(SK: Show<K>, SA: Show<A>): String = "Map(${toList().k().map { it.toTuple2() }.show(Show { show(SK, SA) })})"
 
-  override fun toString(): String = show(Show.any(), Show.any())
+  override fun toString(): String =
+    map.toString()
 
   override fun equals(other: Any?): Boolean =
     when (other) {

--- a/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
@@ -8,6 +8,7 @@ import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 
 @Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
 class ForNonEmptyList private constructor() { companion object }
@@ -306,11 +307,12 @@ class NonEmptyList<out A>(
   override fun hashCode(): Int =
     all.hashCode()
 
+  @Deprecated(ShowDeprecation)
   fun show(SA: Show<A>): String =
     "NonEmptyList(${all.k().show(SA)})"
 
   override fun toString(): String =
-    show(Show.any())
+    "NonEmptyList(${all.joinToString()})"
 
   fun <B> align(b: NonEmptyList<B>): NonEmptyList<Ior<A, B>> =
     NonEmptyList(Ior.Both(head, b.head), tail.align(b.tail))
@@ -664,9 +666,6 @@ fun <A> Order.Companion.nonEmptyList(OA: Order<A>): Order<NonEmptyList<A>> =
 fun <A> Semigroup.Companion.nonEmptyList(): Semigroup<NonEmptyList<A>> =
   NonEmptyListSemigroup as Semigroup<NonEmptyList<A>>
 
-fun <A> Show.Companion.nonEmptyList(SA: Show<A>): Show<NonEmptyList<A>> =
-  NonEmptyListShow(SA)
-
 private class NonEmptyListEq<A>(
   private val EQA: Eq<A>,
 ) : Eq<NonEmptyList<A>> {
@@ -690,12 +689,6 @@ private class NonEmptyListOrder<A>(
 object NonEmptyListSemigroup : Semigroup<NonEmptyList<Any?>> {
   override fun NonEmptyList<Any?>.combine(b: NonEmptyList<Any?>): NonEmptyList<Any?> =
     NonEmptyList(this.head, this.tail.plus(b))
-}
-
-private class NonEmptyListShow<A>(
-  private val SA: Show<A>,
-) : Show<NonEmptyList<A>> {
-  override fun NonEmptyList<A>.show(): String = show(SA)
 }
 
 fun <A, B, Z> NonEmptyList<A>.zip(fb: NonEmptyList<B>, f: (A, B) -> Z): NonEmptyList<Z> =

--- a/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
@@ -960,25 +960,26 @@ sealed class Option<out A> : OptionOf<A> {
     DeprecationLevel.WARNING
   )
   fun show(SA: Show<A>): String = fold(
-    {
-      "None"
-    },
-    {
-      "Some(${SA.run { it.show() }})"
-    }
+    { "None" },
+    { "Some(${SA.run { it.show() }})" }
   )
+
+  override fun toString(): String = fold(
+      { "Option.None" },
+      { "Option.Some($it)" }
+    )
 }
 
 object None : Option<Nothing>() {
   override fun isEmpty() = true
 
-  override fun toString(): String = "None"
+  override fun toString(): String = "Option.None"
 }
 
 data class Some<out T>(val t: T) : Option<T>() {
   override fun isEmpty() = false
 
-  override fun toString(): String = "Some($t)"
+  override fun toString(): String = "Option.Some($t)"
 }
 
 /**

--- a/arrow-core-data/src/main/kotlin/arrow/core/Ordering.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Ordering.kt
@@ -5,29 +5,42 @@ import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
 import arrow.typeclasses.Semigroup
-import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import arrow.typeclasses.hashWithSalt
 
 sealed class Ordering {
   override fun equals(other: Any?): Boolean = this === other // ref equality is fine because objects should be singletons
 
-  override fun toString(): String = show()
+  override fun toString(): String =
+    when (this) {
+      LT -> "LT"
+      GT -> "GT"
+      EQ -> "EQ"
+    }
 
-  override fun hashCode(): Int = toInt()
+  override fun hashCode(): Int =
+    when (this) {
+      LT -> -1
+      GT -> 1
+      EQ -> 0
+    }
 
-  fun toInt(): Int = when (this) {
-    LT -> -1
-    GT -> 1
-    EQ -> 0
-  }
+  fun toInt(): Int =
+    when (this) {
+      LT -> -1
+      GT -> 1
+      EQ -> 0
+    }
 
-  operator fun plus(b: Ordering): Ordering = when (this) {
-    LT -> LT
-    EQ -> b
-    GT -> GT
-  }
+  operator fun plus(b: Ordering): Ordering =
+    when (this) {
+      LT -> LT
+      EQ -> b
+      GT -> GT
+    }
 
-  fun hash(): Int = hashWithSalt(hashCode())
+  fun hash(): Int =
+    hashWithSalt(hashCode())
 
   fun hashWithSalt(salt: Int): Int =
     salt.hashWithSalt(hashCode())
@@ -67,11 +80,9 @@ sealed class Ordering {
 
   fun combine(b: Ordering): Ordering = this + b
 
-  fun show(): String = when (this) {
-    LT -> "LT"
-    GT -> "GT"
-    EQ -> "EQ"
-  }
+  @Deprecated(ShowDeprecation)
+  fun show(): String =
+    toString()
 
   companion object {
     fun fromInt(i: Int): Ordering = when (i) {
@@ -98,8 +109,6 @@ fun Monoid.Companion.ordering(): Monoid<Ordering> = OrderingMonoid
 
 fun Order.Companion.ordering(): Order<Ordering> = OrderingOrder
 
-fun Show.Companion.ordering(): Show<Ordering> = OrderingShow
-
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 private object OrderingEq : Eq<Ordering> {
   override fun Ordering.eqv(b: Ordering): Boolean =
@@ -125,9 +134,4 @@ private object OrderingMonoid : Monoid<Ordering> {
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 private object OrderingOrder : Order<Ordering> {
   override fun Ordering.compare(b: Ordering): Ordering = this.compare(b)
-}
-
-@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
-private object OrderingShow : Show<Ordering> {
-  override fun Ordering.show(): String = this.show()
 }

--- a/arrow-core-data/src/main/kotlin/arrow/core/SequenceK.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/SequenceK.kt
@@ -3,8 +3,11 @@ package arrow.core
 import arrow.Kind
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 
-class ForSequenceK private constructor() { companion object }
+class ForSequenceK private constructor() {
+  companion object
+}
 typealias SequenceKOf<A> = arrow.Kind<ForSequenceK, A>
 
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
@@ -75,9 +78,12 @@ data class SequenceK<out A>(val sequence: Sequence<A>) : SequenceKOf<A>, Sequenc
 
   fun toList(): List<A> = this.fix().sequence.toList()
 
-  fun show(SA: Show<A>): String = "Sequence(${toList().k().show(SA)})"
+  @Deprecated(ShowDeprecation)
+  fun show(SA: Show<A>): String =
+    "Sequence(${toList().k().show(SA)})"
 
-  override fun toString(): String = show(Show.any())
+  override fun toString(): String =
+    sequence.toString()
 
   companion object {
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/SetK.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/SetK.kt
@@ -1,6 +1,7 @@
 package arrow.core
 
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 
 @Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
 class ForSetK private constructor() { companion object }
@@ -32,9 +33,11 @@ data class SetK<out A>(private val set: Set<A>) : SetKOf<A>, Set<A> by set {
       else -> false
     }
 
+  @Deprecated(ShowDeprecation)
   fun show(SA: Show<A>): String = "Set(${toList().k().show(SA)})"
 
-  override fun toString(): String = show(Show.any())
+  override fun toString(): String =
+    set.toString()
 
   companion object {
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/SortedMapK.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/SortedMapK.kt
@@ -3,6 +3,7 @@ package arrow.core
 import arrow.Kind
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import kotlin.collections.flatMap
 
 class ForSortedMapK private constructor() { companion object }
@@ -65,9 +66,12 @@ data class SortedMapK<A : Comparable<A>, B>(private val map: SortedMap<A, B>) : 
 
   override fun hashCode(): Int = map.hashCode()
 
-  fun show(SA: Show<A>, SB: Show<B>): String = "SortedMap(${toList().k().map { it.toTuple2() }.show(Show { show(SA, SB) })})"
+  @Deprecated(ShowDeprecation)
+  fun show(SA: Show<A>, SB: Show<B>): String =
+    "SortedMap(${toList().k().map { it.toTuple2() }.show(Show { show(SA, SB) })})"
 
-  override fun toString(): String = show(Show.any(), Show.any())
+  override fun toString(): String =
+    map.toString()
 
   companion object
 }

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple10.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple10.kt
@@ -8,6 +8,7 @@ import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import arrow.typeclasses.defaultSalt
 
 class ForTuple10 private constructor() {
@@ -21,43 +22,16 @@ inline fun <A, B, C, D, E, F, G, H, I, J> Tuple10Of<A, B, C, D, E, F, G, H, I, J
   this as Tuple10<A, B, C, D, E, F, G, H, I, J>
 
 data class Tuple10<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G, val h: H, val i: I, val j: J) : Tuple10Of<A, B, C, D, E, F, G, H, I, J> {
+
+  @Deprecated(ShowDeprecation)
   fun show(SA: Show<A>, SB: Show<B>, SC: Show<C>, SD: Show<D>, SE: Show<E>, SF: Show<F>, SG: Show<G>, SH: Show<H>, SI: Show<I>, SJ: Show<J>): String =
     "(" + listOf(SA.run { a.show() }, SB.run { b.show() }, SC.run { c.show() }, SD.run { d.show() }, SE.run { e.show() }, SF.run { f.show() }, SG.run { g.show() }, SH.run { h.show() }, SI.run { i.show() }, SJ.run { j.show() }).joinToString(", ") + ")"
 
-  override fun toString(): String = show(Show.any(), Show.any(), Show.any(), Show.any(), Show.any(), Show.any(), Show.any(), Show.any(), Show.any(), Show.any())
+  override fun toString(): String =
+    "($a, $b, $c, $d, $e, $f, $g, $h, $i, $j)"
 
   companion object
 }
-
-private class Tuple10Show<A, B, C, D, E, F, G, H, I, J>(
-  private val SA: Show<A>,
-  private val SB: Show<B>,
-  private val SC: Show<C>,
-  private val SD: Show<D>,
-  private val SE: Show<E>,
-  private val SF: Show<F>,
-  private val SG: Show<G>,
-  private val SH: Show<H>,
-  private val SI: Show<I>,
-  private val SJ: Show<J>
-) : Show<Tuple10<A, B, C, D, E, F, G, H, I, J>> {
-  override fun Tuple10<A, B, C, D, E, F, G, H, I, J>.show(): String =
-    show(SA, SB, SC, SD, SE, SF, SG, SH, SI, SJ)
-}
-
-fun <A, B, C, D, E, F, G, H, I, J> Show.Companion.tuple10(
-  SA: Show<A>,
-  SB: Show<B>,
-  SC: Show<C>,
-  SD: Show<D>,
-  SE: Show<E>,
-  SF: Show<F>,
-  SG: Show<G>,
-  SH: Show<H>,
-  SI: Show<I>,
-  SJ: Show<J>
-): Show<Tuple10<A, B, C, D, E, F, G, H, I, J>> =
-  Tuple10Show(SA, SB, SC, SD, SE, SF, SG, SH, SI, SJ)
 
 fun <A, B, C, D, E, F, G, H, I, J> Tuple10<A, B, C, D, E, F, G, H, I, J>.eqv(
   EQA: Eq<A>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple2.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple2.kt
@@ -9,6 +9,7 @@ import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import arrow.typeclasses.defaultSalt
 
 class ForTuple2 private constructor() {
@@ -58,30 +59,15 @@ data class Tuple2<out A, out B>(val a: A, val b: B) : Tuple2Of<A, B> {
 
   fun reverse(): Tuple2<B, A> = Tuple2(b, a)
 
+  @Deprecated(ShowDeprecation)
   fun show(SA: Show<A>, SB: Show<B>): String =
     "(" + listOf(SA.run { a.show() }, SB.run { b.show() }).joinToString(", ") + ")"
 
-  override fun toString(): String = show(Show.any(), Show.any())
+  override fun toString(): String =
+    "($a, $b)"
 
   companion object
 }
-
-fun <A, B> Pair<A, B>.show(SA: Show<A>, SB: Show<B>): String =
-  "(${SA.run { first.show() }}, ${SB.run { second.show() }})"
-
-private class PairShow<A, B>(
-  private val SA: Show<A>,
-  private val SB: Show<B>
-) : Show<Pair<A, B>> {
-  override fun Pair<A, B>.show(): String =
-    show(SA, SB)
-}
-
-fun <A, B> Show.Companion.pair(
-  SA: Show<A>,
-  SB: Show<B>
-): Show<Pair<A, B>> =
-  PairShow(SA, SB)
 
 fun <A, B> Pair<A, B>.eqv(
   EQA: Eq<A>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple3.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple3.kt
@@ -8,6 +8,7 @@ import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import arrow.typeclasses.defaultSalt
 
 class ForTuple3 private constructor() {
@@ -22,32 +23,15 @@ inline fun <A, B, C> Tuple3Of<A, B, C>.fix(): Tuple3<A, B, C> =
 
 @Deprecated("Deprecated in favor of Kotlin's Triple", ReplaceWith("Triple(a, b, c)"))
 data class Tuple3<out A, out B, out C>(val a: A, val b: B, val c: C) : Tuple3Of<A, B, C> {
+  @Deprecated(ShowDeprecation)
   fun show(SA: Show<A>, SB: Show<B>, SC: Show<C>): String =
     "(" + listOf(SA.run { a.show() }, SB.run { b.show() }, SC.run { c.show() }).joinToString(", ") + ")"
 
-  override fun toString(): String = show(Show.any(), Show.any(), Show.any())
+  override fun toString(): String =
+    "($a, $b, $c)"
 
   companion object
 }
-
-fun <A, B, C> Triple<A, B, C>.show(SA: Show<A>, SB: Show<B>, SC: Show<C>): String =
-  "(${SA.run { first.show() }}, ${SB.run { second.show() }}, ${SC.run { third.show() }})"
-
-private class TripleShow<A, B, C>(
-  private val SA: Show<A>,
-  private val SB: Show<B>,
-  private val SC: Show<C>
-) : Show<Triple<A, B, C>> {
-  override fun Triple<A, B, C>.show(): String =
-    show(SA, SB, SC)
-}
-
-fun <A, B, C> Show.Companion.triple(
-  SA: Show<A>,
-  SB: Show<B>,
-  SC: Show<C>
-): Show<Triple<A, B, C>> =
-  TripleShow(SA, SB, SC)
 
 fun <A, B, C> Triple<A, B, C>.eqv(
   EQA: Eq<A>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple4.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple4.kt
@@ -8,6 +8,7 @@ import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import arrow.typeclasses.defaultSalt
 
 class ForTuple4 private constructor() {
@@ -21,31 +22,16 @@ inline fun <A, B, C, D> Tuple4Of<A, B, C, D>.fix(): Tuple4<A, B, C, D> =
   this as Tuple4<A, B, C, D>
 
 data class Tuple4<out A, out B, out C, out D>(val a: A, val b: B, val c: C, val d: D) : Tuple4Of<A, B, C, D> {
+
+  @Deprecated(ShowDeprecation)
   fun show(SA: Show<A>, SB: Show<B>, SC: Show<C>, SD: Show<D>): String =
     "(" + listOf(SA.run { a.show() }, SB.run { b.show() }, SC.run { c.show() }, SD.run { d.show() }).joinToString(", ") + ")"
 
-  override fun toString(): String = show(Show.any(), Show.any(), Show.any(), Show.any())
+  override fun toString(): String =
+    "($a, $b, $c, $d)"
 
   companion object
 }
-
-private class Tuple4Show<A, B, C, D>(
-  private val SA: Show<A>,
-  private val SB: Show<B>,
-  private val SC: Show<C>,
-  private val SD: Show<D>
-) : Show<Tuple4<A, B, C, D>> {
-  override fun Tuple4<A, B, C, D>.show(): String =
-    show(SA, SB, SC, SD)
-}
-
-fun <A, B, C, D> Show.Companion.tuple4(
-  SA: Show<A>,
-  SB: Show<B>,
-  SC: Show<C>,
-  SD: Show<D>
-): Show<Tuple4<A, B, C, D>> =
-  Tuple4Show(SA, SB, SC, SD)
 
 fun <A, B, C, D> Tuple4<A, B, C, D>.eqv(
   EQA: Eq<A>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple5.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple5.kt
@@ -8,6 +8,7 @@ import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import arrow.typeclasses.defaultSalt
 
 class ForTuple5 private constructor() {
@@ -21,33 +22,16 @@ inline fun <A, B, C, D, E> Tuple5Of<A, B, C, D, E>.fix(): Tuple5<A, B, C, D, E> 
   this as Tuple5<A, B, C, D, E>
 
 data class Tuple5<out A, out B, out C, out D, out E>(val a: A, val b: B, val c: C, val d: D, val e: E) : Tuple5Of<A, B, C, D, E> {
+
+  @Deprecated(ShowDeprecation)
   fun show(SA: Show<A>, SB: Show<B>, SC: Show<C>, SD: Show<D>, SE: Show<E>): String =
     "(" + listOf(SA.run { a.show() }, SB.run { b.show() }, SC.run { c.show() }, SD.run { d.show() }, SE.run { e.show() }).joinToString(", ") + ")"
 
-  override fun toString(): String = show(Show.any(), Show.any(), Show.any(), Show.any(), Show.any())
+  override fun toString(): String =
+    "($a, $b, $c, $d, $e)"
 
   companion object
 }
-
-private class Tuple5Show<A, B, C, D, E>(
-  private val SA: Show<A>,
-  private val SB: Show<B>,
-  private val SC: Show<C>,
-  private val SD: Show<D>,
-  private val SE: Show<E>
-) : Show<Tuple5<A, B, C, D, E>> {
-  override fun Tuple5<A, B, C, D, E>.show(): String =
-    show(SA, SB, SC, SD, SE)
-}
-
-fun <A, B, C, D, E> Show.Companion.tuple5(
-  SA: Show<A>,
-  SB: Show<B>,
-  SC: Show<C>,
-  SD: Show<D>,
-  SE: Show<E>
-): Show<Tuple5<A, B, C, D, E>> =
-  Tuple5Show(SA, SB, SC, SD, SE)
 
 fun <A, B, C, D, E> Tuple5<A, B, C, D, E>.eqv(
   EQA: Eq<A>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple6.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple6.kt
@@ -8,6 +8,7 @@ import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import arrow.typeclasses.defaultSalt
 
 class ForTuple6 private constructor() {
@@ -21,35 +22,15 @@ inline fun <A, B, C, D, E, F> Tuple6Of<A, B, C, D, E, F>.fix(): Tuple6<A, B, C, 
   this as Tuple6<A, B, C, D, E, F>
 
 data class Tuple6<out A, out B, out C, out D, out E, out F>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F) : Tuple6Of<A, B, C, D, E, F> {
+  @Deprecated(ShowDeprecation)
   fun show(SA: Show<A>, SB: Show<B>, SC: Show<C>, SD: Show<D>, SE: Show<E>, SF: Show<F>): String =
     "(" + listOf(SA.run { a.show() }, SB.run { b.show() }, SC.run { c.show() }, SD.run { d.show() }, SE.run { e.show() }, SF.run { f.show() }).joinToString(", ") + ")"
 
-  override fun toString(): String = show(Show.any(), Show.any(), Show.any(), Show.any(), Show.any(), Show.any())
+  override fun toString(): String =
+    "($a, $b, $c, $d, $e, $f)"
 
   companion object
 }
-
-private class Tuple6Show<A, B, C, D, E, F>(
-  private val SA: Show<A>,
-  private val SB: Show<B>,
-  private val SC: Show<C>,
-  private val SD: Show<D>,
-  private val SE: Show<E>,
-  private val SF: Show<F>
-) : Show<Tuple6<A, B, C, D, E, F>> {
-  override fun Tuple6<A, B, C, D, E, F>.show(): String =
-    show(SA, SB, SC, SD, SE, SF)
-}
-
-fun <A, B, C, D, E, F> Show.Companion.tuple6(
-  SA: Show<A>,
-  SB: Show<B>,
-  SC: Show<C>,
-  SD: Show<D>,
-  SE: Show<E>,
-  SF: Show<F>
-): Show<Tuple6<A, B, C, D, E, F>> =
-  Tuple6Show(SA, SB, SC, SD, SE, SF)
 
 fun <A, B, C, D, E, F> Tuple6<A, B, C, D, E, F>.eqv(
   EQA: Eq<A>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple7.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple7.kt
@@ -8,6 +8,7 @@ import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import arrow.typeclasses.defaultSalt
 
 class ForTuple7 private constructor() {
@@ -21,37 +22,15 @@ inline fun <A, B, C, D, E, F, G> Tuple7Of<A, B, C, D, E, F, G>.fix(): Tuple7<A, 
   this as Tuple7<A, B, C, D, E, F, G>
 
 data class Tuple7<out A, out B, out C, out D, out E, out F, out G>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G) : Tuple7Of<A, B, C, D, E, F, G> {
+  @Deprecated(ShowDeprecation)
   fun show(SA: Show<A>, SB: Show<B>, SC: Show<C>, SD: Show<D>, SE: Show<E>, SF: Show<F>, SG: Show<G>): String =
     "(" + listOf(SA.run { a.show() }, SB.run { b.show() }, SC.run { c.show() }, SD.run { d.show() }, SE.run { e.show() }, SF.run { f.show() }, SG.run { g.show() }).joinToString(", ") + ")"
 
-  override fun toString(): String = show(Show.any(), Show.any(), Show.any(), Show.any(), Show.any(), Show.any(), Show.any())
+  override fun toString(): String =
+    "($a, $b, $c, $d, $e, $f, $g)"
 
   companion object
 }
-
-private class Tuple7Show<A, B, C, D, E, F, G>(
-  private val SA: Show<A>,
-  private val SB: Show<B>,
-  private val SC: Show<C>,
-  private val SD: Show<D>,
-  private val SE: Show<E>,
-  private val SF: Show<F>,
-  private val SG: Show<G>
-) : Show<Tuple7<A, B, C, D, E, F, G>> {
-  override fun Tuple7<A, B, C, D, E, F, G>.show(): String =
-    show(SA, SB, SC, SD, SE, SF, SG)
-}
-
-fun <A, B, C, D, E, F, G> Show.Companion.tuple7(
-  SA: Show<A>,
-  SB: Show<B>,
-  SC: Show<C>,
-  SD: Show<D>,
-  SE: Show<E>,
-  SF: Show<F>,
-  SG: Show<G>
-): Show<Tuple7<A, B, C, D, E, F, G>> =
-  Tuple7Show(SA, SB, SC, SD, SE, SF, SG)
 
 fun <A, B, C, D, E, F, G> Tuple7<A, B, C, D, E, F, G>.eqv(
   EQA: Eq<A>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple8.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple8.kt
@@ -8,6 +8,7 @@ import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import arrow.typeclasses.defaultSalt
 
 class ForTuple8 private constructor() {
@@ -21,39 +22,15 @@ inline fun <A, B, C, D, E, F, G, H> Tuple8Of<A, B, C, D, E, F, G, H>.fix(): Tupl
   this as Tuple8<A, B, C, D, E, F, G, H>
 
 data class Tuple8<out A, out B, out C, out D, out E, out F, out G, out H>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G, val h: H) : Tuple8Of<A, B, C, D, E, F, G, H> {
+  @Deprecated(ShowDeprecation)
   fun show(SA: Show<A>, SB: Show<B>, SC: Show<C>, SD: Show<D>, SE: Show<E>, SF: Show<F>, SG: Show<G>, SH: Show<H>): String =
     "(" + listOf(SA.run { a.show() }, SB.run { b.show() }, SC.run { c.show() }, SD.run { d.show() }, SE.run { e.show() }, SF.run { f.show() }, SG.run { g.show() }, SH.run { h.show() }).joinToString(", ") + ")"
 
-  override fun toString(): String = show(Show.any(), Show.any(), Show.any(), Show.any(), Show.any(), Show.any(), Show.any(), Show.any())
+  override fun toString(): String =
+    "($a, $b, $c, $d, $e, $f, $g, $h)"
 
   companion object
 }
-
-private class Tuple8Show<A, B, C, D, E, F, G, H>(
-  private val SA: Show<A>,
-  private val SB: Show<B>,
-  private val SC: Show<C>,
-  private val SD: Show<D>,
-  private val SE: Show<E>,
-  private val SF: Show<F>,
-  private val SG: Show<G>,
-  private val SH: Show<H>
-) : Show<Tuple8<A, B, C, D, E, F, G, H>> {
-  override fun Tuple8<A, B, C, D, E, F, G, H>.show(): String =
-    show(SA, SB, SC, SD, SE, SF, SG, SH)
-}
-
-fun <A, B, C, D, E, F, G, H> Show.Companion.tuple8(
-  SA: Show<A>,
-  SB: Show<B>,
-  SC: Show<C>,
-  SD: Show<D>,
-  SE: Show<E>,
-  SF: Show<F>,
-  SG: Show<G>,
-  SH: Show<H>
-): Show<Tuple8<A, B, C, D, E, F, G, H>> =
-  Tuple8Show(SA, SB, SC, SD, SE, SF, SG, SH)
 
 fun <A, B, C, D, E, F, G, H> Tuple8<A, B, C, D, E, F, G, H>.eqv(
   EQA: Eq<A>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple9.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple9.kt
@@ -8,6 +8,7 @@ import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import arrow.typeclasses.defaultSalt
 
 class ForTuple9 private constructor() {
@@ -21,41 +22,15 @@ inline fun <A, B, C, D, E, F, G, H, I> Tuple9Of<A, B, C, D, E, F, G, H, I>.fix()
   this as Tuple9<A, B, C, D, E, F, G, H, I>
 
 data class Tuple9<out A, out B, out C, out D, out E, out F, out G, out H, out I>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G, val h: H, val i: I) : Tuple9Of<A, B, C, D, E, F, G, H, I> {
+  @Deprecated(ShowDeprecation)
   fun show(SA: Show<A>, SB: Show<B>, SC: Show<C>, SD: Show<D>, SE: Show<E>, SF: Show<F>, SG: Show<G>, SH: Show<H>, SI: Show<I>): String =
     "(" + listOf(SA.run { a.show() }, SB.run { b.show() }, SC.run { c.show() }, SD.run { d.show() }, SE.run { e.show() }, SF.run { f.show() }, SG.run { g.show() }, SH.run { h.show() }, SI.run { i.show() }).joinToString(", ") + ")"
 
-  override fun toString(): String = show(Show.any(), Show.any(), Show.any(), Show.any(), Show.any(), Show.any(), Show.any(), Show.any(), Show.any())
+  override fun toString(): String =
+    "($a, $b, $c, $d, $e, $f, $g, $h, $i)"
 
   companion object
 }
-
-private class Tuple9Show<A, B, C, D, E, F, G, H, I>(
-  private val SA: Show<A>,
-  private val SB: Show<B>,
-  private val SC: Show<C>,
-  private val SD: Show<D>,
-  private val SE: Show<E>,
-  private val SF: Show<F>,
-  private val SG: Show<G>,
-  private val SH: Show<H>,
-  private val SI: Show<I>
-) : Show<Tuple9<A, B, C, D, E, F, G, H, I>> {
-  override fun Tuple9<A, B, C, D, E, F, G, H, I>.show(): String =
-    show(SA, SB, SC, SD, SE, SF, SG, SH, SI)
-}
-
-fun <A, B, C, D, E, F, G, H, I> Show.Companion.tuple9(
-  SA: Show<A>,
-  SB: Show<B>,
-  SC: Show<C>,
-  SD: Show<D>,
-  SE: Show<E>,
-  SF: Show<F>,
-  SG: Show<G>,
-  SH: Show<H>,
-  SI: Show<I>
-): Show<Tuple9<A, B, C, D, E, F, G, H, I>> =
-  Tuple9Show(SA, SB, SC, SD, SE, SF, SG, SH, SI)
 
 fun <A, B, C, D, E, F, G, H, I> Tuple9<A, B, C, D, E, F, G, H, I>.eqv(
   EQA: Eq<A>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -958,9 +958,6 @@ fun <E, A> Eq.Companion.validated(EQE: Eq<E>, EQA: Eq<A>): Eq<Validated<E, A>> =
 fun <E, A> Hash.Companion.validated(HE: Hash<E>, HA: Hash<A>): Hash<Validated<E, A>> =
   ValidatedHash(HE, HA)
 
-fun <E, A> Show.Companion.validated(SE: Show<E>, SA: Show<A>): Show<Validated<E, A>> =
-  ValidatedShow(SE, SA)
-
 fun <E, A> Order.Companion.validated(OE: Order<E>, OA: Order<A>): Order<Validated<E, A>> =
   ValidatedOrder(OE, OA)
 
@@ -1265,14 +1262,6 @@ private class ValidatedEq<L, R>(
 
   override fun Validated<L, R>.eqv(b: Validated<L, R>): Boolean =
     eqv(EQL, EQR, b)
-}
-
-private class ValidatedShow<L, R>(
-  private val SL: Show<L>,
-  private val SR: Show<R>,
-) : Show<Validated<L, R>> {
-  override fun Validated<L, R>.show(): String =
-    show(SL, SR)
 }
 
 private class ValidatedHash<L, R>(

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -8,6 +8,7 @@ import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import arrow.typeclasses.defaultSalt
 import arrow.typeclasses.hashWithSalt
 
@@ -821,13 +822,15 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
   inline fun <B> foldMap(MB: Monoid<B>, f: (A) -> B): B =
     fold({ MB.empty() }, f)
 
+  @Deprecated(ShowDeprecation)
   fun show(SE: Show<E>, SA: Show<A>): String = fold(
-    {
-      "Invalid(${SE.run { it.show() }})"
-    },
-    {
-      "Valid(${SA.run { it.show() }})"
-    }
+    { "Invalid(${SE.run { it.show() }})" },
+    { "Valid(${SA.run { it.show() }})" }
+  )
+
+  override fun toString(): String = fold(
+    { "Validated.Invalid($it)" },
+    { "Validated.Valid($it)" }
   )
 
   fun hash(HL: Hash<E>, HR: Hash<A>): Int =
@@ -839,11 +842,11 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
   )
 
   data class Valid<out A>(val a: A) : Validated<Nothing, A>() {
-    override fun toString(): String = show(Show.any(), Show.any())
+    override fun toString(): String = "Validated.Valid($a)"
   }
 
   data class Invalid<out E>(val e: E) : Validated<E, Nothing>() {
-    override fun toString(): String = show(Show.any(), Show.any())
+    override fun toString(): String = "Validated.Invalid($e)"
   }
 
   inline fun <B> fold(fe: (E) -> B, fa: (A) -> B): B =

--- a/arrow-core-data/src/main/kotlin/arrow/core/boolean.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/boolean.kt
@@ -4,12 +4,6 @@ import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
-import arrow.typeclasses.Show
-
-private object BooleanShow : Show<Boolean> {
-  override fun Boolean.show(): String =
-    this.toString()
-}
 
 private object BooleanEq : Eq<Boolean> {
   override fun Boolean.eqv(b: Boolean): Boolean = this == b
@@ -23,9 +17,6 @@ private object BooleanOrder : Order<Boolean> {
 private object BooleanHash : Hash<Boolean> {
   override fun Boolean.hash(): Int = this.hashCode()
 }
-
-fun Show.Companion.boolean(): Show<Boolean> =
-  BooleanShow
 
 fun Eq.Companion.boolean(): Eq<Boolean> =
   BooleanEq

--- a/arrow-core-data/src/main/kotlin/arrow/core/char.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/char.kt
@@ -3,12 +3,6 @@ package arrow.core
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Order
-import arrow.typeclasses.Show
-
-private object CharShow : Show<Char> {
-  override fun Char.show(): String =
-    this.toString()
-}
 
 private object CharEq : Eq<Char> {
   override fun Char.eqv(b: Char): Boolean = this == b
@@ -25,9 +19,6 @@ private object CharOrder : Order<Char> {
 private object CharHash : Hash<Char> {
   override fun Char.hash(): Int = this.hashCode()
 }
-
-fun Show.Companion.char(): Show<Char> =
-  CharShow
 
 fun Eq.Companion.char(): Eq<Char> =
   CharEq

--- a/arrow-core-data/src/main/kotlin/arrow/core/map.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/map.kt
@@ -4,7 +4,6 @@ import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Semigroup
-import arrow.typeclasses.Show
 import arrow.typeclasses.defaultSalt
 import kotlin.collections.flatMap as _flatMap
 
@@ -342,19 +341,6 @@ private class MapHash<K, A>(
 ) : Hash<Map<K, A>> {
   override fun Map<K, A>.hashWithSalt(salt: Int): Int =
     hashWithSalt(HK, HA, salt)
-}
-
-fun <K, A> Map<K, A>.show(SK: Show<K>, SA: Show<A>): String =
-  "Map(${toList().k().show(Show { show(SK, SA) })})"
-
-fun <K, A> Show.Companion.map(SK: Show<K>, SA: Show<A>): Show<Map<K, A>> =
-  MapShow(SK, SA)
-
-private class MapShow<K, A>(
-  private val SK: Show<K>,
-  private val SA: Show<A>
-) : Show<Map<K, A>> {
-  override fun Map<K, A>.show(): String = show(SK, SA)
 }
 
 fun <K, A> Map<K, A>.combine(SG: Semigroup<A>, b: Map<K, A>): Map<K, A> = with(SG) {

--- a/arrow-core-data/src/main/kotlin/arrow/core/number.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/number.kt
@@ -6,7 +6,6 @@ import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Semiring
-import arrow.typeclasses.Show
 
 // ////////
 // Byte
@@ -37,19 +36,12 @@ private object ByteEq : Eq<Byte> {
   override fun Byte.eqv(b: Byte): Boolean = this == b
 }
 
-private object ByteShow : Show<Byte> {
-  override fun Byte.show(): String = toString()
-}
-
 private object ByteHash : Hash<Byte> {
   override fun Byte.hash(): Int = hashCode()
 }
 
 fun Hash.Companion.byte(): Hash<Byte> =
   ByteHash
-
-fun Show.Companion.byte(): Show<Byte> =
-  ByteShow
 
 fun Eq.Companion.byte(): Eq<Byte> =
   ByteEq
@@ -95,19 +87,12 @@ private object DoubleEq : Eq<Double> {
   override fun Double.eqv(b: Double): Boolean = this == b
 }
 
-private object DoubleShow : Show<Double> {
-  override fun Double.show(): String = toString()
-}
-
 private object DoubleHash : Hash<Double> {
   override fun Double.hash(): Int = hashCode()
 }
 
 fun Hash.Companion.double(): Hash<Double> =
   DoubleHash
-
-fun Show.Companion.double(): Show<Double> =
-  DoubleShow
 
 fun Eq.Companion.double(): Eq<Double> =
   DoubleEq
@@ -148,10 +133,6 @@ private object IntEq : Eq<Int> {
   override fun Int.eqv(b: Int): Boolean = this == b
 }
 
-private object IntShow : Show<Int> {
-  override fun Int.show(): String = toString()
-}
-
 private object IntOrder : Order<Int> {
   override fun Int.compare(b: Int): Ordering = Ordering.fromInt(this.compareTo(b))
   override fun Int.compareTo(b: Int): Int = this.compareTo(b)
@@ -163,9 +144,6 @@ private object IntHash : Hash<Int> {
 
 fun Hash.Companion.int(): Hash<Int> =
   IntHash
-
-fun Show.Companion.int(): Show<Int> =
-  IntShow
 
 fun Eq.Companion.int(): Eq<Int> =
   IntEq
@@ -211,19 +189,12 @@ private object LongEq : Eq<Long> {
   override fun Long.eqv(b: Long): Boolean = this == b
 }
 
-private object LongShow : Show<Long> {
-  override fun Long.show(): String = toString()
-}
-
 private object LongHash : Hash<Long> {
   override fun Long.hash(): Int = hashCode()
 }
 
 fun Hash.Companion.long(): Hash<Long> =
   LongHash
-
-fun Show.Companion.long(): Show<Long> =
-  LongShow
 
 fun Eq.Companion.long(): Eq<Long> =
   LongEq
@@ -269,19 +240,12 @@ private object ShortEq : Eq<Short> {
   override fun Short.eqv(b: Short): Boolean = this == b
 }
 
-private object ShortShow : Show<Short> {
-  override fun Short.show(): String = toString()
-}
-
 private object ShortHash : Hash<Short> {
   override fun Short.hash(): Int = hashCode()
 }
 
 fun Hash.Companion.short(): Hash<Short> =
   ShortHash
-
-fun Show.Companion.short(): Show<Short> =
-  ShortShow
 
 fun Eq.Companion.short(): Eq<Short> =
   ShortEq
@@ -327,19 +291,12 @@ private object FloatEq : Eq<Float> {
   override fun Float.eqv(b: Float): Boolean = this == b
 }
 
-private object FloatShow : Show<Float> {
-  override fun Float.show(): String = toString()
-}
-
 private object FloatHash : Hash<Float> {
   override fun Float.hash(): Int = hashCode()
 }
 
 fun Hash.Companion.float(): Hash<Float> =
   FloatHash
-
-fun Show.Companion.float(): Show<Float> =
-  FloatShow
 
 fun Eq.Companion.float(): Eq<Float> =
   FloatEq

--- a/arrow-core-data/src/main/kotlin/arrow/core/set.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/set.kt
@@ -4,7 +4,6 @@ import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Semigroup
-import arrow.typeclasses.Show
 import arrow.typeclasses.hashWithSalt
 
 object SetExtensions
@@ -44,11 +43,6 @@ fun <A> Eq.Companion.set(EQ: () -> Eq<A>): Eq<Set<A>> = object : Eq<Set<A>> {
       acc && bool
     }
     else false
-}
-
-fun <A> Show.Companion.set(SA: () -> Show<A>): Show<Set<A>> = object : Show<Set<A>> {
-  override fun Set<A>.show(): String =
-    show(SA())
 }
 
 fun <A> Hash.Companion.set(HA: Hash<A>): Hash<Set<A>> = object : Hash<Set<A>> {

--- a/arrow-core-data/src/main/kotlin/arrow/core/string.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/string.kt
@@ -5,7 +5,6 @@ import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
 import arrow.typeclasses.Semigroup
-import arrow.typeclasses.Show
 
 private object StringSemigroup : Semigroup<String> {
   override fun String.combine(b: String): String = "${this}$b"
@@ -29,17 +28,10 @@ private object StringEq : Eq<String> {
 fun Eq.Companion.string(): Eq<String> =
   StringEq
 
-private object StringShow : Show<String> {
-  override fun String.show(): String = "\"${this.escape()}\""
-
-  private fun String.escape(): String =
-    replace("\n", "\\n").replace("\r", "\\r")
-      .replace("\"", "\\\"").replace("\'", "\\\'")
-      .replace("\t", "\\t").replace("\b", "\\b")
-}
-
-fun Show.Companion.string(): Show<String> =
-  StringShow
+fun String.escaped(): String =
+  replace("\n", "\\n").replace("\r", "\\r")
+    .replace("\"", "\\\"").replace("\'", "\\\'")
+    .replace("\t", "\\t").replace("\b", "\\b")
 
 private object StringOrder : Order<String> {
   override fun String.compare(b: String): Ordering =

--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Show.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Show.kt
@@ -1,9 +1,12 @@
 package arrow.typeclasses
 
+const val ShowDeprecation = "Show is deprecated in favor of toString(), since Kotlin's Std doesn't take Show into account"
+
 /**
  * A type class used to get a textual representation for an instance of type [A] in a type safe way.
  *
  */
+@Deprecated(ShowDeprecation)
 interface Show<in A> {
 
   /**

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/boolean.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/boolean.kt
@@ -6,8 +6,9 @@ import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 
-@Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Show.boolean()", "arrow.core.Show", "arrow.core.boolean"))
+@Deprecated(ShowDeprecation)
 interface BooleanShow : Show<Boolean> {
   override fun Boolean.show(): String =
     this.toString()
@@ -29,7 +30,7 @@ interface BooleanHash : Hash<Boolean>, BooleanEq {
   override fun Boolean.hash(): Int = this.hashCode()
 }
 
-@Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Show.boolean()", "arrow.core.Show", "arrow.core.boolean"))
+@Deprecated(ShowDeprecation)
 fun Boolean.Companion.show(): Show<Boolean> =
   object : BooleanShow {}
 

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/char.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/char.kt
@@ -5,8 +5,9 @@ import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Order
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 
-@Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Show.char()", "arrow.core.Show", "arrow.core.char"))
+@Deprecated(ShowDeprecation)
 interface CharShow : Show<Char> {
   override fun Char.show(): String =
     this.toString()
@@ -31,7 +32,7 @@ interface CharHash : Hash<Char>, CharEq {
   override fun Char.hash(): Int = this.hashCode()
 }
 
-@Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Show.char()", "arrow.core.Show", "arrow.core.char"))
+@Deprecated(ShowDeprecation)
 fun Char.Companion.show(): Show<Char> =
   object : CharShow {}
 

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/show/ConstShow.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/show/ConstShow.kt
@@ -3,11 +3,13 @@ package arrow.core.extensions.const.show
 import arrow.core.Const.Companion
 import arrow.core.extensions.ConstShow
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import kotlin.Suppress
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated(ShowDeprecation)
 inline fun <A, T> Companion.show(SA: Show<A>): ConstShow<A, T> = object :
     arrow.core.extensions.ConstShow<A, T> { override fun SA(): arrow.typeclasses.Show<A> = SA }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/show/EitherShow.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/show/EitherShow.kt
@@ -3,13 +3,14 @@ package arrow.core.extensions.either.show
 import arrow.core.Either.Companion
 import arrow.core.extensions.EitherShow
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import kotlin.Suppress
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Show.either(HL, HR)", "arrow.core.Show", "arrow.core.either"))
+@Deprecated(ShowDeprecation)
 inline fun <L, R> Companion.show(SL: Show<L>, SR: Show<R>): EitherShow<L, R> = object :
   arrow.core.extensions.EitherShow<L, R> {
   override fun SL(): arrow.typeclasses.Show<L> = SL

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/hashed/show/HashedShow.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/hashed/show/HashedShow.kt
@@ -3,11 +3,13 @@ package arrow.core.extensions.hashed.show
 import arrow.core.Hashed.Companion
 import arrow.core.extensions.HashedShow
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import kotlin.Suppress
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated(ShowDeprecation)
 inline fun <A> Companion.show(SA: Show<A>): HashedShow<A> = object :
     arrow.core.extensions.HashedShow<A> { override fun SA(): arrow.typeclasses.Show<A> = SA }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/show/IorShow.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/show/IorShow.kt
@@ -3,15 +3,13 @@ package arrow.core.extensions.ior.show
 import arrow.core.Ior.Companion
 import arrow.core.extensions.IorShow
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated(
-  "Show typeclass is deprecated. Use concrete methods on Ior",
-  level = DeprecationLevel.WARNING
-)
+@Deprecated(ShowDeprecation)
 inline fun <L, R> Companion.show(SL: Show<L>, SR: Show<R>): IorShow<L, R> = object :
     arrow.core.extensions.IorShow<L, R> { override fun SL(): arrow.typeclasses.Show<L> = SL
 

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/list/show/ListKShow.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/list/show/ListKShow.kt
@@ -1,8 +1,9 @@
 package arrow.core.extensions.list.show
 
 import arrow.core.extensions.ListKShow
-import arrow.core.show as _show
+import arrow.core.k
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import kotlin.String
 import kotlin.Suppress
 import kotlin.collections.List
@@ -15,9 +16,9 @@ import kotlin.jvm.JvmName
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension projected functions are deprecated", ReplaceWith("show(arg1)", "arrow.core.show"))
+@Deprecated(ShowDeprecation, ReplaceWith("toString()"))
 fun <A> List<A>.show(SA: Show<A>): String =
-  _show(SA)
+  k().show(SA)
 
 @Deprecated("Receiver List object is deprecated, prefer to turn List functions into top-level functions")
 object List {
@@ -25,6 +26,6 @@ object List {
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
   )
-  @Deprecated("@extension projected functions are deprecated", ReplaceWith("Show.list(arg1)", "arrow.core.list", "arrow.core.Show"))
+  @Deprecated(ShowDeprecation)
   inline fun <A> show(SA: Show<A>): ListKShow<A> = object : arrow.core.extensions.ListKShow<A> {
       override fun SA(): arrow.typeclasses.Show<A> = SA }}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/listk/show/ListKShow.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/listk/show/ListKShow.kt
@@ -5,6 +5,7 @@ import arrow.core.ForListK
 import arrow.core.ListK.Companion
 import arrow.core.extensions.ListKShow
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import kotlin.String
 import kotlin.Suppress
 import kotlin.jvm.JvmName
@@ -16,7 +17,7 @@ import kotlin.jvm.JvmName
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension projected functions are deprecated", ReplaceWith("show(arg1)", "arrow.core.show"))
+@Deprecated(ShowDeprecation, ReplaceWith("toString()"))
 fun <A> Kind<ForListK, A>.show(SA: Show<A>): String = arrow.core.ListK.show<A>(SA).run {
   this@show.show() as kotlin.String
 }
@@ -25,6 +26,6 @@ fun <A> Kind<ForListK, A>.show(SA: Show<A>): String = arrow.core.ListK.show<A>(S
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("@extension projected functions are deprecated", ReplaceWith("Show.list(SA)", "arrow.core.list", "arrow.core.Show"))
+@Deprecated(ShowDeprecation)
 inline fun <A> Companion.show(SA: Show<A>): ListKShow<A> = object :
     arrow.core.extensions.ListKShow<A> { override fun SA(): arrow.typeclasses.Show<A> = SA }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/mapk/show/MapKShow.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/mapk/show/MapKShow.kt
@@ -3,13 +3,14 @@ package arrow.core.extensions.mapk.show
 import arrow.core.MapK.Companion
 import arrow.core.extensions.MapKShow
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import kotlin.Suppress
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("@extension projected functions are deprecated", ReplaceWith("Show.map(SK, SA)", "arrow.core.Show", "arrow.core.map"))
+@Deprecated(ShowDeprecation)
 inline fun <K, A> Companion.show(SK: Show<K>, SA: Show<A>): MapKShow<K, A> = object :
     arrow.core.extensions.MapKShow<K, A> { override fun SK(): arrow.typeclasses.Show<K> = SK
 

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/show/NonEmptyListShow.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/show/NonEmptyListShow.kt
@@ -3,19 +3,13 @@ package arrow.core.extensions.nonemptylist.show
 import arrow.core.NonEmptyList.Companion
 import arrow.core.extensions.NonEmptyListShow
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import kotlin.Suppress
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated(
-  "@extension projected functions are deprecated",
-  ReplaceWith(
-    "Show.nonEmptyList(SA)",
-    "arrow.core.nonEmptyList", "arrow.core.Show"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(ShowDeprecation)
 inline fun <A> Companion.show(SA: Show<A>): NonEmptyListShow<A> = object :
     arrow.core.extensions.NonEmptyListShow<A> { override fun SA(): arrow.typeclasses.Show<A> = SA }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/number.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/number.kt
@@ -8,6 +8,7 @@ import arrow.typeclasses.Order
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Semiring
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 
 // ////////
 // Byte
@@ -42,7 +43,7 @@ interface ByteEq : Eq<Byte> {
   override fun Byte.eqv(b: Byte): Boolean = this == b
 }
 
-@Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Show.byte()", "arrow.core.Show", "arrow.core.byte"))
+@Deprecated(ShowDeprecation)
 interface ByteShow : Show<Byte> {
   override fun Byte.show(): String = toString()
 }
@@ -56,7 +57,7 @@ interface ByteHash : Hash<Byte>, ByteEq {
 fun Byte.Companion.hash(): Hash<Byte> =
   object : ByteHash {}
 
-@Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Show.byte()", "arrow.core.Show", "arrow.core.byte"))
+@Deprecated(ShowDeprecation)
 fun Byte.Companion.show(): Show<Byte> =
   object : ByteShow {}
 
@@ -113,7 +114,7 @@ interface DoubleEq : Eq<Double> {
   override fun Double.eqv(b: Double): Boolean = this == b
 }
 
-@Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Show.double()", "arrow.core.Show", "arrow.core.double"))
+@Deprecated(ShowDeprecation)
 interface DoubleShow : Show<Double> {
   override fun Double.show(): String = toString()
 }
@@ -127,7 +128,7 @@ interface DoubleHash : Hash<Double>, DoubleEq {
 fun Double.Companion.hash(): Hash<Double> =
   object : DoubleHash {}
 
-@Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Show.double()", "arrow.core.Show", "arrow.core.double"))
+@Deprecated(ShowDeprecation)
 fun Double.Companion.show(): Show<Double> =
   object : DoubleShow {}
 
@@ -178,7 +179,7 @@ interface IntEq : Eq<Int> {
   override fun Int.eqv(b: Int): Boolean = this == b
 }
 
-@Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Show.int()", "arrow.core.Show", "arrow.core.int"))
+@Deprecated(ShowDeprecation)
 interface IntShow : Show<Int> {
   override fun Int.show(): String = toString()
 }
@@ -197,7 +198,7 @@ interface IntHash : Hash<Int> {
 @Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Hash.int()", "arrow.core.Hash", "arrow.core.int"))
 fun Int.Companion.hash(): Hash<Int> = object : IntHash {}
 
-@Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Show.int()", "arrow.core.Show", "arrow.core.int"))
+@Deprecated(ShowDeprecation)
 fun Int.Companion.show(): Show<Int> =
   object : IntShow {}
 
@@ -254,7 +255,7 @@ interface LongEq : Eq<Long> {
   override fun Long.eqv(b: Long): Boolean = this == b
 }
 
-@Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Show.long()", "arrow.core.Show", "arrow.core.long"))
+@Deprecated(ShowDeprecation)
 interface LongShow : Show<Long> {
   override fun Long.show(): String = toString()
 }
@@ -268,7 +269,7 @@ interface LongHash : Hash<Long>, LongEq {
 fun Long.Companion.hash(): Hash<Long> =
   object : LongHash {}
 
-@Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Hash.long()", "arrow.core.Show", "arrow.core.long"))
+@Deprecated(ShowDeprecation)
 fun Long.Companion.show(): Show<Long> =
   object : LongShow {}
 
@@ -325,7 +326,7 @@ interface ShortEq : Eq<Short> {
   override fun Short.eqv(b: Short): Boolean = this == b
 }
 
-@Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Show.short()", "arrow.core.Show", "arrow.core.short"))
+@Deprecated(ShowDeprecation)
 interface ShortShow : Show<Short> {
   override fun Short.show(): String = toString()
 }
@@ -339,7 +340,7 @@ interface ShortHash : Hash<Short>, ShortEq {
 fun Short.Companion.hash(): Hash<Short> =
   object : ShortHash {}
 
-@Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Show.short()", "arrow.core.Show", "arrow.core.short"))
+@Deprecated(ShowDeprecation)
 fun Short.Companion.show(): Show<Short> =
   object : ShortShow {}
 
@@ -396,7 +397,7 @@ interface FloatEq : Eq<Float> {
   override fun Float.eqv(b: Float): Boolean = this == b
 }
 
-@Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Show.float()", "arrow.core.Show", "arrow.core.float"))
+@Deprecated(ShowDeprecation)
 interface FloatShow : Show<Float> {
   override fun Float.show(): String = toString()
 }
@@ -410,7 +411,7 @@ interface FloatHash : Hash<Float>, FloatEq {
 fun Float.Companion.hash(): Hash<Float> =
   object : FloatHash {}
 
-@Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Show.float()", "arrow.core.Show", "arrow.core.float"))
+@Deprecated(ShowDeprecation)
 fun Float.Companion.show(): Show<Float> =
   object : FloatShow {}
 

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/option/show/OptionShow.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/option/show/OptionShow.kt
@@ -3,14 +3,12 @@ package arrow.core.extensions.option.show
 import arrow.core.Option.Companion
 import arrow.core.extensions.OptionShow
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated(
-  "Show typeclass is deprecated. Use concrete methods on Option",
-  level = DeprecationLevel.WARNING
-)
+@Deprecated(ShowDeprecation)
 inline fun <A> Companion.show(SA: Show<A>): OptionShow<A> = object :
     arrow.core.extensions.OptionShow<A> { override fun SA(): arrow.typeclasses.Show<A> = SA }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ordering/show/OrderingShow.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ordering/show/OrderingShow.kt
@@ -2,6 +2,7 @@ package arrow.core.extensions.ordering.show
 
 import arrow.core.Ordering.Companion
 import arrow.core.extensions.OrderingShow
+import arrow.typeclasses.ShowDeprecation
 import kotlin.PublishedApi
 import kotlin.Suppress
 
@@ -15,5 +16,5 @@ internal val show_singleton: OrderingShow = object : arrow.core.extensions.Order
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Show.ordering()", "arrow.core.Show", "arrow.core.ordering"))
+@Deprecated(ShowDeprecation)
 inline fun Companion.show(): OrderingShow = show_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/show/SequenceKShow.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/show/SequenceKShow.kt
@@ -3,11 +3,13 @@ package arrow.core.extensions.sequencek.show
 import arrow.core.SequenceK.Companion
 import arrow.core.extensions.SequenceKShow
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import kotlin.Suppress
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated(ShowDeprecation)
 inline fun <A> Companion.show(SA: Show<A>): SequenceKShow<A> = object :
     arrow.core.extensions.SequenceKShow<A> { override fun SA(): arrow.typeclasses.Show<A> = SA }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/setk/show/SetKShow.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/setk/show/SetKShow.kt
@@ -3,21 +3,14 @@ package arrow.core.extensions.setk.show
 import arrow.core.SetK.Companion
 import arrow.core.extensions.SetKShow
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import kotlin.Suppress
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "Show.set<A>(SA)",
-    "arrow.core.set",
-    "arrow.typeclasses.Show"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(ShowDeprecation)
 inline fun <A> Companion.show(SA: Show<A>): SetKShow<A> = object : arrow.core.extensions.SetKShow<A> {
   override fun SA(): arrow.typeclasses.Show<A> = SA
 }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/tuple10/show/Tuple10Show.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/tuple10/show/Tuple10Show.kt
@@ -3,21 +3,14 @@ package arrow.core.extensions.tuple10.show
 import arrow.core.Tuple10.Companion
 import arrow.core.extensions.Tuple10Show
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import kotlin.Suppress
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "Show.tuple10(SA, SB, SC, SD, SE, SF, SG, SH, SI, SJ)",
-    "arrow.core.Show",
-    "arrow.core.tuple10"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(ShowDeprecation)
 inline fun <A, B, C, D, E, F, G, H, I, J> Companion.show(
   SA: Show<A>,
   SB: Show<B>,

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/tuple2/show/Tuple2Show.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/tuple2/show/Tuple2Show.kt
@@ -3,21 +3,14 @@ package arrow.core.extensions.tuple2.show
 import arrow.core.Tuple2.Companion
 import arrow.core.extensions.Tuple2Show
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import kotlin.Suppress
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated(
-  "Tuple2 is deprecated in favor of Kotlin's Pair. ReplaceWith Pair and use Pair instance of Show",
-  ReplaceWith(
-    "Show.pair(SA, SB, SC)",
-    "arrow.core.Show",
-    "arrow.core.pair"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(ShowDeprecation)
 inline fun <A, B> Companion.show(SA: Show<A>, SB: Show<B>): Tuple2Show<A, B> = object :
     arrow.core.extensions.Tuple2Show<A, B> { override fun SA(): arrow.typeclasses.Show<A> = SA
 

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/tuple3/show/Tuple3Show.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/tuple3/show/Tuple3Show.kt
@@ -3,21 +3,14 @@ package arrow.core.extensions.tuple3.show
 import arrow.core.Tuple3.Companion
 import arrow.core.extensions.Tuple3Show
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import kotlin.Suppress
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated(
-  "Tuple3 is deprecated in favor of Kotlin's Triple. ReplaceWith Triple and use Triple instance of Show",
-  ReplaceWith(
-    "Show.triple(SA, SB, SC)",
-    "arrow.core.Show",
-    "arrow.core.triple"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(ShowDeprecation)
 inline fun <A, B, C> Companion.show(
   SA: Show<A>,
   SB: Show<B>,

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/tuple4/show/Tuple4Show.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/tuple4/show/Tuple4Show.kt
@@ -3,21 +3,14 @@ package arrow.core.extensions.tuple4.show
 import arrow.core.Tuple4.Companion
 import arrow.core.extensions.Tuple4Show
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import kotlin.Suppress
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "Show.tuple4(SA, SB, SC, SD)",
-    "arrow.core.Show",
-    "arrow.core.tuple4"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(ShowDeprecation)
 inline fun <A, B, C, D> Companion.show(
   SA: Show<A>,
   SB: Show<B>,

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/tuple5/show/Tuple5Show.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/tuple5/show/Tuple5Show.kt
@@ -3,21 +3,14 @@ package arrow.core.extensions.tuple5.show
 import arrow.core.Tuple5.Companion
 import arrow.core.extensions.Tuple5Show
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import kotlin.Suppress
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "Show.tuple5(SA, SB, SC, SD, SE)",
-    "arrow.core.Show",
-    "arrow.core.tuple5"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(ShowDeprecation)
 inline fun <A, B, C, D, E> Companion.show(
   SA: Show<A>,
   SB: Show<B>,

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/tuple6/show/Tuple6Show.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/tuple6/show/Tuple6Show.kt
@@ -3,21 +3,14 @@ package arrow.core.extensions.tuple6.show
 import arrow.core.Tuple6.Companion
 import arrow.core.extensions.Tuple6Show
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import kotlin.Suppress
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "Show.tuple6(SA, SB, SC, SD, SE, SF)",
-    "arrow.core.Show",
-    "arrow.core.tuple6"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(ShowDeprecation)
 inline fun <A, B, C, D, E, F> Companion.show(
   SA: Show<A>,
   SB: Show<B>,

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/tuple7/show/Tuple7Show.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/tuple7/show/Tuple7Show.kt
@@ -3,21 +3,14 @@ package arrow.core.extensions.tuple7.show
 import arrow.core.Tuple7.Companion
 import arrow.core.extensions.Tuple7Show
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import kotlin.Suppress
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "Show.tuple7(SA, SB, SC, SD, SE, SF, SG)",
-    "arrow.core.Show",
-    "arrow.core.tuple7"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(ShowDeprecation)
 inline fun <A, B, C, D, E, F, G> Companion.show(
   SA: Show<A>,
   SB: Show<B>,

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/tuple8/show/Tuple8Show.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/tuple8/show/Tuple8Show.kt
@@ -3,21 +3,14 @@ package arrow.core.extensions.tuple8.show
 import arrow.core.Tuple8.Companion
 import arrow.core.extensions.Tuple8Show
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import kotlin.Suppress
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "Show.tuple8(SA, SB, SC, SD, SE, SF, SG, SH)",
-    "arrow.core.Show",
-    "arrow.core.tuple8"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(ShowDeprecation)
 inline fun <A, B, C, D, E, F, G, H> Companion.show(
   SA: Show<A>,
   SB: Show<B>,

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/tuple9/show/Tuple9Show.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/tuple9/show/Tuple9Show.kt
@@ -3,21 +3,14 @@ package arrow.core.extensions.tuple9.show
 import arrow.core.Tuple9.Companion
 import arrow.core.extensions.Tuple9Show
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import kotlin.Suppress
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "Show.tuple9(SA, SB, SC, SD, SE, SF, SG, SH, SI)",
-    "arrow.core.Show",
-    "arrow.core.tuple9"
-  ),
-  DeprecationLevel.WARNING
-)
+@Deprecated(ShowDeprecation)
 inline fun <A, B, C, D, E, F, G, H, I> Companion.show(
   SA: Show<A>,
   SB: Show<B>,

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/show/ValidatedShow.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/show/ValidatedShow.kt
@@ -3,13 +3,14 @@ package arrow.core.extensions.validated.show
 import arrow.core.Validated.Companion
 import arrow.core.extensions.ValidatedShow
 import arrow.typeclasses.Show
+import arrow.typeclasses.ShowDeprecation
 import kotlin.Suppress
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Show.validated(SL, SR)", "arrow.core.Show", "arrow.core.validated"))
+@Deprecated(ShowDeprecation)
 inline fun <L, R> Companion.show(SL: Show<L>, SR: Show<R>): ValidatedShow<L, R> = object :
     arrow.core.extensions.ValidatedShow<L, R> { override fun SL(): arrow.typeclasses.Show<L> = SL
 


### PR DESCRIPTION
This PR deprecates `Show` since Kotlin, and Kotlin's Std doesn't take `Show` into account nor does Kotlin have the power to automatically derive or inject `Show` anywhere. This makes `Show` very cumbersome to work with, see [Tuple10Show.kt](https://github.com/arrow-kt/arrow-core/compare/sv-deprecate-show?expand=1#diff-7f26da547470ab066e076a5795cdd1e670a17d5eded730b20bf9a7ecd844be86).

The use-cases of `Show` seemed very limited and niche to us, so we've decided to exclude it from Arrow in 1.0.0. The common technique for this is to use `data class`, which automatically implements `toString()` and correctly implementing `toString()`.