### PR TITLE
Deprecate Eq

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -4,7 +4,6 @@ import arrow.Kind
 import arrow.core.Either.Companion.resolve
 import arrow.core.Either.Left
 import arrow.core.Either.Right
-import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
@@ -1404,10 +1403,6 @@ fun <L> Left(left: L): Either<L, Nothing> = Left(left)
 
 fun <R> Right(right: R): Either<Nothing, R> = Right(right)
 
-/** Construct an [Eq] instance which use [EQL] and [EQR] to compare the [Left] and [Right] cases **/
-fun <L, R> Eq.Companion.either(EQL: Eq<L>, EQR: Eq<R>): Eq<Either<L, R>> =
-  EitherEq(EQL, EQR)
-
 fun <A, B> Hash.Companion.either(HA: Hash<A>, HB: Hash<B>): Hash<Either<A, B>> =
   EitherHash(HA, HB)
 
@@ -1646,41 +1641,6 @@ inline fun <A, B, C> Either<A, B>.redeem(fe: (A) -> C, fa: (B) -> C): Either<A, 
     is Right -> map(fa)
   }
 
-/**
- * Compares two instances of [Either] and returns true if they're considered not equal for this instance.
- *
- * @receiver object to compare with [other]
- * @param other object to compare with [this@neqv]
- * @returns false if [this@neqv] and [other] are equivalent, true otherwise.
- */
-fun <L, R> Either<L, R>.neqv(
-  EQL: Eq<L>,
-  EQR: Eq<R>,
-  other: Either<L, R>
-): Boolean = !eqv(EQL, EQR, other)
-
-/**
- * Compares two instances of [Either] and returns true if they're considered not equal for this instance.
- *
- * @receiver object to compare with [other]
- * @param other object to compare with [this@neqv]
- * @returns false if [this@neqv] and [other] are equivalent, true otherwise.
- */
-fun <L, R> Either<L, R>.eqv(
-  EQL: Eq<L>,
-  EQR: Eq<R>,
-  other: Either<L, R>
-): Boolean = when (this) {
-  is Left -> when (other) {
-    is Left -> EQL.run { a.eqv(other.a) }
-    is Right -> false
-  }
-  is Right -> when (other) {
-    is Left -> false
-    is Right -> EQR.run { this@eqv.b.eqv(other.b) }
-  }
-}
-
 fun <A, B> Either<A, B>.compare(OA: Order<A>, OB: Order<B>, b: Either<A, B>): Ordering = fold(
   { a1 -> b.fold({ a2 -> OA.run { a1.compare(a2) } }, { LT }) },
   { b1 -> b.fold({ GT }, { b2 -> OB.run { b1.compare(b2) } }) }
@@ -1832,14 +1792,6 @@ fun <A, B> Either<Iterable<A>, Iterable<B>>.bisequence(): List<Either<A, B>> =
 
 fun <A, B, C> Either<Validated<A, B>, Validated<A, C>>.bisequenceValidated(): Validated<A, Either<B, C>> =
   bitraverseValidated(::identity, ::identity)
-
-private class EitherEq<L, R>(
-  private val EQL: Eq<L>,
-  private val EQR: Eq<R>
-) : Eq<Either<L, R>> {
-  override fun Either<L, R>.eqv(b: Either<L, R>): Boolean =
-    eqv(EQL, EQR, b)
-}
 
 private class EitherHash<L, R>(
   private val HL: Hash<L>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Iterable.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Iterable.kt
@@ -2,7 +2,6 @@
 
 package arrow.core
 
-import arrow.typeclasses.Eq
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
@@ -667,17 +666,6 @@ fun <A, B> Iterable<A>.foldMap(MB: Monoid<B>, f: (A) -> B): B = MB.run {
     acc.combine(f(a))
   }
 }
-
-fun <A> Iterable<A>.eqv(EQA: Eq<A>, other: Iterable<A>): Boolean = EQA.run {
-  if (this is Collection<*> && other is Collection && this.size != other.size) false
-  else {
-    zip(other) { a, b -> a.eqv(b) }
-      .fold(true) { acc, bool -> acc && bool }
-  }
-}
-
-fun <A> Iterable<A>.neqv(EQA: Eq<A>, other: Iterable<A>): Boolean =
-  !eqv(EQA, other)
 
 fun <A, B> Iterable<A>.crosswalk(f: (A) -> Iterable<B>): List<List<B>> =
   fold(emptyList()) { bs, a ->

--- a/arrow-core-data/src/main/kotlin/arrow/core/List.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/List.kt
@@ -1,6 +1,5 @@
 package arrow.core
 
-import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
@@ -9,14 +8,6 @@ import arrow.typeclasses.Show
 import arrow.typeclasses.defaultSalt
 import arrow.typeclasses.hashWithSalt
 import kotlin.collections.plus as _plus
-
-fun <A> Eq.Companion.list(EQA: Eq<A>): Eq<List<A>> =
-  ListEq(EQA)
-
-private class ListEq<A>(private val EQA: Eq<A>) : Eq<List<A>> {
-  override fun List<A>.eqv(b: List<A>): Boolean =
-    eqv(EQA, b)
-}
 
 fun <A> Hash.Companion.list(HA: Hash<A>): Hash<List<A>> =
   ListHash(HA)

--- a/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
@@ -2,7 +2,6 @@ package arrow.core
 
 import arrow.Kind
 import arrow.typeclasses.Applicative
-import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
@@ -650,10 +649,6 @@ fun <A> NonEmptyList<A>.min(OA: Order<A>, b: NonEmptyList<A>): NonEmptyList<A> =
 fun <A> NonEmptyList<A>.sort(OA: Order<A>, b: NonEmptyList<A>): Tuple2<NonEmptyList<A>, NonEmptyList<A>> =
   if (gte(OA, b)) Tuple2(this, b) else Tuple2(b, this)
 
-/** Construct an [Eq] instance which use [EQA] to compare the elements of the lists **/
-fun <A> Eq.Companion.nonEmptyList(EQA: Eq<A>): Eq<NonEmptyList<A>> =
-  NonEmptyListEq(EQA)
-
 fun <A> Hash.Companion.nonEmptyList(HA: Hash<A>): Hash<NonEmptyList<A>> =
   NonEmptyListHash(HA)
 
@@ -666,12 +661,6 @@ fun <A> Semigroup.Companion.nonEmptyList(): Semigroup<NonEmptyList<A>> =
 
 fun <A> Show.Companion.nonEmptyList(SA: Show<A>): Show<NonEmptyList<A>> =
   NonEmptyListShow(SA)
-
-private class NonEmptyListEq<A>(
-  private val EQA: Eq<A>,
-) : Eq<NonEmptyList<A>> {
-  override fun NonEmptyList<A>.eqv(b: NonEmptyList<A>): Boolean = eqv(EQA, b)
-}
 
 private class NonEmptyListHash<A>(
   private val HA: Hash<A>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Ordering.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Ordering.kt
@@ -1,6 +1,5 @@
 package arrow.core
 
-import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
@@ -46,8 +45,6 @@ sealed class Ordering {
 
   fun compareTo(b: Ordering): Int = compare(b).toInt()
 
-  fun eqv(other: Ordering): Boolean = compare(other) == EQ
-
   fun lt(b: Ordering): Boolean = compare(b) == LT
 
   fun lte(b: Ordering): Boolean = compare(b) != GT
@@ -88,8 +85,6 @@ object EQ : Ordering()
 fun Collection<Ordering>.combineAll(): Ordering =
   if (isEmpty()) OrderingMonoid.empty() else reduce { a, b -> a.combine(b) }
 
-fun Eq.Companion.ordering(): Eq<Ordering> = OrderingEq
-
 fun Hash.Companion.ordering(): Hash<Ordering> = OrderingHash
 
 fun Semigroup.Companion.ordering(): Semigroup<Ordering> = OrderingMonoid
@@ -99,12 +94,6 @@ fun Monoid.Companion.ordering(): Monoid<Ordering> = OrderingMonoid
 fun Order.Companion.ordering(): Order<Ordering> = OrderingOrder
 
 fun Show.Companion.ordering(): Show<Ordering> = OrderingShow
-
-@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
-private object OrderingEq : Eq<Ordering> {
-  override fun Ordering.eqv(b: Ordering): Boolean =
-    this.eqv(b)
-}
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 private object OrderingHash : Hash<Ordering> {

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple10.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple10.kt
@@ -3,7 +3,6 @@
 
 package arrow.core
 
-import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
@@ -58,74 +57,6 @@ fun <A, B, C, D, E, F, G, H, I, J> Show.Companion.tuple10(
   SJ: Show<J>
 ): Show<Tuple10<A, B, C, D, E, F, G, H, I, J>> =
   Tuple10Show(SA, SB, SC, SD, SE, SF, SG, SH, SI, SJ)
-
-fun <A, B, C, D, E, F, G, H, I, J> Tuple10<A, B, C, D, E, F, G, H, I, J>.eqv(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  EQC: Eq<C>,
-  EQD: Eq<D>,
-  EQE: Eq<E>,
-  EQF: Eq<F>,
-  EQG: Eq<G>,
-  EQH: Eq<H>,
-  EQI: Eq<I>,
-  EQJ: Eq<J>,
-  other: Tuple10<A, B, C, D, E, F, G, H, I, J>
-): Boolean =
-  EQA.run { a.eqv(other.a) } &&
-    EQB.run { this@eqv.b.eqv(other.b) } &&
-    EQC.run { c.eqv(other.c) } &&
-    EQD.run { d.eqv(other.d) } &&
-    EQE.run { e.eqv(other.e) } &&
-    EQF.run { f.eqv(other.f) } &&
-    EQG.run { g.eqv(other.g) } &&
-    EQH.run { h.eqv(other.h) } &&
-    EQI.run { i.eqv(other.i) } &&
-    EQJ.run { j.eqv(other.j) }
-
-fun <A, B, C, D, E, F, G, H, I, J> Tuple10<A, B, C, D, E, F, G, H, I, J>.neqv(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  EQC: Eq<C>,
-  EQD: Eq<D>,
-  EQE: Eq<E>,
-  EQF: Eq<F>,
-  EQG: Eq<G>,
-  EQH: Eq<H>,
-  EQI: Eq<I>,
-  EQJ: Eq<J>,
-  other: Tuple10<A, B, C, D, E, F, G, H, I, J>
-): Boolean = !eqv(EQA, EQB, EQC, EQD, EQE, EQF, EQG, EQH, EQI, EQJ, other)
-
-private class Tuple10Eq<A, B, C, D, E, F, G, H, I, J>(
-  private val EQA: Eq<A>,
-  private val EQB: Eq<B>,
-  private val EQC: Eq<C>,
-  private val EQD: Eq<D>,
-  private val EQE: Eq<E>,
-  private val EQF: Eq<F>,
-  private val EQG: Eq<G>,
-  private val EQH: Eq<H>,
-  private val EQI: Eq<I>,
-  private val EQJ: Eq<J>,
-) : Eq<Tuple10<A, B, C, D, E, F, G, H, I, J>> {
-  override fun Tuple10<A, B, C, D, E, F, G, H, I, J>.eqv(other: Tuple10<A, B, C, D, E, F, G, H, I, J>): Boolean =
-    eqv(EQA, EQB, EQC, EQD, EQE, EQF, EQG, EQH, EQI, EQJ, other)
-}
-
-fun <A, B, C, D, E, F, G, H, I, J> Eq.Companion.tuple10(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  EQC: Eq<C>,
-  EQD: Eq<D>,
-  EQE: Eq<E>,
-  EQF: Eq<F>,
-  EQG: Eq<G>,
-  EQH: Eq<H>,
-  EQI: Eq<I>,
-  EQJ: Eq<J>
-): Eq<Tuple10<A, B, C, D, E, F, G, H, I, J>> =
-  Tuple10Eq(EQA, EQB, EQC, EQD, EQE, EQF, EQG, EQH, EQI, EQJ)
 
 fun <A, B, C, D, E, F, G, H, I, J> Tuple10<A, B, C, D, E, F, G, H, I, J>.hashWithSalt(
   HA: Hash<A>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple2.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple2.kt
@@ -3,7 +3,6 @@
 
 package arrow.core
 
-import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
@@ -82,34 +81,6 @@ fun <A, B> Show.Companion.pair(
   SB: Show<B>
 ): Show<Pair<A, B>> =
   PairShow(SA, SB)
-
-fun <A, B> Pair<A, B>.eqv(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  other: Pair<A, B>
-): Boolean =
-  EQA.run { first.eqv(other.first) } &&
-    EQB.run { this@eqv.second.eqv(other.second) }
-
-fun <A, B> Pair<A, B>.neqv(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  other: Pair<A, B>
-): Boolean = !eqv(EQA, EQB, other)
-
-private class PairEq<A, B>(
-  private val EQA: Eq<A>,
-  private val EQB: Eq<B>
-) : Eq<Pair<A, B>> {
-  override fun Pair<A, B>.eqv(other: Pair<A, B>): Boolean =
-    eqv(EQA, EQB, other)
-}
-
-fun <A, B> Eq.Companion.pair(
-  EQA: Eq<A>,
-  EQB: Eq<B>
-): Eq<Pair<A, B>> =
-  PairEq(EQA, EQB)
 
 fun <A, B> Pair<A, B>.hashWithSalt(
   HA: Hash<A>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple3.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple3.kt
@@ -3,7 +3,6 @@
 
 package arrow.core
 
-import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
@@ -48,39 +47,6 @@ fun <A, B, C> Show.Companion.triple(
   SC: Show<C>
 ): Show<Triple<A, B, C>> =
   TripleShow(SA, SB, SC)
-
-fun <A, B, C> Triple<A, B, C>.eqv(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  EQC: Eq<C>,
-  other: Triple<A, B, C>
-): Boolean =
-  EQA.run { first.eqv(other.first) } &&
-    EQB.run { this@eqv.second.eqv(other.second) } &&
-    EQC.run { third.eqv(other.third) }
-
-fun <A, B, C> Triple<A, B, C>.neqv(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  EQC: Eq<C>,
-  other: Triple<A, B, C>
-): Boolean = !eqv(EQA, EQB, EQC, other)
-
-private class TripleEq<A, B, C>(
-  private val EQA: Eq<A>,
-  private val EQB: Eq<B>,
-  private val EQC: Eq<C>
-) : Eq<Triple<A, B, C>> {
-  override fun Triple<A, B, C>.eqv(other: Triple<A, B, C>): Boolean =
-    eqv(EQA, EQB, EQC, other)
-}
-
-fun <A, B, C> Eq.Companion.triple(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  EQC: Eq<C>
-): Eq<Triple<A, B, C>> =
-  TripleEq(EQA, EQB, EQC)
 
 fun <A, B, C> Triple<A, B, C>.hashWithSalt(
   HA: Hash<A>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple4.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple4.kt
@@ -3,7 +3,6 @@
 
 package arrow.core
 
-import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
@@ -46,44 +45,6 @@ fun <A, B, C, D> Show.Companion.tuple4(
   SD: Show<D>
 ): Show<Tuple4<A, B, C, D>> =
   Tuple4Show(SA, SB, SC, SD)
-
-fun <A, B, C, D> Tuple4<A, B, C, D>.eqv(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  EQC: Eq<C>,
-  EQD: Eq<D>,
-  other: Tuple4<A, B, C, D>
-): Boolean =
-  EQA.run { a.eqv(other.a) } &&
-    EQB.run { this@eqv.b.eqv(other.b) } &&
-    EQC.run { c.eqv(other.c) } &&
-    EQD.run { d.eqv(other.d) }
-
-fun <A, B, C, D> Tuple4<A, B, C, D>.neqv(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  EQC: Eq<C>,
-  EQD: Eq<D>,
-  other: Tuple4<A, B, C, D>
-): Boolean = !eqv(EQA, EQB, EQC, EQD, other)
-
-private class Tuple4Eq<A, B, C, D>(
-  private val EQA: Eq<A>,
-  private val EQB: Eq<B>,
-  private val EQC: Eq<C>,
-  private val EQD: Eq<D>
-) : Eq<Tuple4<A, B, C, D>> {
-  override fun Tuple4<A, B, C, D>.eqv(other: Tuple4<A, B, C, D>): Boolean =
-    eqv(EQA, EQB, EQC, EQD, other)
-}
-
-fun <A, B, C, D> Eq.Companion.tuple4(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  EQC: Eq<C>,
-  EQD: Eq<D>
-): Eq<Tuple4<A, B, C, D>> =
-  Tuple4Eq(EQA, EQB, EQC, EQD)
 
 fun <A, B, C, D> Tuple4<A, B, C, D>.hashWithSalt(
   HA: Hash<A>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple5.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple5.kt
@@ -3,7 +3,6 @@
 
 package arrow.core
 
-import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
@@ -48,49 +47,6 @@ fun <A, B, C, D, E> Show.Companion.tuple5(
   SE: Show<E>
 ): Show<Tuple5<A, B, C, D, E>> =
   Tuple5Show(SA, SB, SC, SD, SE)
-
-fun <A, B, C, D, E> Tuple5<A, B, C, D, E>.eqv(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  EQC: Eq<C>,
-  EQD: Eq<D>,
-  EQE: Eq<E>,
-  other: Tuple5<A, B, C, D, E>
-): Boolean =
-  EQA.run { a.eqv(other.a) } &&
-    EQB.run { this@eqv.b.eqv(other.b) } &&
-    EQC.run { c.eqv(other.c) } &&
-    EQD.run { d.eqv(other.d) } &&
-    EQE.run { e.eqv(other.e) }
-
-fun <A, B, C, D, E> Tuple5<A, B, C, D, E>.neqv(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  EQC: Eq<C>,
-  EQD: Eq<D>,
-  EQE: Eq<E>,
-  other: Tuple5<A, B, C, D, E>
-): Boolean = !eqv(EQA, EQB, EQC, EQD, EQE, other)
-
-private class Tuple5Eq<A, B, C, D, E>(
-  private val EQA: Eq<A>,
-  private val EQB: Eq<B>,
-  private val EQC: Eq<C>,
-  private val EQD: Eq<D>,
-  private val EQE: Eq<E>
-) : Eq<Tuple5<A, B, C, D, E>> {
-  override fun Tuple5<A, B, C, D, E>.eqv(other: Tuple5<A, B, C, D, E>): Boolean =
-    eqv(EQA, EQB, EQC, EQD, EQE, other)
-}
-
-fun <A, B, C, D, E> Eq.Companion.tuple5(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  EQC: Eq<C>,
-  EQD: Eq<D>,
-  EQE: Eq<E>
-): Eq<Tuple5<A, B, C, D, E>> =
-  Tuple5Eq(EQA, EQB, EQC, EQD, EQE)
 
 fun <A, B, C, D, E> Tuple5<A, B, C, D, E>.hashWithSalt(
   HA: Hash<A>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple6.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple6.kt
@@ -3,7 +3,6 @@
 
 package arrow.core
 
-import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
@@ -50,54 +49,6 @@ fun <A, B, C, D, E, F> Show.Companion.tuple6(
   SF: Show<F>
 ): Show<Tuple6<A, B, C, D, E, F>> =
   Tuple6Show(SA, SB, SC, SD, SE, SF)
-
-fun <A, B, C, D, E, F> Tuple6<A, B, C, D, E, F>.eqv(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  EQC: Eq<C>,
-  EQD: Eq<D>,
-  EQE: Eq<E>,
-  EQF: Eq<F>,
-  other: Tuple6<A, B, C, D, E, F>
-): Boolean =
-  EQA.run { a.eqv(other.a) } &&
-    EQB.run { this@eqv.b.eqv(other.b) } &&
-    EQC.run { c.eqv(other.c) } &&
-    EQD.run { d.eqv(other.d) } &&
-    EQE.run { e.eqv(other.e) } &&
-    EQF.run { f.eqv(other.f) }
-
-fun <A, B, C, D, E, F> Tuple6<A, B, C, D, E, F>.neqv(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  EQC: Eq<C>,
-  EQD: Eq<D>,
-  EQE: Eq<E>,
-  EQF: Eq<F>,
-  other: Tuple6<A, B, C, D, E, F>
-): Boolean = !eqv(EQA, EQB, EQC, EQD, EQE, EQF, other)
-
-private class Tuple6Eq<A, B, C, D, E, F>(
-  private val EQA: Eq<A>,
-  private val EQB: Eq<B>,
-  private val EQC: Eq<C>,
-  private val EQD: Eq<D>,
-  private val EQE: Eq<E>,
-  private val EQF: Eq<F>
-) : Eq<Tuple6<A, B, C, D, E, F>> {
-  override fun Tuple6<A, B, C, D, E, F>.eqv(other: Tuple6<A, B, C, D, E, F>): Boolean =
-    eqv(EQA, EQB, EQC, EQD, EQE, EQF, other)
-}
-
-fun <A, B, C, D, E, F> Eq.Companion.tuple6(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  EQC: Eq<C>,
-  EQD: Eq<D>,
-  EQE: Eq<E>,
-  EQF: Eq<F>
-): Eq<Tuple6<A, B, C, D, E, F>> =
-  Tuple6Eq(EQA, EQB, EQC, EQD, EQE, EQF)
 
 fun <A, B, C, D, E, F> Tuple6<A, B, C, D, E, F>.hashWithSalt(
   HA: Hash<A>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple7.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple7.kt
@@ -3,7 +3,6 @@
 
 package arrow.core
 
-import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
@@ -52,59 +51,6 @@ fun <A, B, C, D, E, F, G> Show.Companion.tuple7(
   SG: Show<G>
 ): Show<Tuple7<A, B, C, D, E, F, G>> =
   Tuple7Show(SA, SB, SC, SD, SE, SF, SG)
-
-fun <A, B, C, D, E, F, G> Tuple7<A, B, C, D, E, F, G>.eqv(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  EQC: Eq<C>,
-  EQD: Eq<D>,
-  EQE: Eq<E>,
-  EQF: Eq<F>,
-  EQG: Eq<G>,
-  other: Tuple7<A, B, C, D, E, F, G>
-): Boolean =
-  EQA.run { a.eqv(other.a) } &&
-    EQB.run { this@eqv.b.eqv(other.b) } &&
-    EQC.run { c.eqv(other.c) } &&
-    EQD.run { d.eqv(other.d) } &&
-    EQE.run { e.eqv(other.e) } &&
-    EQF.run { f.eqv(other.f) } &&
-    EQG.run { g.eqv(other.g) }
-
-fun <A, B, C, D, E, F, G> Tuple7<A, B, C, D, E, F, G>.neqv(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  EQC: Eq<C>,
-  EQD: Eq<D>,
-  EQE: Eq<E>,
-  EQF: Eq<F>,
-  EQG: Eq<G>,
-  other: Tuple7<A, B, C, D, E, F, G>
-): Boolean = !eqv(EQA, EQB, EQC, EQD, EQE, EQF, EQG, other)
-
-private class Tuple7Eq<A, B, C, D, E, F, G>(
-  private val EQA: Eq<A>,
-  private val EQB: Eq<B>,
-  private val EQC: Eq<C>,
-  private val EQD: Eq<D>,
-  private val EQE: Eq<E>,
-  private val EQF: Eq<F>,
-  private val EQG: Eq<G>
-) : Eq<Tuple7<A, B, C, D, E, F, G>> {
-  override fun Tuple7<A, B, C, D, E, F, G>.eqv(other: Tuple7<A, B, C, D, E, F, G>): Boolean =
-    eqv(EQA, EQB, EQC, EQD, EQE, EQF, EQG, other)
-}
-
-fun <A, B, C, D, E, F, G> Eq.Companion.tuple7(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  EQC: Eq<C>,
-  EQD: Eq<D>,
-  EQE: Eq<E>,
-  EQF: Eq<F>,
-  EQG: Eq<G>
-): Eq<Tuple7<A, B, C, D, E, F, G>> =
-  Tuple7Eq(EQA, EQB, EQC, EQD, EQE, EQF, EQG)
 
 fun <A, B, C, D, E, F, G> Tuple7<A, B, C, D, E, F, G>.hashWithSalt(
   HA: Hash<A>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple8.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple8.kt
@@ -3,7 +3,6 @@
 
 package arrow.core
 
-import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
@@ -54,64 +53,6 @@ fun <A, B, C, D, E, F, G, H> Show.Companion.tuple8(
   SH: Show<H>
 ): Show<Tuple8<A, B, C, D, E, F, G, H>> =
   Tuple8Show(SA, SB, SC, SD, SE, SF, SG, SH)
-
-fun <A, B, C, D, E, F, G, H> Tuple8<A, B, C, D, E, F, G, H>.eqv(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  EQC: Eq<C>,
-  EQD: Eq<D>,
-  EQE: Eq<E>,
-  EQF: Eq<F>,
-  EQG: Eq<G>,
-  EQH: Eq<H>,
-  other: Tuple8<A, B, C, D, E, F, G, H>
-): Boolean =
-  EQA.run { a.eqv(other.a) } &&
-    EQB.run { this@eqv.b.eqv(other.b) } &&
-    EQC.run { c.eqv(other.c) } &&
-    EQD.run { d.eqv(other.d) } &&
-    EQE.run { e.eqv(other.e) } &&
-    EQF.run { f.eqv(other.f) } &&
-    EQG.run { g.eqv(other.g) } &&
-    EQH.run { h.eqv(other.h) }
-
-fun <A, B, C, D, E, F, G, H> Tuple8<A, B, C, D, E, F, G, H>.neqv(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  EQC: Eq<C>,
-  EQD: Eq<D>,
-  EQE: Eq<E>,
-  EQF: Eq<F>,
-  EQG: Eq<G>,
-  EQH: Eq<H>,
-  other: Tuple8<A, B, C, D, E, F, G, H>
-): Boolean = !eqv(EQA, EQB, EQC, EQD, EQE, EQF, EQG, EQH, other)
-
-private class Tuple8Eq<A, B, C, D, E, F, G, H>(
-  private val EQA: Eq<A>,
-  private val EQB: Eq<B>,
-  private val EQC: Eq<C>,
-  private val EQD: Eq<D>,
-  private val EQE: Eq<E>,
-  private val EQF: Eq<F>,
-  private val EQG: Eq<G>,
-  private val EQH: Eq<H>
-) : Eq<Tuple8<A, B, C, D, E, F, G, H>> {
-  override fun Tuple8<A, B, C, D, E, F, G, H>.eqv(other: Tuple8<A, B, C, D, E, F, G, H>): Boolean =
-    eqv(EQA, EQB, EQC, EQD, EQE, EQF, EQG, EQH, other)
-}
-
-fun <A, B, C, D, E, F, G, H> Eq.Companion.tuple8(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  EQC: Eq<C>,
-  EQD: Eq<D>,
-  EQE: Eq<E>,
-  EQF: Eq<F>,
-  EQG: Eq<G>,
-  EQH: Eq<H>
-): Eq<Tuple8<A, B, C, D, E, F, G, H>> =
-  Tuple8Eq(EQA, EQB, EQC, EQD, EQE, EQF, EQG, EQH)
 
 fun <A, B, C, D, E, F, G, H> Tuple8<A, B, C, D, E, F, G, H>.hashWithSalt(
   HA: Hash<A>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple9.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple9.kt
@@ -3,7 +3,6 @@
 
 package arrow.core
 
-import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
@@ -56,69 +55,6 @@ fun <A, B, C, D, E, F, G, H, I> Show.Companion.tuple9(
   SI: Show<I>
 ): Show<Tuple9<A, B, C, D, E, F, G, H, I>> =
   Tuple9Show(SA, SB, SC, SD, SE, SF, SG, SH, SI)
-
-fun <A, B, C, D, E, F, G, H, I> Tuple9<A, B, C, D, E, F, G, H, I>.eqv(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  EQC: Eq<C>,
-  EQD: Eq<D>,
-  EQE: Eq<E>,
-  EQF: Eq<F>,
-  EQG: Eq<G>,
-  EQH: Eq<H>,
-  EQI: Eq<I>,
-  other: Tuple9<A, B, C, D, E, F, G, H, I>
-): Boolean =
-  EQA.run { a.eqv(other.a) } &&
-    EQB.run { this@eqv.b.eqv(other.b) } &&
-    EQC.run { c.eqv(other.c) } &&
-    EQD.run { d.eqv(other.d) } &&
-    EQE.run { e.eqv(other.e) } &&
-    EQF.run { f.eqv(other.f) } &&
-    EQG.run { g.eqv(other.g) } &&
-    EQH.run { h.eqv(other.h) } &&
-    EQI.run { i.eqv(other.i) }
-
-fun <A, B, C, D, E, F, G, H, I> Tuple9<A, B, C, D, E, F, G, H, I>.neqv(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  EQC: Eq<C>,
-  EQD: Eq<D>,
-  EQE: Eq<E>,
-  EQF: Eq<F>,
-  EQG: Eq<G>,
-  EQH: Eq<H>,
-  EQI: Eq<I>,
-  other: Tuple9<A, B, C, D, E, F, G, H, I>
-): Boolean = !eqv(EQA, EQB, EQC, EQD, EQE, EQF, EQG, EQH, EQI, other)
-
-private class Tuple9Eq<A, B, C, D, E, F, G, H, I>(
-  private val EQA: Eq<A>,
-  private val EQB: Eq<B>,
-  private val EQC: Eq<C>,
-  private val EQD: Eq<D>,
-  private val EQE: Eq<E>,
-  private val EQF: Eq<F>,
-  private val EQG: Eq<G>,
-  private val EQH: Eq<H>,
-  private val EQI: Eq<I>
-) : Eq<Tuple9<A, B, C, D, E, F, G, H, I>> {
-  override fun Tuple9<A, B, C, D, E, F, G, H, I>.eqv(other: Tuple9<A, B, C, D, E, F, G, H, I>): Boolean =
-    eqv(EQA, EQB, EQC, EQD, EQE, EQF, EQG, EQH, EQI, other)
-}
-
-fun <A, B, C, D, E, F, G, H, I> Eq.Companion.tuple9(
-  EQA: Eq<A>,
-  EQB: Eq<B>,
-  EQC: Eq<C>,
-  EQD: Eq<D>,
-  EQE: Eq<E>,
-  EQF: Eq<F>,
-  EQG: Eq<G>,
-  EQH: Eq<H>,
-  EQI: Eq<I>
-): Eq<Tuple9<A, B, C, D, E, F, G, H, I>> =
-  Tuple9Eq(EQA, EQB, EQC, EQD, EQE, EQF, EQG, EQH, EQI)
 
 fun <A, B, C, D, E, F, G, H, I> Tuple9<A, B, C, D, E, F, G, H, I>.hashWithSalt(
   HA: Hash<A>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -2,7 +2,6 @@ package arrow.core
 
 import arrow.Kind
 import arrow.typeclasses.Applicative
-import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
@@ -948,10 +947,6 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
     fold(::Valid, ::Invalid)
 }
 
-/** Construct an [Eq] instance which use [EQE] and [EQA] to compare the [Invalid] and [Valid] cases **/
-fun <E, A> Eq.Companion.validated(EQE: Eq<E>, EQA: Eq<A>): Eq<Validated<E, A>> =
-  ValidatedEq(EQE, EQA)
-
 fun <E, A> Hash.Companion.validated(HE: Hash<E>, HA: Hash<A>): Hash<Validated<E, A>> =
   ValidatedHash(HE, HA)
 
@@ -966,42 +961,6 @@ fun <E, A> Semigroup.Companion.validated(SE: Semigroup<E>, SA: Semigroup<A>): Se
 
 fun <E, A> Semigroup.Companion.monoid(SE: Semigroup<E>, MA: Monoid<A>): Monoid<Validated<E, A>> =
   ValidatedMonoid(SE, MA)
-
-/**
- * Compares two instances of [Validated] and returns true if they're considered not equal for this instance.
- *
- * @receiver object to compare with [other]
- * @param other object to compare with [this@neqv]
- * @returns false if [this@neqv] and [other] are equivalent, true otherwise.
- */
-fun <E, B> Validated<E, B>.neqv(
-  EQL: Eq<E>,
-  EQR: Eq<B>,
-  other: Validated<E, B>
-): Boolean =
-  !eqv(EQL, EQR, other)
-
-/**
- * Compares two instances of [Validated] and returns true if they're considered not equal for this instance.
- *
- * @receiver object to compare with [other]
- * @param other object to compare with [this@neqv]
- * @returns false if [this@neqv] and [other] are equivalent, true otherwise.
- */
-fun <E, B> Validated<E, B>.eqv(
-  EQL: Eq<E>,
-  EQR: Eq<B>,
-  other: Validated<E, B>
-): Boolean = when (this) {
-  is Valid -> when (other) {
-    is Invalid -> false
-    is Valid -> EQR.run { a.eqv(other.a) }
-  }
-  is Invalid -> when (other) {
-    is Invalid -> EQL.run { e.eqv(other.e) }
-    is Valid -> false
-  }
-}
 
 /**
  * Given [A] is a sub type of [B], re-type this value from Validated<E, A> to Validated<E, B>
@@ -1254,15 +1213,6 @@ inline fun <A> A.validNel(): ValidatedNel<Nothing, A> =
 
 inline fun <E> E.invalidNel(): ValidatedNel<E, Nothing> =
   Validated.invalidNel(this)
-
-private class ValidatedEq<L, R>(
-  private val EQL: Eq<L>,
-  private val EQR: Eq<R>
-) : Eq<Validated<L, R>> {
-
-  override fun Validated<L, R>.eqv(b: Validated<L, R>): Boolean =
-    eqv(EQL, EQR, b)
-}
 
 private class ValidatedShow<L, R>(
   private val SL: Show<L>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/boolean.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/boolean.kt
@@ -1,6 +1,5 @@
 package arrow.core
 
-import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
@@ -9,10 +8,6 @@ import arrow.typeclasses.Show
 private object BooleanShow : Show<Boolean> {
   override fun Boolean.show(): String =
     this.toString()
-}
-
-private object BooleanEq : Eq<Boolean> {
-  override fun Boolean.eqv(b: Boolean): Boolean = this == b
 }
 
 private object BooleanOrder : Order<Boolean> {
@@ -26,9 +21,6 @@ private object BooleanHash : Hash<Boolean> {
 
 fun Show.Companion.boolean(): Show<Boolean> =
   BooleanShow
-
-fun Eq.Companion.boolean(): Eq<Boolean> =
-  BooleanEq
 
 fun Order.Companion.boolean(): Order<Boolean> =
   BooleanOrder

--- a/arrow-core-data/src/main/kotlin/arrow/core/char.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/char.kt
@@ -1,6 +1,5 @@
 package arrow.core
 
-import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Order
 import arrow.typeclasses.Show
@@ -8,10 +7,6 @@ import arrow.typeclasses.Show
 private object CharShow : Show<Char> {
   override fun Char.show(): String =
     this.toString()
-}
-
-private object CharEq : Eq<Char> {
-  override fun Char.eqv(b: Char): Boolean = this == b
 }
 
 private object CharOrder : Order<Char> {
@@ -28,9 +23,6 @@ private object CharHash : Hash<Char> {
 
 fun Show.Companion.char(): Show<Char> =
   CharShow
-
-fun Eq.Companion.char(): Eq<Char> =
-  CharEq
 
 fun Order.Companion.char(): Order<Char> =
   CharOrder

--- a/arrow-core-data/src/main/kotlin/arrow/core/map.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/map.kt
@@ -1,6 +1,5 @@
 package arrow.core
 
-import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Semigroup
@@ -304,27 +303,6 @@ fun <K, A, B, C> Map<K, A>.zip(other: Map<K, B>, f: (K, A, B) -> C): Map<K, C> =
   keys.intersect(other.keys).mapNotNull { key ->
     Nullable.mapN(this[key], other[key]) { a, b -> key to f(key, a, b) }
   }.toMap()
-
-fun <K, A> Map<K, A>.eqv(EQK: Eq<K>, EQA: Eq<A>, b: Map<K, A>): Boolean =
-  if (keys.eqv(EQK, b.keys)) EQA.run {
-    keys.map { key ->
-      b[key]?.let { getValue(key).eqv(it) } ?: false
-    }.fold(true) { b1, b2 -> b1 && b2 }
-  } else false
-
-fun <K, A> Map<K, A>.neqv(EQK: Eq<K>, EQA: Eq<A>, b: Map<K, A>): Boolean =
-  !eqv(EQK, EQA, b)
-
-fun <K, A> Eq.Companion.map(EQK: Eq<K>, EQA: Eq<A>): Eq<Map<K, A>> =
-  MapEq(EQK, EQA)
-
-private class MapEq<K, A>(
-  private val EQK: Eq<K>,
-  private val EQA: Eq<A>
-) : Eq<Map<K, A>> {
-  override fun Map<K, A>.eqv(b: Map<K, A>): Boolean =
-    eqv(EQK, EQA, b)
-}
 
 fun <K, A> Map<K, A>.hashWithSalt(HK: Hash<K>, HA: Hash<A>, salt: Int): Int =
   values.toHashSet().hashWithSalt(HA, salt)

--- a/arrow-core-data/src/main/kotlin/arrow/core/number.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/number.kt
@@ -1,6 +1,5 @@
 package arrow.core
 
-import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
@@ -33,10 +32,6 @@ private object ByteOrder : Order<Byte> {
   override fun Byte.compareTo(b: Byte): Int = this.compareTo(b)
 }
 
-private object ByteEq : Eq<Byte> {
-  override fun Byte.eqv(b: Byte): Boolean = this == b
-}
-
 private object ByteShow : Show<Byte> {
   override fun Byte.show(): String = toString()
 }
@@ -50,9 +45,6 @@ fun Hash.Companion.byte(): Hash<Byte> =
 
 fun Show.Companion.byte(): Show<Byte> =
   ByteShow
-
-fun Eq.Companion.byte(): Eq<Byte> =
-  ByteEq
 
 fun Order.Companion.byte(): Order<Byte> =
   ByteOrder
@@ -91,10 +83,6 @@ private object DoubleOrder : Order<Double> {
   override fun Double.compareTo(b: Double): Int = this.compareTo(b)
 }
 
-private object DoubleEq : Eq<Double> {
-  override fun Double.eqv(b: Double): Boolean = this == b
-}
-
 private object DoubleShow : Show<Double> {
   override fun Double.show(): String = toString()
 }
@@ -108,9 +96,6 @@ fun Hash.Companion.double(): Hash<Double> =
 
 fun Show.Companion.double(): Show<Double> =
   DoubleShow
-
-fun Eq.Companion.double(): Eq<Double> =
-  DoubleEq
 
 fun Order.Companion.double(): Order<Double> =
   DoubleOrder
@@ -144,10 +129,6 @@ private object IntSemiring : Semiring<Int> {
   override fun Int.combineMultiplicate(b: Int): Int = this * b
 }
 
-private object IntEq : Eq<Int> {
-  override fun Int.eqv(b: Int): Boolean = this == b
-}
-
 private object IntShow : Show<Int> {
   override fun Int.show(): String = toString()
 }
@@ -166,9 +147,6 @@ fun Hash.Companion.int(): Hash<Int> =
 
 fun Show.Companion.int(): Show<Int> =
   IntShow
-
-fun Eq.Companion.int(): Eq<Int> =
-  IntEq
 
 fun Order.Companion.int(): Order<Int> =
   IntOrder
@@ -207,10 +185,6 @@ private object LongOrder : Order<Long> {
   override fun Long.compareTo(b: Long): Int = this.compareTo(b)
 }
 
-private object LongEq : Eq<Long> {
-  override fun Long.eqv(b: Long): Boolean = this == b
-}
-
 private object LongShow : Show<Long> {
   override fun Long.show(): String = toString()
 }
@@ -224,9 +198,6 @@ fun Hash.Companion.long(): Hash<Long> =
 
 fun Show.Companion.long(): Show<Long> =
   LongShow
-
-fun Eq.Companion.long(): Eq<Long> =
-  LongEq
 
 fun Order.Companion.long(): Order<Long> =
   LongOrder
@@ -265,10 +236,6 @@ private object ShortOrder : Order<Short> {
   override fun Short.compareTo(b: Short): Int = this.compareTo(b)
 }
 
-private object ShortEq : Eq<Short> {
-  override fun Short.eqv(b: Short): Boolean = this == b
-}
-
 private object ShortShow : Show<Short> {
   override fun Short.show(): String = toString()
 }
@@ -282,9 +249,6 @@ fun Hash.Companion.short(): Hash<Short> =
 
 fun Show.Companion.short(): Show<Short> =
   ShortShow
-
-fun Eq.Companion.short(): Eq<Short> =
-  ShortEq
 
 fun Order.Companion.short(): Order<Short> =
   ShortOrder
@@ -323,10 +287,6 @@ private object FloatOrder : Order<Float> {
   override fun Float.compareTo(b: Float): Int = this.compareTo(b)
 }
 
-private object FloatEq : Eq<Float> {
-  override fun Float.eqv(b: Float): Boolean = this == b
-}
-
 private object FloatShow : Show<Float> {
   override fun Float.show(): String = toString()
 }
@@ -340,9 +300,6 @@ fun Hash.Companion.float(): Hash<Float> =
 
 fun Show.Companion.float(): Show<Float> =
   FloatShow
-
-fun Eq.Companion.float(): Eq<Float> =
-  FloatEq
 
 fun Order.Companion.float(): Order<Float> =
   FloatOrder

--- a/arrow-core-data/src/main/kotlin/arrow/core/set.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/set.kt
@@ -1,6 +1,5 @@
 package arrow.core
 
-import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Semigroup
@@ -10,14 +9,6 @@ import arrow.typeclasses.hashWithSalt
 object SetExtensions
 
 object SortedSetInstances
-
-fun <A> Set<A>.eqv(EQA: Eq<A>, b: Set<A>): Boolean =
-  if (size == b.size) EQA.run {
-    fold(true) { acc, aa ->
-      val found = (b.find { bb -> aa.eqv(bb) } != null)
-      acc && found
-    }
-  } else false
 
 fun <A> Set<A>.hashWithSalt(HA: Hash<A>, salt: Int): Int = HA.run {
   fold(salt) { hash, v -> v.hashWithSalt(hash) }
@@ -34,16 +25,6 @@ fun <A> Monoid.Companion.set(): Monoid<Set<A>> = object : Monoid<Set<A>> {
 
   override fun Set<A>.combine(b: Set<A>): Set<A> =
     this + b
-}
-
-fun <A> Eq.Companion.set(EQ: () -> Eq<A>): Eq<Set<A>> = object : Eq<Set<A>> {
-  override fun Set<A>.eqv(b: Set<A>): Boolean =
-    if (size == b.size) map { aa ->
-      b.find { bb -> EQ().run { aa.eqv(bb) } } != null
-    }.fold(true) { acc, bool ->
-      acc && bool
-    }
-    else false
 }
 
 fun <A> Show.Companion.set(SA: () -> Show<A>): Show<Set<A>> = object : Show<Set<A>> {

--- a/arrow-core-data/src/main/kotlin/arrow/core/string.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/string.kt
@@ -1,6 +1,5 @@
 package arrow.core
 
-import arrow.typeclasses.Eq
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
@@ -21,13 +20,6 @@ private object StringMonoid : Monoid<String> {
 
 fun Monoid.Companion.string(): Monoid<String> =
   StringMonoid
-
-private object StringEq : Eq<String> {
-  override fun String.eqv(b: String): Boolean = this == b
-}
-
-fun Eq.Companion.string(): Eq<String> =
-  StringEq
 
 private object StringShow : Show<String> {
   override fun String.show(): String = "\"${this.escape()}\""

--- a/arrow-core-data/src/main/kotlin/arrow/typeclasses/Eq.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/typeclasses/Eq.kt
@@ -1,10 +1,13 @@
 package arrow.typeclasses
 
+const val EqDeprecation = "Eq is deprecated in favor of equals(), since Kotlin's Std doesn't take Eq into account"
+
 /**
  * A type class used to determine equality between 2 instances of the same type [F] in a type safe way.
  *
  * @see <a href="http://arrow-kt.io/docs/arrow/typeclasses/eq/">Eq documentation</a>
  */
+@Deprecated(EqDeprecation)
 interface Eq<in F> {
 
   /**

--- a/arrow-core-data/src/test/kotlin/arrow/core/IterableTest.kt
+++ b/arrow-core-data/src/test/kotlin/arrow/core/IterableTest.kt
@@ -1,6 +1,5 @@
 package arrow.core
 
-import arrow.core.extensions.eq
 import arrow.core.test.UnitSpec
 import arrow.core.test.laws.equalUnderTheLaw
 import arrow.typeclasses.Eq
@@ -63,7 +62,7 @@ class IterableTest : UnitSpec() {
         val result = a.rightPadZip(b)
 
         result == left.zip(right) { l, r -> l toT r }.filter { it.a != null } &&
-          result.map { it.a }.equalUnderTheLaw(a, Eq.list(Int.eq()))
+          result.map { it.a }.equalUnderTheLaw(a, Eq.any())
       }
     }
 
@@ -75,7 +74,7 @@ class IterableTest : UnitSpec() {
         val result = a.rightPadZip(b) { a, b -> a toT b }
 
         result == left.zip(right) { l, r -> l toT r }.filter { it.a != null } &&
-          result.map { it.a }.equalUnderTheLaw(a, Eq.list(Int.eq()))
+          result.map { it.a }.equalUnderTheLaw(a, Eq.any())
       }
     }
 

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/boolean.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/boolean.kt
@@ -2,6 +2,7 @@ package arrow.core.extensions
 
 import arrow.core.Ordering
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
@@ -13,7 +14,7 @@ interface BooleanShow : Show<Boolean> {
     this.toString()
 }
 
-@Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Eq.boolean()", "arrow.core.Eq", "arrow.core.boolean"))
+@Deprecated(EqDeprecation)
 interface BooleanEq : Eq<Boolean> {
   override fun Boolean.eqv(b: Boolean): Boolean = this == b
 }
@@ -33,7 +34,7 @@ interface BooleanHash : Hash<Boolean>, BooleanEq {
 fun Boolean.Companion.show(): Show<Boolean> =
   object : BooleanShow {}
 
-@Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Eq.boolean()", "arrow.core.Eq", "arrow.core.boolean"))
+@Deprecated(EqDeprecation)
 fun Boolean.Companion.eq(): Eq<Boolean> =
   object : BooleanEq {}
 

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/char.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/char.kt
@@ -2,6 +2,7 @@ package arrow.core.extensions
 
 import arrow.core.Ordering
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Order
 import arrow.typeclasses.Show
@@ -12,7 +13,7 @@ interface CharShow : Show<Char> {
     this.toString()
 }
 
-@Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Eq.char()", "arrow.core.Eq", "arrow.core.char"))
+@Deprecated(EqDeprecation)
 interface CharEq : Eq<Char> {
   override fun Char.eqv(b: Char): Boolean = this == b
 }
@@ -35,7 +36,7 @@ interface CharHash : Hash<Char>, CharEq {
 fun Char.Companion.show(): Show<Char> =
   object : CharShow {}
 
-@Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Eq.char()", "arrow.core.Eq", "arrow.core.char"))
+@Deprecated(EqDeprecation)
 fun Char.Companion.eq(): Eq<Char> =
   object : CharEq {}
 

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/eq/ConstEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/eq/ConstEq.kt
@@ -4,6 +4,7 @@ import arrow.core.Const
 import arrow.core.Const.Companion
 import arrow.core.extensions.ConstEq
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import kotlin.Boolean
 import kotlin.Deprecated
 import kotlin.Suppress
@@ -17,15 +18,12 @@ import kotlin.jvm.JvmName
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "neqv(EQ, arg1)",
-  "arrow.core.neqv"
-  ),
+  EqDeprecation,
+  ReplaceWith("this != arg1"),
   DeprecationLevel.WARNING
 )
 fun <A, T> Const<A, T>.neqv(EQ: Eq<A>, arg1: Const<A, T>): Boolean = arrow.core.Const.eq<A,
-    T>(EQ).run {
+  T>(EQ).run {
   this@neqv.neqv(arg1) as kotlin.Boolean
 }
 
@@ -33,5 +31,8 @@ fun <A, T> Const<A, T>.neqv(EQ: Eq<A>, arg1: Const<A, T>): Boolean = arrow.core.
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated(EqDeprecation)
 inline fun <A, T> Companion.eq(EQ: Eq<A>): ConstEq<A, T> = object : arrow.core.extensions.ConstEq<A,
-    T> { override fun EQ(): arrow.typeclasses.Eq<A> = EQ }
+  T> {
+  override fun EQ(): arrow.typeclasses.Eq<A> = EQ
+}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/eq/EitherEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/eq/EitherEq.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import arrow.core.Either.Companion
 import arrow.core.extensions.EitherEq
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import kotlin.Boolean
 import kotlin.Suppress
 import kotlin.jvm.JvmName
@@ -15,7 +16,7 @@ import kotlin.jvm.JvmName
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension projected functions are deprecated", ReplaceWith("neqv(EQL, EQR, arg1)", "arrow.core.neqv"))
+@Deprecated(EqDeprecation, ReplaceWith("this != arg1"))
 fun <L, R> Either<L, R>.neqv(
   EQL: Eq<L>,
   EQR: Eq<R>,
@@ -28,7 +29,7 @@ fun <L, R> Either<L, R>.neqv(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("@extension projected functions are deprecated", ReplaceWith("Eq.either(EQL, EQR)", "arrow.core.Eq", "arrow.core.either"))
+@Deprecated(EqDeprecation)
 inline fun <L, R> Companion.eq(EQL: Eq<L>, EQR: Eq<R>): EitherEq<L, R> = object :
   arrow.core.extensions.EitherEq<L, R> {
   override fun EQL(): arrow.typeclasses.Eq<L> = EQL

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/hashed/eq/HashedEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/hashed/eq/HashedEq.kt
@@ -4,6 +4,7 @@ import arrow.core.Hashed
 import arrow.core.Hashed.Companion
 import arrow.core.extensions.HashedEq
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import kotlin.Boolean
 import kotlin.Deprecated
 import kotlin.Suppress
@@ -17,10 +18,9 @@ import kotlin.jvm.JvmName
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
+  EqDeprecation,
   ReplaceWith(
-  "neqv(EQA, arg1)",
-  "arrow.core.neqv"
+  "this != arg1"
   ),
   DeprecationLevel.WARNING
 )
@@ -32,5 +32,6 @@ fun <A> Hashed<A>.neqv(EQA: Eq<A>, arg1: Hashed<A>): Boolean = arrow.core.Hashed
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated(EqDeprecation)
 inline fun <A> Companion.eq(EQA: Eq<A>): HashedEq<A> = object : arrow.core.extensions.HashedEq<A> {
     override fun EQA(): arrow.typeclasses.Eq<A> = EQA }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ior/eq/IorEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ior/eq/IorEq.kt
@@ -4,6 +4,7 @@ import arrow.core.Ior
 import arrow.core.Ior.Companion
 import arrow.core.extensions.IorEq
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 
 @JvmName("neqv")
 @Suppress(
@@ -13,11 +14,8 @@ import arrow.typeclasses.Eq
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "this.compareTo(arg1) != 0",
-    "arrow.core.compareTo"
-  ),
+  EqDeprecation,
+  ReplaceWith("this != arg1"),
   DeprecationLevel.WARNING
 )
 fun <L, R> Ior<L, R>.neqv(
@@ -33,7 +31,7 @@ fun <L, R> Ior<L, R>.neqv(
   "NOTHING_TO_INLINE"
 )
 @Deprecated(
-  "Eq typeclass is deprecated. Use concrete methods on Ior",
+  EqDeprecation,
   level = DeprecationLevel.WARNING
 )
 inline fun <L, R> Companion.eq(EQL: Eq<L>, EQR: Eq<R>): IorEq<L, R> = object :

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/list/eq/ListKEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/list/eq/ListKEq.kt
@@ -1,9 +1,11 @@
 package arrow.core.extensions.list.eq
 
+import arrow.core.ListK
 import arrow.core.extensions.ListKEq
+import arrow.core.extensions.listk.eq.eq
+import arrow.core.k
 import arrow.typeclasses.Eq
-import arrow.core.eqv as _eqv
-import arrow.core.neqv as _neqv
+import arrow.typeclasses.EqDeprecation
 import kotlin.Boolean
 import kotlin.Suppress
 import kotlin.collections.List
@@ -16,9 +18,9 @@ import kotlin.jvm.JvmName
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension projected functions are deprecated", ReplaceWith("neqv(EQL, EQR, arg1)", "arrow.core.neqv"))
+@Deprecated(EqDeprecation, ReplaceWith("this == arg1"))
 fun <A> List<A>.eqv(EQ: Eq<A>, arg1: List<A>): Boolean =
-  _eqv(EQ, arg1)
+  ListK.eq(EQ).run { this@eqv.k().eqv(arg1.k()) }
 
 @JvmName("neqv")
 @Suppress(
@@ -27,9 +29,9 @@ fun <A> List<A>.eqv(EQ: Eq<A>, arg1: List<A>): Boolean =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension projected functions are deprecated", ReplaceWith("neqv(EQL, EQR, arg1)", "arrow.core.neqv"))
+@Deprecated(EqDeprecation, ReplaceWith("this != arg1"))
 fun <A> List<A>.neqv(EQ: Eq<A>, arg1: List<A>): Boolean =
-  _neqv(EQ, arg1)
+  ListK.eq(EQ).run { this@neqv.k().neqv(arg1.k()) }
 
 @Deprecated("Receiver List object is deprecated, prefer to turn List functions into top-level functions")
 object List {
@@ -37,6 +39,6 @@ object List {
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
   )
-  @Deprecated("@extension projected functions are deprecated", ReplaceWith("Eq.list(EQ)", "arrow.core.list", "arrow.core.Eq"))
+  @Deprecated(EqDeprecation)
   inline fun <A> eq(EQ: Eq<A>): ListKEq<A> = object : arrow.core.extensions.ListKEq<A> { override
       fun EQ(): arrow.typeclasses.Eq<A> = EQ }}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/listk/eq/ListKEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/listk/eq/ListKEq.kt
@@ -5,6 +5,7 @@ import arrow.core.ForListK
 import arrow.core.ListK.Companion
 import arrow.core.extensions.ListKEq
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import kotlin.Boolean
 import kotlin.Suppress
 import kotlin.jvm.JvmName
@@ -16,7 +17,7 @@ import kotlin.jvm.JvmName
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension projected functions are deprecated", ReplaceWith("neqv(EQL, EQR, arg1)", "arrow.core.neqv"))
+@Deprecated(EqDeprecation, ReplaceWith("this == arg1"))
 fun <A> Kind<ForListK, A>.eqv(EQ: Eq<A>, arg1: Kind<ForListK, A>): Boolean =
     arrow.core.ListK.eq<A>(EQ).run {
   this@eqv.eqv(arg1) as kotlin.Boolean
@@ -29,7 +30,7 @@ fun <A> Kind<ForListK, A>.eqv(EQ: Eq<A>, arg1: Kind<ForListK, A>): Boolean =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension projected functions are deprecated", ReplaceWith("neqv(EQL, EQR, arg1)", "arrow.core.neqv"))
+@Deprecated(EqDeprecation, ReplaceWith("this != arg1"))
 fun <A> Kind<ForListK, A>.neqv(EQ: Eq<A>, arg1: Kind<ForListK, A>): Boolean =
     arrow.core.ListK.eq<A>(EQ).run {
   this@neqv.neqv(arg1) as kotlin.Boolean
@@ -39,6 +40,6 @@ fun <A> Kind<ForListK, A>.neqv(EQ: Eq<A>, arg1: Kind<ForListK, A>): Boolean =
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("@extension projected functions are deprecated", ReplaceWith("Eq.list(EQ)", "arrow.core.list", "arrow.core.Eq"))
+@Deprecated(EqDeprecation)
 inline fun <A> Companion.eq(EQ: Eq<A>): ListKEq<A> = object : arrow.core.extensions.ListKEq<A> {
     override fun EQ(): arrow.typeclasses.Eq<A> = EQ }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/map/eq/MapKEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/map/eq/MapKEq.kt
@@ -2,6 +2,7 @@ package arrow.core.extensions.map.eq
 
 import arrow.core.extensions.MapKEq
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import kotlin.Boolean
 import kotlin.Deprecated
 import kotlin.Suppress
@@ -16,11 +17,8 @@ import kotlin.jvm.JvmName
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "neqv(EQK, EQA, arg1)",
-  "arrow.core.neqv"
-  ),
+  EqDeprecation,
+  ReplaceWith("this == arg1"),
   DeprecationLevel.WARNING
 )
 fun <K, A> Map<K, A>.neqv(
@@ -36,7 +34,7 @@ object Map {
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
   )
-  @Deprecated("@extension projected functions are deprecated", ReplaceWith("Eq.map(EQK, EQA)", "arrow.core.Eq", "arrow.core.Eq"))
+  @Deprecated(EqDeprecation)
   inline fun <K, A> eq(EQK: Eq<K>, EQA: Eq<A>): MapKEq<K, A> = object :
       arrow.core.extensions.MapKEq<K, A> { override fun EQK(): arrow.typeclasses.Eq<K> = EQK
 

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/mapk/eq/MapKEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/mapk/eq/MapKEq.kt
@@ -4,6 +4,7 @@ import arrow.core.MapK
 import arrow.core.MapK.Companion
 import arrow.core.extensions.MapKEq
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import kotlin.Boolean
 import kotlin.Deprecated
 import kotlin.Suppress
@@ -17,11 +18,8 @@ import kotlin.jvm.JvmName
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "neqv(EQK, EQA, arg1)",
-  "arrow.core.neqv"
-  ),
+  EqDeprecation,
+  ReplaceWith("this == arg1"),
   DeprecationLevel.WARNING
 )
 fun <K, A> MapK<K, A>.neqv(
@@ -36,7 +34,7 @@ fun <K, A> MapK<K, A>.neqv(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("@extension projected functions are deprecated", ReplaceWith("Eq.map(EQK, EQA)", "arrow.core.map", "arrow.core.Eq"))
+@Deprecated(EqDeprecation)
 inline fun <K, A> Companion.eq(EQK: Eq<K>, EQA: Eq<A>): MapKEq<K, A> = object :
     arrow.core.extensions.MapKEq<K, A> { override fun EQK(): arrow.typeclasses.Eq<K> = EQK
 

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/eq/NonEmptyListEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/nonemptylist/eq/NonEmptyListEq.kt
@@ -4,6 +4,7 @@ import arrow.core.NonEmptyList
 import arrow.core.NonEmptyList.Companion
 import arrow.core.extensions.NonEmptyListEq
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import kotlin.Boolean
 import kotlin.Suppress
 import kotlin.jvm.JvmName
@@ -16,26 +17,23 @@ import kotlin.jvm.JvmName
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension projected functions are deprecated",
-  ReplaceWith(
-    "neqv<A>(EQ, arg1)",
-    "arrow.core.neqv"))
+  EqDeprecation,
+  ReplaceWith("this == arg1")
+)
 fun <A> NonEmptyList<A>.neqv(EQ: Eq<A>, arg1: NonEmptyList<A>): Boolean =
-    arrow.core.NonEmptyList.eq<A>(EQ).run {
-  this@neqv.neqv(arg1) as kotlin.Boolean
-}
+  arrow.core.NonEmptyList.eq<A>(EQ).run {
+    this@neqv.neqv(arg1) as kotlin.Boolean
+  }
 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
 @Deprecated(
-  "@extension projected functions are deprecated",
-  ReplaceWith(
-    "Eq.nonEmptyList<A>(EQ)",
-    "arrow.core.NonEmptyList", "arrow.typeclasses.Eq"
-  ),
-  DeprecationLevel.WARNING
+  EqDeprecation,
+  level = DeprecationLevel.WARNING
 )
 inline fun <A> Companion.eq(EQ: Eq<A>): NonEmptyListEq<A> = object :
-    arrow.core.extensions.NonEmptyListEq<A> { override fun EQ(): arrow.typeclasses.Eq<A> = EQ }
+  arrow.core.extensions.NonEmptyListEq<A> {
+  override fun EQ(): arrow.typeclasses.Eq<A> = EQ
+}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/number.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/number.kt
@@ -2,6 +2,7 @@ package arrow.core.extensions
 
 import arrow.core.Ordering
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
@@ -37,7 +38,7 @@ interface ByteOrder : Order<Byte> {
   override fun Byte.compareTo(b: Byte): Int = this.compareTo(b)
 }
 
-@Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Eq.byte()", "arrow.core.Eq", "arrow.core.byte"))
+@Deprecated(EqDeprecation)
 interface ByteEq : Eq<Byte> {
   override fun Byte.eqv(b: Byte): Boolean = this == b
 }
@@ -60,7 +61,7 @@ fun Byte.Companion.hash(): Hash<Byte> =
 fun Byte.Companion.show(): Show<Byte> =
   object : ByteShow {}
 
-@Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Eq.byte()", "arrow.core.Eq", "arrow.core.byte"))
+@Deprecated(EqDeprecation)
 fun Byte.Companion.eq(): Eq<Byte> =
   object : ByteEq {}
 
@@ -108,7 +109,7 @@ interface DoubleOrder : Order<Double> {
   override fun Double.compareTo(b: Double): Int = this.compareTo(b)
 }
 
-@Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Eq.double()", "arrow.core.Eq", "arrow.core.double"))
+@Deprecated(EqDeprecation)
 interface DoubleEq : Eq<Double> {
   override fun Double.eqv(b: Double): Boolean = this == b
 }
@@ -131,7 +132,7 @@ fun Double.Companion.hash(): Hash<Double> =
 fun Double.Companion.show(): Show<Double> =
   object : DoubleShow {}
 
-@Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Eq.double()", "arrow.core.Eq", "arrow.core.double"))
+@Deprecated(EqDeprecation)
 fun Double.Companion.eq(): Eq<Double> =
   object : DoubleEq {}
 
@@ -173,7 +174,7 @@ interface IntSemiring : Semiring<Int> {
   override fun Int.combineMultiplicate(b: Int): Int = this * b
 }
 
-@Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Eq.int()", "arrow.core.Eq", "arrow.core.int"))
+@Deprecated(EqDeprecation)
 interface IntEq : Eq<Int> {
   override fun Int.eqv(b: Int): Boolean = this == b
 }
@@ -201,7 +202,7 @@ fun Int.Companion.hash(): Hash<Int> = object : IntHash {}
 fun Int.Companion.show(): Show<Int> =
   object : IntShow {}
 
-@Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Eq.int()", "arrow.core.Eq", "arrow.core.int"))
+@Deprecated(EqDeprecation)
 fun Int.Companion.eq(): Eq<Int> =
   object : IntEq {}
 
@@ -249,7 +250,7 @@ interface LongOrder : Order<Long> {
   override fun Long.compareTo(b: Long): Int = this.compareTo(b)
 }
 
-@Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Eq.long()", "arrow.core.Eq", "arrow.core.long"))
+@Deprecated(EqDeprecation)
 interface LongEq : Eq<Long> {
   override fun Long.eqv(b: Long): Boolean = this == b
 }
@@ -272,7 +273,7 @@ fun Long.Companion.hash(): Hash<Long> =
 fun Long.Companion.show(): Show<Long> =
   object : LongShow {}
 
-@Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Eq.long()", "arrow.core.Eq", "arrow.core.long"))
+@Deprecated(EqDeprecation)
 fun Long.Companion.eq(): Eq<Long> =
   object : LongEq {}
 
@@ -320,7 +321,7 @@ interface ShortOrder : Order<Short> {
   override fun Short.compareTo(b: Short): Int = this.compareTo(b)
 }
 
-@Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Eq.short()", "arrow.core.Eq", "arrow.core.short"))
+@Deprecated(EqDeprecation)
 interface ShortEq : Eq<Short> {
   override fun Short.eqv(b: Short): Boolean = this == b
 }
@@ -343,7 +344,7 @@ fun Short.Companion.hash(): Hash<Short> =
 fun Short.Companion.show(): Show<Short> =
   object : ShortShow {}
 
-@Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Eq.short()", "arrow.core.Eq", "arrow.core.short"))
+@Deprecated(EqDeprecation)
 fun Short.Companion.eq(): Eq<Short> =
   object : ShortEq {}
 
@@ -391,7 +392,7 @@ interface FloatOrder : Order<Float> {
   override fun Float.compareTo(b: Float): Int = this.compareTo(b)
 }
 
-@Deprecated("Typeclass interface implementation will not be exposed directly anymore", ReplaceWith("Eq.float()", "arrow.core.Eq", "arrow.core.float"))
+@Deprecated(EqDeprecation)
 interface FloatEq : Eq<Float> {
   override fun Float.eqv(b: Float): Boolean = this == b
 }
@@ -414,7 +415,7 @@ fun Float.Companion.hash(): Hash<Float> =
 fun Float.Companion.show(): Show<Float> =
   object : FloatShow {}
 
-@Deprecated("Typeclass instance have been moved to the companion object of the typeclass", ReplaceWith("Eq.float()", "arrow.core.Eq", "arrow.core.float"))
+@Deprecated(EqDeprecation)
 fun Float.Companion.eq(): Eq<Float> =
   object : FloatEq {}
 

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/option/eq/OptionEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/option/eq/OptionEq.kt
@@ -4,6 +4,7 @@ import arrow.core.Option
 import arrow.core.Option.Companion
 import arrow.core.extensions.OptionEq
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 
 @JvmName("neqv")
 @Suppress(
@@ -13,11 +14,8 @@ import arrow.typeclasses.Eq
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "this.compareTo(arg1) != 0",
-    "arrow.core.compareTo"
-  ),
+  EqDeprecation,
+  ReplaceWith("this != arg1"),
   DeprecationLevel.WARNING
 )
 fun <A> Option<A>.neqv(EQ: Eq<A>, arg1: Option<A>): Boolean = arrow.core.Option.eq<A>(EQ).run {
@@ -29,7 +27,7 @@ fun <A> Option<A>.neqv(EQ: Eq<A>, arg1: Option<A>): Boolean = arrow.core.Option.
   "NOTHING_TO_INLINE"
 )
 @Deprecated(
-  "Eq typeclass is deprecated. Use concrete methods on Option",
+  EqDeprecation,
   level = DeprecationLevel.WARNING
 )
 inline fun <A> Companion.eq(EQ: Eq<A>): OptionEq<A> = object : arrow.core.extensions.OptionEq<A> {

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/ordering/eq/OrderingEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/ordering/eq/OrderingEq.kt
@@ -3,6 +3,7 @@ package arrow.core.extensions.ordering.eq
 import arrow.core.Ordering
 import arrow.core.Ordering.Companion
 import arrow.core.extensions.OrderingEq
+import arrow.typeclasses.EqDeprecation
 import kotlin.Boolean
 import kotlin.PublishedApi
 import kotlin.Suppress
@@ -21,7 +22,7 @@ internal val eq_singleton: OrderingEq = object : arrow.core.extensions.OrderingE
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension projected functions are deprecated", ReplaceWith("neqv(arg1)"))
+@Deprecated(EqDeprecation, ReplaceWith("this != arg1"))
 fun Ordering.neqv(arg1: Ordering): Boolean = arrow.core.Ordering.eq().run {
   this@neqv.neqv(arg1) as kotlin.Boolean
 }
@@ -30,5 +31,5 @@ fun Ordering.neqv(arg1: Ordering): Boolean = arrow.core.Ordering.eq().run {
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("@extension projected functions are deprecated", ReplaceWith("Eq.ordering()", "arrow.core.Eq", "arrow.core.ordering"))
+@Deprecated(EqDeprecation)
 inline fun Companion.eq(): OrderingEq = eq_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/eq/SequenceKEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/eq/SequenceKEq.kt
@@ -2,6 +2,7 @@ package arrow.core.extensions.sequence.eq
 
 import arrow.core.extensions.SequenceKEq
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import kotlin.Boolean
 import kotlin.Deprecated
 import kotlin.Suppress
@@ -16,11 +17,8 @@ import kotlin.sequences.Sequence
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "neqv(EQ, arg1)",
-  "arrow.core.neqv"
-  ),
+  EqDeprecation,
+  ReplaceWith("this != arg1"),
   DeprecationLevel.WARNING
 )
 fun <A> Sequence<A>.neqv(EQ: Eq<A>, arg1: Sequence<A>): Boolean =
@@ -33,5 +31,6 @@ object Sequence {
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
   )
+  @Deprecated(EqDeprecation)
   inline fun <A> eq(EQ: Eq<A>): SequenceKEq<A> = object : arrow.core.extensions.SequenceKEq<A> {
       override fun EQ(): arrow.typeclasses.Eq<A> = EQ }}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/eq/SequenceKEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/eq/SequenceKEq.kt
@@ -4,6 +4,7 @@ import arrow.core.SequenceK
 import arrow.core.SequenceK.Companion
 import arrow.core.extensions.SequenceKEq
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import kotlin.Boolean
 import kotlin.Deprecated
 import kotlin.Suppress
@@ -17,11 +18,8 @@ import kotlin.jvm.JvmName
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "neqv(EQ, arg1)",
-  "arrow.core.neqv"
-  ),
+  EqDeprecation,
+  ReplaceWith("this != arg1"),
   DeprecationLevel.WARNING
 )
 fun <A> SequenceK<A>.neqv(EQ: Eq<A>, arg1: SequenceK<A>): Boolean =
@@ -33,5 +31,6 @@ fun <A> SequenceK<A>.neqv(EQ: Eq<A>, arg1: SequenceK<A>): Boolean =
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated(EqDeprecation)
 inline fun <A> Companion.eq(EQ: Eq<A>): SequenceKEq<A> = object :
     arrow.core.extensions.SequenceKEq<A> { override fun EQ(): arrow.typeclasses.Eq<A> = EQ }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/set/eq/SetKEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/set/eq/SetKEq.kt
@@ -2,6 +2,7 @@ package arrow.core.extensions.set.eq
 
 import arrow.core.extensions.SetKEq
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import kotlin.Boolean
 import kotlin.Deprecated
 import kotlin.Suppress
@@ -16,11 +17,8 @@ import kotlin.jvm.JvmName
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "!eqv(EQ, arg1)",
-    "arrow.core.eqv"
-  ),
+  EqDeprecation,
+  ReplaceWith("this != arg1"),
   DeprecationLevel.WARNING
 )
 fun <A> Set<A>.neqv(EQ: Eq<A>, arg1: Set<A>): Boolean =
@@ -34,13 +32,8 @@ object Set {
     "NOTHING_TO_INLINE"
   )
   @Deprecated(
-    "@extension kinded projected functions are deprecated",
-    ReplaceWith(
-      "Eq.set(EQ)",
-      "arrow.core.set",
-      "arrow.typeclasses.Eq"
-    ),
-    DeprecationLevel.WARNING
+    EqDeprecation,
+    level = DeprecationLevel.WARNING
   )
   inline fun <A> eq(EQ: Eq<A>): SetKEq<A> = object : arrow.core.extensions.SetKEq<A> {
     override fun EQ(): arrow.typeclasses.Eq<A> =

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/setk/eq/SetKEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/setk/eq/SetKEq.kt
@@ -4,6 +4,7 @@ import arrow.core.SetK
 import arrow.core.SetK.Companion
 import arrow.core.extensions.SetKEq
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import kotlin.Boolean
 import kotlin.Deprecated
 import kotlin.Suppress
@@ -17,11 +18,8 @@ import kotlin.jvm.JvmName
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "!eqv(EQ, arg1)",
-    "arrow.core.eqv"
-  ),
+  EqDeprecation,
+  ReplaceWith("this != arg1"),
   DeprecationLevel.WARNING
 )
 fun <A> SetK<A>.neqv(EQ: Eq<A>, arg1: SetK<A>): Boolean = arrow.core.SetK.eq<A>(EQ).run {
@@ -33,13 +31,8 @@ fun <A> SetK<A>.neqv(EQ: Eq<A>, arg1: SetK<A>): Boolean = arrow.core.SetK.eq<A>(
   "NOTHING_TO_INLINE"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "Eq.set<A>(EQ)",
-    "arrow.core.set",
-    "arrow.typeclasses.Eq"
-  ),
-  DeprecationLevel.WARNING
+  EqDeprecation,
+  level = DeprecationLevel.WARNING
 )
 inline fun <A> Companion.eq(EQ: Eq<A>): SetKEq<A> = object : arrow.core.extensions.SetKEq<A> {
   override fun EQ(): arrow.typeclasses.Eq<A> = EQ

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sortedmapk/eq/SortedMapKEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sortedmapk/eq/SortedMapKEq.kt
@@ -4,6 +4,7 @@ import arrow.core.SortedMapK
 import arrow.core.SortedMapK.Companion
 import arrow.core.extensions.SortedMapKEq
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Deprecated
@@ -18,11 +19,8 @@ import kotlin.jvm.JvmName
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "neqv(EQK, EQA, arg1)",
-  "arrow.core.neqv"
-  ),
+  EqDeprecation,
+  ReplaceWith("this != arg1"),
   DeprecationLevel.WARNING
 )
 fun <K : Comparable<K>, A> SortedMapK<K, A>.neqv(
@@ -37,6 +35,7 @@ fun <K : Comparable<K>, A> SortedMapK<K, A>.neqv(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
+@Deprecated(EqDeprecation)
 inline fun <K : Comparable<K>, A> Companion.eq(EQK: Eq<K>, EQA: Eq<A>): SortedMapKEq<K, A> =
   object : arrow.core.extensions.SortedMapKEq<K, A> {
     override fun EQK(): arrow.typeclasses.Eq<K> = EQK

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/tuple10/eq/Tuple10Eq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/tuple10/eq/Tuple10Eq.kt
@@ -4,6 +4,7 @@ import arrow.core.Tuple10
 import arrow.core.Tuple10.Companion
 import arrow.core.extensions.Tuple10Eq
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import kotlin.Boolean
 import kotlin.Deprecated
 import kotlin.Suppress
@@ -17,11 +18,8 @@ import kotlin.jvm.JvmName
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "neqv(EQA, EQB, EQC, EQD, EQE, EQF, EQG, EQH, EQI, EQJ, arg1)",
-  "arrow.core.neqv"
-  ),
+  EqDeprecation,
+  ReplaceWith("this != arg1"),
   DeprecationLevel.WARNING
 )
 fun <A, B, C, D, E, F, G, H, I, J> Tuple10<A, B, C, D, E, F, G, H, I, J>.neqv(
@@ -46,13 +44,8 @@ fun <A, B, C, D, E, F, G, H, I, J> Tuple10<A, B, C, D, E, F, G, H, I, J>.neqv(
   "NOTHING_TO_INLINE"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "Eq.tuple10(EQA, EQB, EQC, EQD, EQE, EQF, EQG, EQH, EQI, EQJ, arg1)",
-    "arrow.core.Eq",
-    "arrow.core.tuple10"
-  ),
-  DeprecationLevel.WARNING
+  EqDeprecation,
+  level = DeprecationLevel.WARNING
 )
 inline fun <A, B, C, D, E, F, G, H, I, J> Companion.eq(
   EQA: Eq<A>,

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/tuple2/eq/Tuple2Eq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/tuple2/eq/Tuple2Eq.kt
@@ -4,6 +4,7 @@ import arrow.core.Tuple2
 import arrow.core.Tuple2.Companion
 import arrow.core.extensions.Tuple2Eq
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import kotlin.Boolean
 import kotlin.Deprecated
 import kotlin.Suppress
@@ -17,11 +18,8 @@ import kotlin.jvm.JvmName
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "neqv(EQA, EQB, arg1)",
-  "arrow.core.neqv"
-  ),
+  EqDeprecation,
+  ReplaceWith("this != arg1"),
   DeprecationLevel.WARNING
 )
 fun <A, B> Tuple2<A, B>.neqv(
@@ -37,13 +35,8 @@ fun <A, B> Tuple2<A, B>.neqv(
   "NOTHING_TO_INLINE"
 )
 @Deprecated(
-  "Tuple2 is deprecated in favor of Kotlin's Pair. ReplaceWith Pair and use Pair instance of Eq",
-  ReplaceWith(
-    "Eq.pair(EQA, EQB)",
-    "arrow.core.Eq",
-    "arrow.core.pair"
-  ),
-  DeprecationLevel.WARNING
+  EqDeprecation,
+  level = DeprecationLevel.WARNING
 )
 inline fun <A, B> Companion.eq(EQA: Eq<A>, EQB: Eq<B>): Tuple2Eq<A, B> = object :
     arrow.core.extensions.Tuple2Eq<A, B> { override fun EQA(): arrow.typeclasses.Eq<A> = EQA

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/tuple3/eq/Tuple3Eq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/tuple3/eq/Tuple3Eq.kt
@@ -4,6 +4,7 @@ import arrow.core.Tuple3
 import arrow.core.Tuple3.Companion
 import arrow.core.extensions.Tuple3Eq
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import kotlin.Boolean
 import kotlin.Deprecated
 import kotlin.Suppress
@@ -17,10 +18,9 @@ import kotlin.jvm.JvmName
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
+  EqDeprecation,
   ReplaceWith(
-  "neqv(EQA, EQB, EQC, arg1)",
-  "arrow.core.neqv"
+  "this != arg1"
   ),
   DeprecationLevel.WARNING
 )
@@ -38,13 +38,8 @@ fun <A, B, C> Tuple3<A, B, C>.neqv(
   "NOTHING_TO_INLINE"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "Tuple3 is deprecated in favor of Kotlin's Triple. ReplaceWith Triple and use Triple instance of Eq",
-    "arrow.core.Eq",
-    "arrow.core.triple"
-  ),
-  DeprecationLevel.WARNING
+  EqDeprecation,
+  level = DeprecationLevel.WARNING
 )
 inline fun <A, B, C> Companion.eq(
   EQA: Eq<A>,

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/tuple4/eq/Tuple4Eq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/tuple4/eq/Tuple4Eq.kt
@@ -4,6 +4,7 @@ import arrow.core.Tuple4
 import arrow.core.Tuple4.Companion
 import arrow.core.extensions.Tuple4Eq
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import kotlin.Boolean
 import kotlin.Deprecated
 import kotlin.Suppress
@@ -17,11 +18,8 @@ import kotlin.jvm.JvmName
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "neqv(EQA, EQB, EQC, EQD, arg1)",
-  "arrow.core.neqv"
-  ),
+  EqDeprecation,
+  ReplaceWith("this != arg1"),
   DeprecationLevel.WARNING
 )
 fun <A, B, C, D> Tuple4<A, B, C, D>.neqv(
@@ -39,13 +37,8 @@ fun <A, B, C, D> Tuple4<A, B, C, D>.neqv(
   "NOTHING_TO_INLINE"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "Eq.tuple4(EQA, EQB, EQC, EQD)",
-    "arrow.core.Eq",
-    "arrow.core.tuple4"
-  ),
-  DeprecationLevel.WARNING
+  EqDeprecation,
+  level = DeprecationLevel.WARNING
 )
 inline fun <A, B, C, D> Companion.eq(
   EQA: Eq<A>,

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/tuple5/eq/Tuple5Eq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/tuple5/eq/Tuple5Eq.kt
@@ -4,6 +4,7 @@ import arrow.core.Tuple5
 import arrow.core.Tuple5.Companion
 import arrow.core.extensions.Tuple5Eq
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import kotlin.Boolean
 import kotlin.Deprecated
 import kotlin.Suppress
@@ -17,10 +18,9 @@ import kotlin.jvm.JvmName
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
+  EqDeprecation,
   ReplaceWith(
-  "neqv(EQA, EQB, EQC, EQD, EQE, arg1)",
-  "arrow.core.neqv"
+  "this != arg1"
   ),
   DeprecationLevel.WARNING
 )
@@ -40,13 +40,8 @@ fun <A, B, C, D, E> Tuple5<A, B, C, D, E>.neqv(
   "NOTHING_TO_INLINE"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "Eq.tuple5(EQA, EQB, EQC, EQD, EQE)",
-    "arrow.core.Eq",
-    "arrow.core.tuple5"
-  ),
-  DeprecationLevel.WARNING
+  EqDeprecation,
+  level = DeprecationLevel.WARNING
 )
 inline fun <A, B, C, D, E> Companion.eq(
   EQA: Eq<A>,

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/tuple6/eq/Tuple6Eq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/tuple6/eq/Tuple6Eq.kt
@@ -4,6 +4,7 @@ import arrow.core.Tuple6
 import arrow.core.Tuple6.Companion
 import arrow.core.extensions.Tuple6Eq
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import kotlin.Boolean
 import kotlin.Deprecated
 import kotlin.Suppress
@@ -17,11 +18,8 @@ import kotlin.jvm.JvmName
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "neqv(EQA, EQB, EQC, EQD, EQE, EQF, arg1)",
-  "arrow.core.neqv"
-  ),
+  EqDeprecation,
+  ReplaceWith("this != arg1"),
   DeprecationLevel.WARNING
 )
 fun <A, B, C, D, E, F> Tuple6<A, B, C, D, E, F>.neqv(
@@ -41,13 +39,8 @@ fun <A, B, C, D, E, F> Tuple6<A, B, C, D, E, F>.neqv(
   "NOTHING_TO_INLINE"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "Eq.tuple6(EQA, EQB, EQC, EQD, EQE, EQF, arg1)",
-    "arrow.core.Eq",
-    "arrow.core.tuple6"
-  ),
-  DeprecationLevel.WARNING
+  EqDeprecation,
+  level = DeprecationLevel.WARNING
 )
 inline fun <A, B, C, D, E, F> Companion.eq(
   EQA: Eq<A>,

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/tuple7/eq/Tuple7Eq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/tuple7/eq/Tuple7Eq.kt
@@ -4,6 +4,7 @@ import arrow.core.Tuple7
 import arrow.core.Tuple7.Companion
 import arrow.core.extensions.Tuple7Eq
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import kotlin.Boolean
 import kotlin.Deprecated
 import kotlin.Suppress
@@ -17,11 +18,8 @@ import kotlin.jvm.JvmName
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "neqv(EQA, EQB, EQC, EQD, EQE, EQF, EQG, arg1)",
-  "arrow.core.neqv"
-  ),
+  EqDeprecation,
+  ReplaceWith("this != arg1"),
   DeprecationLevel.WARNING
 )
 fun <A, B, C, D, E, F, G> Tuple7<A, B, C, D, E, F, G>.neqv(
@@ -42,13 +40,8 @@ fun <A, B, C, D, E, F, G> Tuple7<A, B, C, D, E, F, G>.neqv(
   "NOTHING_TO_INLINE"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "Eq.tuple7(EQA, EQB, EQC, EQD, EQE, EQF, EQG)",
-    "arrow.core.Eq",
-    "arrow.core.tuple7"
-  ),
-  DeprecationLevel.WARNING
+  EqDeprecation,
+  level = DeprecationLevel.WARNING
 )
 inline fun <A, B, C, D, E, F, G> Companion.eq(
   EQA: Eq<A>,

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/tuple8/eq/Tuple8Eq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/tuple8/eq/Tuple8Eq.kt
@@ -4,6 +4,7 @@ import arrow.core.Tuple8
 import arrow.core.Tuple8.Companion
 import arrow.core.extensions.Tuple8Eq
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import kotlin.Boolean
 import kotlin.Deprecated
 import kotlin.Suppress
@@ -17,11 +18,8 @@ import kotlin.jvm.JvmName
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "neqv(EQA, EQB, EQC, EQD, EQE, EQF, EQG, EQH, arg1)",
-  "arrow.core.neqv"
-  ),
+  EqDeprecation,
+  ReplaceWith("this != arg1"),
   DeprecationLevel.WARNING
 )
 fun <A, B, C, D, E, F, G, H> Tuple8<A, B, C, D, E, F, G, H>.neqv(
@@ -44,13 +42,8 @@ fun <A, B, C, D, E, F, G, H> Tuple8<A, B, C, D, E, F, G, H>.neqv(
   "NOTHING_TO_INLINE"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "Eq.tuple8(EQA, EQB, EQC, EQD, EQE, EQF, EQG, EQH)",
-    "arrow.core.Eq",
-    "arrow.core.tuple8"
-  ),
-  DeprecationLevel.WARNING
+  EqDeprecation,
+  level = DeprecationLevel.WARNING
 )
 inline fun <A, B, C, D, E, F, G, H> Companion.eq(
   EQA: Eq<A>,

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/tuple9/eq/Tuple9Eq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/tuple9/eq/Tuple9Eq.kt
@@ -4,6 +4,7 @@ import arrow.core.Tuple9
 import arrow.core.Tuple9.Companion
 import arrow.core.extensions.Tuple9Eq
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import kotlin.Boolean
 import kotlin.Deprecated
 import kotlin.Suppress
@@ -17,11 +18,8 @@ import kotlin.jvm.JvmName
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "neqv(EQA, EQB, EQC, EQD, EQE, EQF, EQG, EQH, EQI, arg1)",
-  "arrow.core.neqv"
-  ),
+  EqDeprecation,
+  ReplaceWith("this != arg1"),
   DeprecationLevel.WARNING
 )
 fun <A, B, C, D, E, F, G, H, I> Tuple9<A, B, C, D, E, F, G, H, I>.neqv(
@@ -45,13 +43,8 @@ fun <A, B, C, D, E, F, G, H, I> Tuple9<A, B, C, D, E, F, G, H, I>.neqv(
   "NOTHING_TO_INLINE"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-    "Eq.tuple9(EQA, EQB, EQC, EQD, EQE, EQF, EQG, EQH, EQI)",
-    "arrow.core.Eq",
-    "arrow.core.tuple9"
-  ),
-  DeprecationLevel.WARNING
+  EqDeprecation,
+  level = DeprecationLevel.WARNING
 )
 inline fun <A, B, C, D, E, F, G, H, I> Companion.eq(
   EQA: Eq<A>,

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/eq/ValidatedEq.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/eq/ValidatedEq.kt
@@ -4,8 +4,8 @@ import arrow.core.Validated
 import arrow.core.Validated.Companion
 import arrow.core.extensions.ValidatedEq
 import arrow.core.fix
-import arrow.core.neqv
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqDeprecation
 import kotlin.Boolean
 import kotlin.Suppress
 import kotlin.jvm.JvmName
@@ -17,7 +17,11 @@ import kotlin.jvm.JvmName
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension projected functions are deprecated", ReplaceWith("neqv(EQL, EQR, arg1)", "arrow.core.neqv"))
+@Deprecated(
+  EqDeprecation,
+  ReplaceWith("this != arg1"),
+  level = DeprecationLevel.WARNING
+)
 fun <L, R> Validated<L, R>.neqv(
   EQL: Eq<L>,
   EQR: Eq<R>,
@@ -29,7 +33,10 @@ fun <L, R> Validated<L, R>.neqv(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
 )
-@Deprecated("@extension projected functions are deprecated", ReplaceWith("Eq.validated(EQL, EQR)", "arrow.core.Eq", "arrow.core.validated"))
+@Deprecated(
+  EqDeprecation,
+  level = DeprecationLevel.WARNING
+)
 inline fun <L, R> Companion.eq(EQL: Eq<L>, EQR: Eq<R>): ValidatedEq<L, R> = object :
   arrow.core.extensions.ValidatedEq<L, R> {
   override fun EQL(): arrow.typeclasses.Eq<L> = EQL

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/order/ValidatedOrder.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/order/ValidatedOrder.kt
@@ -4,7 +4,6 @@ import arrow.core.Tuple2
 import arrow.core.Validated
 import arrow.core.Validated.Companion
 import arrow.core.compareTo
-import arrow.core.eqv
 import arrow.core.lt
 import arrow.core.lte
 import arrow.core.gt


### PR DESCRIPTION
This PR deprecates `Eq` since Kotlin, and Kotlin's Std doesn't take `Eq` into account nor does Kotlin have the power to automatically derive or inject `Eq` anywhere. This makes `Eq` very cumbersome to work with, see [`Tuple10Eq.kt`](https://github.com/arrow-kt/arrow-core/compare/sv-deprecate-eq?expand=1#diff-71c97dda0b6a770b17e372fadc91f43578fe2e833d77959444cab6885fc000b8)

The use-cases of `Eq` seemed very limited and niche to us, so we've decided to exclude it from Arrow in 1.0.0. The common technique for this is to use data class, which automatically implements `equals()`.