### PR TITLE
Deprecate @higherkind & @extension for Sequence/SequenceK

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
@@ -11,10 +11,12 @@ import arrow.typeclasses.ShowDeprecation
 
 @Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
 class ForNonEmptyList private constructor() { companion object }
-typealias NonEmptyListOf<A> = arrow.Kind<ForNonEmptyList, A>
 
 @Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
+typealias NonEmptyListOf<A> = arrow.Kind<ForNonEmptyList, A>
+
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
+@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
 inline fun <A> NonEmptyListOf<A>.fix(): NonEmptyList<A> =
   this as NonEmptyList<A>
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/Sequence.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Sequence.kt
@@ -1,8 +1,678 @@
 package arrow.core
 
+import arrow.Kind
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Semigroup
 import kotlin.sequences.plus as _plus
+
+/**
+ * Combines two structures by taking the union of their shapes and combining the elements with the given function.
+ *
+ * ```kotlin:ank:playground
+ * import arrow.core.*
+ *
+ * fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val result =
+ *    listOf("A", "B").align(listOf(1, 2, 3)) {
+ *      "$it"
+ *    }
+ *   //sampleEnd
+ *   println(result)
+ * }
+ * ```
+ */
+fun <A, B, C> Sequence<A>.align(b: Sequence<B>, fa: (Ior<A, B>) -> C): Sequence<C> =
+  this.align(b).map(fa)
+
+/**
+ * Combines two structures by taking the union of their shapes and using Ior to hold the elements.
+ *
+ * ```kotlin:ank:playground
+ * import arrow.core.*
+ *
+ * fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val result =
+ *     listOf("A", "B").align(listOf(1, 2, 3))
+ *   //sampleEnd
+ *   println(result)
+ * }
+ * ```
+ */
+fun <A, B> Sequence<A>.align(b: Sequence<B>): Sequence<Ior<A, B>> =
+  alignRec(this, b)
+
+private fun <X, Y> alignRec(ls: Sequence<X>, rs: Sequence<Y>): Sequence<Ior<X, Y>> {
+  val lsIterator = ls.iterator()
+  val rsIterator = rs.iterator()
+
+  return sequence {
+    while (lsIterator.hasNext() && rsIterator.hasNext()) {
+      yield(
+        Ior.Both(
+          lsIterator.next(),
+          rsIterator.next()
+        )
+      )
+    }
+    while (lsIterator.hasNext()) yield(lsIterator.next().leftIor())
+    while (rsIterator.hasNext()) yield(rsIterator.next().rightIor())
+  }
+}
+
+fun <A, B> Sequence<A>.ap(ff: Sequence<(A) -> B>): Sequence<B> =
+  flatMap { a -> ff.map { f -> f(a) } }
+
+fun <A, B> Sequence<A>.apEval(ff: Eval<Sequence<(A) -> B>>): Eval<Sequence<B>> =
+  ff.map { this.ap(it) }
+
+fun <A> Sequence<A>.combineAll(MA: Monoid<A>): A = MA.run {
+  this@combineAll.fold(empty()) { acc, a ->
+    acc.combine(a)
+  }
+}
+
+fun <A, B> Sequence<A>.crosswalk(f: (A) -> Sequence<B>): Sequence<Sequence<B>> =
+  fold(emptySequence()) { bs, a ->
+    f(a).align(bs) { ior ->
+      ior.fold(
+        { sequenceOf(it) },
+        ::identity,
+        { l, r -> sequenceOf(l)._plus(r) }
+      )
+    }
+  }
+
+fun <A, K, V> Sequence<A>.crosswalkMap(f: (A) -> Map<K, V>): Map<K, Sequence<V>> =
+  fold(emptyMap()) { bs, a ->
+    f(a).align(bs) { (_, ior) ->
+      ior.fold(
+        { sequenceOf(it) },
+        ::identity,
+        { l, r -> sequenceOf(l)._plus(r) }
+      )
+    }
+  }
+
+fun <A, B> Sequence<A>.crosswalkNull(f: (A) -> B?): Sequence<B>? =
+  fold<A, Sequence<B>?>(emptySequence()) { bs, a ->
+    Ior.fromNullables(f(a), bs)?.fold(
+      { sequenceOf(it) },
+      ::identity,
+      { l, r -> sequenceOf(l)._plus(r) }
+    )
+  }
+
+fun <E, A> Sequence<Either<E, Sequence<A>>>.flatSequenceEither(): Either<E, Sequence<A>> =
+  flatTraverseEither(::identity)
+
+fun <E, A> Sequence<Validated<E, Sequence<A>>>.flatSequenceValidated(semigroup: Semigroup<E>): Validated<E, Sequence<A>> =
+  flatTraverseValidated(semigroup, ::identity)
+
+fun <E, A, B> Sequence<A>.flatTraverseEither(f: (A) -> Either<E, Sequence<B>>): Either<E, Sequence<B>> =
+  foldRight<A, Either<E, Sequence<B>>>(emptySequence<B>().right()) { a, acc ->
+    f(a).ap(acc.map { bs -> { b: Sequence<B> -> b._plus(bs) } })
+  }
+
+fun <E, A, B> Sequence<A>.flatTraverseValidated(semigroup: Semigroup<E>, f: (A) -> Validated<E, Sequence<B>>): Validated<E, Sequence<B>> =
+  foldRight<A, Validated<E, Sequence<B>>>(emptySequence<B>().valid()) { a, acc ->
+    f(a).ap(semigroup, acc.map { bs -> { b: Sequence<B> -> b._plus(bs) } })
+  }
+
+fun <A> Sequence<Sequence<A>>.flatten(): Sequence<A> =
+  flatMap(::identity)
+
+fun <A> Sequence<A>.fold(MA: Monoid<A>): A = MA.run {
+  this@fold.fold(empty()) { acc, a ->
+    acc.combine(a)
+  }
+}
+
+fun <A, B> Sequence<A>.foldMap(MB: Monoid<B>, f: (A) -> B): B = MB.run {
+  this@foldMap.fold(empty()) { acc, a ->
+    acc.combine(f(a))
+  }
+}
+
+inline fun <A, B> Sequence<A>.foldRight(initial: B, operation: (A, B) -> B): B =
+  toList().foldRight(initial, operation)
+
+fun <A, B> Sequence<A>.foldRight(lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> {
+  fun Iterator<A>.loop(): Eval<B> =
+    if (hasNext()) f(next(), Eval.defer { loop() }) else lb
+  return Eval.defer { this.iterator().loop() }
+}
+
+/**
+ *  Applies [f] to an [A] inside [Iterable] and returns the [List] structure with a tuple of the [A] value and the
+ *  computed [B] value as result of applying [f]
+ *
+ *  ```kotlin:ank:playground
+ * import arrow.core.*
+ *
+ *  fun main(args: Array<String>) {
+ *   val result =
+ *   //sampleStart
+ *   listOf("Hello").fproduct { "$it World" }
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+fun <A, B> Sequence<A>.fproduct(f: (A) -> B): Sequence<Pair<A, B>> =
+  map { a -> a to f(a) }
+
+fun <B> Sequence<Boolean>.ifM(ifFalse: () -> Sequence<B>, ifTrue: () -> Sequence<B>): Sequence<B> =
+  flatMap { bool ->
+    if (bool) ifTrue() else ifFalse()
+  }
+
+/**
+ * Logical conditional. The equivalent of Prolog's soft-cut.
+ * If its first argument succeeds at all, then the results will be
+ * fed into the success branch. Otherwise, the failure branch is taken.
+ *
+ * ```kotlin:ank:playground
+ * import arrow.core.*
+ *
+ * fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val result =
+ *    listOf(1,2,3).ifThen(listOf("empty")) { i ->
+ *      listOf("$i, ${i + 1}")
+ *    }
+ *   //sampleEnd
+ *   println(result)
+ * }
+ */
+fun <A, B> Sequence<A>.ifThen(fb: Sequence<B>, ffa: (A) -> Sequence<B>): Sequence<B> =
+  split()?.let { (fa, a) ->
+    ffa(a)._plus(fa.flatMap(ffa))
+  } ?: fb
+
+/**
+ * interleave both computations in a fair way.
+ *
+ * ```kotlin:ank:playground
+ * import arrow.core.*
+ *
+ * fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val tags = List(10) { "#" }
+ *   val result =
+ *    tags.interleave(listOf("A", "B", "C"))
+ *   //sampleEnd
+ *   println(result)
+ * }
+ */
+fun <A> Sequence<A>.interleave(other: Sequence<A>): Sequence<A> =
+  sequence {
+    val lsIterator = this@interleave.iterator()
+    val rsIterator = other.iterator()
+
+    while (lsIterator.hasNext() && rsIterator.hasNext()) {
+      yield(lsIterator.next())
+      yield(rsIterator.next())
+    }
+    yieldAll(lsIterator)
+    yieldAll(rsIterator)
+  }
+
+/**
+ * Returns a [List<C>] containing the result of applying some transformation `(A?, B) -> C`
+ * on a zip, excluding all cases where the right value is null.
+ *
+ * Example:
+ * ```kotlin:ank:playground
+ * import arrow.core.*
+ *
+ * //sampleStart
+ * val left = listOf(1, 2).leftPadZip(listOf("a")) { l, r -> l toT r }      // Result: [Tuple2(1, "a")]
+ * val right = listOf(1).leftPadZip(listOf("a", "b")) { l, r -> l toT r }   // Result: [Tuple2(1, "a"), Tuple2(null, "b")]
+ * val both = listOf(1, 2).leftPadZip(listOf("a", "b")) { l, r -> l toT r } // Result: [Tuple2(1, "a"), Tuple2(2, "b")]
+ * //sampleEnd
+ *
+ * fun main() {
+ *   println("left = $left")
+ *   println("right = $right")
+ *   println("both = $both")
+ * }
+ * ```
+ */
+fun <A, B, C> Sequence<A>.leftPadZip(other: Sequence<B>, fab: (A?, B) -> C): Sequence<C> =
+  padZip(other) { a: A?, b: B? -> b?.let { fab(a, it) } }.mapNotNull(::identity)
+
+fun <A> Sequence<A>.many(): Sequence<Sequence<A>> =
+  if (none()) sequenceOf(emptySequence())
+  else map { generateSequence { it } }
+
+/**
+ * Returns a [List<Tuple2<A?, B>>] containing the zipped values of the two listKs
+ * with null for padding on the left.
+ *
+ * Example:
+ * ```kotlin:ank:playground
+ * import arrow.core.*
+ *
+ * //sampleStart
+ * val padRight = listOf(1, 2).leftPadZip(listOf("a"))        // Result: [Tuple2(1, "a")]
+ * val padLeft = listOf(1).leftPadZip(listOf("a", "b"))       // Result: [Tuple2(1, "a"), Tuple2(null, "b")]
+ * val noPadding = listOf(1, 2).leftPadZip(listOf("a", "b"))  // Result: [Tuple2(1, "a"), Tuple2(2, "b")]
+ * //sampleEnd
+ *
+ * fun main() {
+ *   println("left = $left")
+ *   println("right = $right")
+ *   println("both = $both")
+ * }
+ * ```
+ */
+fun <A, B> Sequence<A>.leftPadZip(other: Sequence<B>): Sequence<Pair<A?, B>> =
+  this.leftPadZip(other) { a, b -> a to b }
+
+fun <A, B> Sequence<A>.mapConst(b: B): Sequence<B> =
+  map { b }
+
+fun <A> Sequence<A>.once(): Sequence<A> =
+  firstOrNull()?.let { sequenceOf(it) } ?: emptySequence()
+
+/**
+ * Returns a [List<Tuple2<A?, B?>>] containing the zipped values of the two lists with null for padding.
+ *
+ * Example:
+ * ```kotlin:ank:playground
+ * import arrow.core.*
+ *
+ * //sampleStart
+ * val padRight = listOf(1, 2).padZip(listOf("a"))        // Result: [Tuple2(1, "a"), Tuple2(2, null)]
+ * val padLeft = listOf(1).padZip(listOf("a", "b"))       // Result: [Tuple2(1, "a"), Tuple2(null, "b")]
+ * val noPadding = listOf(1, 2).padZip(listOf("a", "b"))  // Result: [Tuple2(1, "a"), Tuple2(2, "b")]
+ * //sampleEnd
+ *
+ * fun main() {
+ *   println("padRight = $padRight")
+ *   println("padLeft = $padLeft")
+ *   println("noPadding = $noPadding")
+ * }
+ * ```
+ */
+fun <A, B> Sequence<A>.padZip(other: Sequence<B>): Sequence<Pair<A?, B?>> =
+  align(other) { ior ->
+    ior.fold(
+      { it to null },
+      { null to it },
+      { a, b -> a to b }
+    )
+  }
+
+/**
+ * Returns a [ListK<C>] containing the result of applying some transformation `(A?, B?) -> C`
+ * on a zip.
+ *
+ * Example:
+ * ```kotlin:ank:playground
+ * import arrow.core.*
+ *
+ * //sampleStart
+ * val padZipRight = listOf(1, 2).padZip(listOf("a")) { l, r -> l toT r }     // Result: [Tuple2(1, "a"), Tuple2(2, null)]
+ * val padZipLeft = listOf(1).padZip(listOf("a", "b")) { l, r -> l toT r }    // Result: [Tuple2(1, "a"), Tuple2(null, "b")]
+ * val noPadding = listOf(1, 2).padZip(listOf("a", "b")) { l, r -> l toT r }  // Result: [Tuple2(1, "a"), Tuple2(2, "b")]
+ * //sampleEnd
+ *
+ * fun main() {
+ *   println("padZipRight = $padZipRight")
+ *   println("padZipLeft = $padZipLeft")
+ *   println("noPadding = $noPadding")
+ * }
+ * ```
+ */
+fun <A, B, C> Sequence<A>.padZip(other: Sequence<B>, fa: (A?, B?) -> C): Sequence<C> =
+  padZip(other).map { fa(it.first, it.second) }
+
+fun <A, B> Sequence<A>.reduceRightEvalOrNull(
+  initial: (A) -> B,
+  operation: (A, acc: Eval<B>) -> Eval<B>
+): Eval<B?> =
+  toList().reduceRightEvalOrNull(initial, operation)
+
+fun <A> Sequence<A>.replicate(n: Int): Sequence<Sequence<A>> =
+  if (n <= 0) emptySequence()
+  else this.let { l -> Sequence { List(n) { l }.iterator() } }
+
+fun <A> Sequence<A>.replicate(n: Int, MA: Monoid<A>): Sequence<A> =
+  if (n <= 0) sequenceOf(MA.empty())
+  else SequenceK.mapN(this@replicate, replicate(n - 1, MA)) { a, xs -> MA.run { a + xs } }
+
+/**
+ * Returns a [List<C>] containing the result of applying some transformation `(A, B?) -> C`
+ * on a zip, excluding all cases where the left value is null.
+ *
+ * Example:
+ * ```kotlin:ank:playground
+ * import arrow.core.*
+ *
+ * //sampleStart
+ * val left = listOf(1, 2).rightPadZip(listOf("a")) { l, r -> l toT r }      // Result: [Tuple2(1, "a"), Tuple2(null, "b")]
+ * val right = listOf(1).rightPadZip(listOf("a", "b")) { l, r -> l toT r }   // Result: [Tuple2(1, "a")]
+ * val both = listOf(1, 2).rightPadZip(listOf("a", "b")) { l, r -> l toT r } // Result: [Tuple2(1, "a"), Tuple2(2, "b")]
+ * //sampleEnd
+ *
+ * fun main() {
+ *   println("left = $left")
+ *   println("right = $right")
+ *   println("both = $both")
+ * }
+ * ```
+ */
+fun <A, B, C> Sequence<A>.rightPadZip(other: Sequence<B>, fa: (A, B?) -> C): Sequence<C> =
+  other.leftPadZip(this) { a, b -> fa(b, a) }
+
+/**
+ * Returns a [List<Tuple2<A, B?>>] containing the zipped values of the two listKs
+ * with null for padding on the right.
+ *
+ * Example:
+ * ```kotlin:ank:playground
+ * import arrow.core.*
+ *
+ * //sampleStart
+ * val padRight = listOf(1, 2).rightPadZip(listOf("a"))        // Result: [Tuple2(1, "a"), Tuple2(2, null)]
+ * val padLeft = listOf(1).rightPadZip(listOf("a", "b"))       // Result: [Tuple2(1, "a")]
+ * val noPadding = listOf(1, 2).rightPadZip(listOf("a", "b"))  // Result: [Tuple2(1, "a"), Tuple2(2, "b")]
+ * //sampleEnd
+ *
+ * fun main() {
+ *   println("left = $left")
+ *   println("right = $right")
+ *   println("both = $both")
+ * }
+ * ```
+ */
+fun <A, B> Sequence<A>.rightPadZip(other: Sequence<B>): Sequence<Pair<A, B?>> =
+  this.rightPadZip(other) { a, b -> a to b }
+
+/**
+ * aligns two structures and combine them with the given [Semigroup.combine]
+ */
+fun <A> Sequence<A>.salign(
+  SG: Semigroup<A>,
+  other: Sequence<A>
+): Sequence<A> = SG.run {
+  align(other) {
+    it.fold(::identity, ::identity) { a, b ->
+      a.combine(b)
+    }
+  }
+}
+
+fun <A, B> Sequence<Either<A, B>>.selectM(f: Sequence<(A) -> B>): Sequence<B> =
+  flatMap { it.fold({ a -> f.map { ff -> ff(a) } }, { b -> sequenceOf(b) }) }
+
+/**
+ * Separate the inner [Either] values into the [Either.Left] and [Either.Right].
+ *
+ * @receiver Iterable of Validated
+ * @return a tuple containing List with [Either.Left] and another List with its [Either.Right] values.
+ */
+fun <A, B> Sequence<Either<A, B>>.separateEither(): Pair<Sequence<A>, Sequence<B>> {
+  val asep = flatMap { gab -> gab.fold({ sequenceOf(it) }, { emptySequence() }) }
+  val bsep = flatMap { gab -> gab.fold({ emptySequence() }, { sequenceOf(it) }) }
+  return asep to bsep
+}
+
+/**
+ * Separate the inner [Validated] values into the [Validated.Invalid] and [Validated.Valid].
+ *
+ * @receiver Iterable of Validated
+ * @return a tuple containing List with [Validated.Invalid] and another List with its [Validated.Valid] values.
+ */
+fun <A, B> Sequence<Validated<A, B>>.separateValidated(): Pair<Sequence<A>, Sequence<B>> {
+  val asep = flatMap { gab -> gab.fold({ sequenceOf(it) }, { emptySequence() }) }
+  val bsep = flatMap { gab -> gab.fold({ emptySequence() }, { sequenceOf(it) }) }
+  return asep to bsep
+}
+
+fun <E, A> Sequence<Either<E, A>>.sequenceEither(): Either<E, Sequence<A>> =
+  traverseEither(::identity)
+
+fun <E> Sequence<Either<E, *>>.sequenceEither_(): Either<E, Unit> =
+  traverseEither_(::identity)
+
+fun <E, A> Sequence<Validated<E, A>>.sequenceValidated(semigroup: Semigroup<E>): Validated<E, Sequence<A>> =
+  traverseValidated(semigroup, ::identity)
+
+fun <E> Sequence<Validated<E, *>>.sequenceValidated_(semigroup: Semigroup<E>): Validated<E, Unit> =
+  traverseValidated_(semigroup, ::identity)
+
+fun <A> Sequence<A>.some(): Sequence<Sequence<A>> =
+  if (none()) emptySequence()
+  else map { generateSequence { it } }
+
+/**
+ * attempt to split the computation, giving access to the first result.
+ *
+ * ```kotlin:ank:playground
+ * import arrow.core.*
+ *
+ * fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val result =
+ *    listOf("A", "B", "C").split()
+ *   //sampleEnd
+ *   println(result)
+ * }
+ */
+fun <A> Sequence<A>.split(): Pair<Sequence<A>, A>? =
+  firstOrNull()?.let { first ->
+    Pair(tail(), first)
+  }
+
+fun <A> Sequence<A>.tail(): Sequence<A> =
+  drop(1)
+
+fun <E, A, B> Sequence<A>.traverseEither(f: (A) -> Either<E, B>): Either<E, Sequence<B>> =
+  foldRight<A, Either<E, Sequence<B>>>(emptySequence<B>().right()) { a, acc ->
+    f(a).ap(acc.map { bs -> { b: B -> sequenceOf(b)._plus(bs) } })
+  }
+
+fun <E, A> Sequence<A>.traverseEither_(f: (A) -> Either<E, *>): Either<E, Unit> {
+  val void = { _: Unit -> { _: Any? -> Unit } }
+  return foldRight<A, Either<E, Unit>>(Unit.right()) { a, acc ->
+    f(a).ap(acc.map(void))
+  }
+}
+
+fun <E, A, B> Sequence<A>.traverseValidated(semigroup: Semigroup<E>, f: (A) -> Validated<E, B>): Validated<E, Sequence<B>> =
+  foldRight<A, Validated<E, Sequence<B>>>(emptySequence<B>().valid()) { a, acc ->
+    f(a).ap(semigroup, acc.map { bs -> { b: B -> sequenceOf(b)._plus(bs) } })
+  }
+
+fun <E, A> Sequence<A>.traverseValidated_(semigroup: Semigroup<E>, f: (A) -> Validated<E, *>): Validated<E, Unit> =
+  foldRight<A, Validated<E, Unit>>(Unit.valid()) { a, acc ->
+    f(a).ap(semigroup, acc.map { { Unit } })
+  }
+
+/**
+ *  Pairs [B] with [A] returning a List<Tuple2<B, A>>
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.core.*
+ *
+ *  fun main(args: Array<String>) {
+ *   val result =
+ *   //sampleStart
+ *   listOf("Hello", "Hello2").tupleLeft("World")
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+fun <A, B> Sequence<A>.tupleLeft(b: B): Sequence<Pair<B, A>> =
+  map { a -> b to a }
+
+/**
+ *  Pairs [A] with [B] returning a List<Tuple2<A, B>>
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.core.*
+ *
+ *  fun main(args: Array<String>) {
+ *   val result =
+ *   //sampleStart
+ *   listOf("Hello").tupleRight("World")
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+fun <A, B> Sequence<A>.tupleRight(b: B): Sequence<Pair<A, B>> =
+  map { a -> a to b }
+
+/**
+ * splits a union into its component parts.
+ *
+ * ```kotlin:ank:playground
+ * import arrow.core.*
+ *
+ * fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val result =
+ *    listOf(("A" toT 1).bothIor(), ("B" toT 2).bothIor(), "C".leftIor())
+ *      .unalign()
+ *   //sampleEnd
+ *   println(result)
+ * }
+ * ```
+ */
+fun <A, B> Sequence<Ior<A, B>>.unalign(): Pair<Sequence<A>, Sequence<B>> =
+  fold(emptySequence<A>() to emptySequence()) { (l, r), x ->
+    x.fold(
+      { l._plus(it) to r },
+      { l to r._plus(it) },
+      { a, b -> l._plus(a) to r._plus(b) }
+    )
+  }
+
+/**
+ * after applying the given function, splits the resulting union shaped structure into its components parts
+ *
+ * ```kotlin:ank:playground
+ * import arrow.core.*
+ *
+ * fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val result =
+ *      listOf(1, 2, 3).unalign {
+ *        it.leftIor()
+ *      }
+ *   //sampleEnd
+ *   println(result)
+ * }
+ * ```
+ */
+fun <A, B, C> Sequence<C>.unalign(fa: (C) -> Ior<A, B>): Pair<Sequence<A>, Sequence<B>> =
+  map(fa).unalign()
+
+fun <A, B> Sequence<Either<A, B>>.uniteEither(): Sequence<B> =
+  flatMap { either ->
+    either.fold({ emptySequence() }, { b -> sequenceOf(b) })
+  }
+
+fun <A, B> Sequence<Validated<A, B>>.uniteValidated(): Sequence<B> =
+  flatMap { validated ->
+    validated.fold({ emptySequence() }, { b -> sequenceOf(b) })
+  }
+
+/**
+ * Fair conjunction. Similarly to interleave
+ *
+ * ```kotlin:ank:playground
+ * import arrow.core.*
+ *
+ * fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val result =
+ *    listOf(1,2,3).unweave { i -> listOf("$i, ${i + 1}") }
+ *   //sampleEnd
+ *   println(result)
+ * }
+ */
+fun <A, B> Sequence<A>.unweave(ffa: (A) -> Sequence<B>): Sequence<B> =
+  split()?.let { (fa, a) ->
+    ffa(a).interleave(fa.unweave(ffa))
+  } ?: emptySequence()
+
+/**
+ * unzips the structure holding the resulting elements in an `Tuple2`
+ *
+ * ```kotlin:ank:playground
+ * import arrow.core.*
+ *
+ * fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val result =
+ *      listOf("A" toT 1, "B" toT 2).k().unzip()
+ *   //sampleEnd
+ *   println(result)
+ * }
+ * ```
+ */
+fun <A, B> Sequence<Pair<A, B>>.unzip(): Pair<Sequence<A>, Sequence<B>> =
+  fold(emptySequence<A>() to emptySequence()) { (l, r), x ->
+    l._plus(x.first) to r._plus(x.second)
+  }
+
+/**
+ * after applying the given function unzip the resulting structure into its elements.
+ *
+ * ```kotlin:ank:playground
+ * import arrow.core.*
+ *
+ * fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val result =
+ *    listOf("A:1", "B:2", "C:3").k().unzip { e ->
+ *      e.split(":").let {
+ *        it.first() toT it.last()
+ *      }
+ *    }
+ *   //sampleEnd
+ *   println(result)
+ * }
+ * ```
+ */
+fun <A, B, C> Sequence<C>.unzip(fc: (C) -> Pair<A, B>): Pair<Sequence<A>, Sequence<B>> =
+  map(fc).unzip()
+
+fun <A> Sequence<A>.void(): Sequence<Unit> =
+  mapConst(Unit)
+
+/**
+ *  Given [A] is a sub type of [B], re-type this value from Iterable<A> to Iterable<B>
+ *
+ *  Kind<F, A> -> Kind<F, B>
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.core.*
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val result: Iterable<CharSequence> =
+ *     listOf("Hello World").widen()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+fun <B, A : B> Sequence<A>.widen(): Sequence<B> =
+  this
+
+fun <A, B, Z> Sequence<A>.zipEval(other: Eval<Sequence<B>>): Eval<Sequence<Pair<A, B>>> =
+  other.map { this.zip(it) }
+
+fun <A, B, Z> Sequence<A>.zipEval(other: Eval<Sequence<B>>, f: (Pair<A, B>) -> Z): Eval<Sequence<Z>> =
+  other.map { this.zip(it).map(f) }
 
 fun <A> Semigroup.Companion.sequence(): Semigroup<Sequence<A>> =
   Monoid.sequence()

--- a/arrow-core-data/src/main/kotlin/arrow/core/Sequence.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Sequence.kt
@@ -1,0 +1,16 @@
+package arrow.core
+
+import arrow.typeclasses.Monoid
+import arrow.typeclasses.Semigroup
+import kotlin.sequences.plus as _plus
+
+fun <A> Semigroup.Companion.sequence(): Semigroup<Sequence<A>> =
+  Monoid.sequence()
+
+fun <A> Monoid.Companion.sequence(): Monoid<Sequence<A>> =
+  SequenceMonoid as Monoid<Sequence<A>>
+
+object SequenceMonoid : Monoid<Sequence<Any?>> {
+  override fun empty(): Sequence<Any?> = emptySequence()
+  override fun Sequence<Any?>.combine(b: Sequence<Any?>): Sequence<Any?> = this._plus(b)
+}

--- a/arrow-core-data/src/main/kotlin/arrow/core/Sequence.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Sequence.kt
@@ -1,6 +1,5 @@
 package arrow.core
 
-import arrow.Kind
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Semigroup
 import kotlin.sequences.plus as _plus

--- a/arrow-core-data/src/main/kotlin/arrow/core/SequenceK.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/SequenceK.kt
@@ -5,12 +5,15 @@ import arrow.typeclasses.Applicative
 import arrow.typeclasses.Show
 import arrow.typeclasses.ShowDeprecation
 
+@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
 class ForSequenceK private constructor() {
   companion object
 }
+@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
 typealias SequenceKOf<A> = arrow.Kind<ForSequenceK, A>
 
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
+@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
 inline fun <A> SequenceKOf<A>.fix(): SequenceK<A> =
   this as SequenceK<A>
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/SequenceK.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/SequenceK.kt
@@ -87,9 +87,132 @@ data class SequenceK<out A>(val sequence: Sequence<A>) : SequenceKOf<A>, Sequenc
 
   companion object {
 
-    fun <A> just(a: A): SequenceK<A> = sequenceOf(a).k()
+    @PublishedApi
+    internal val unit: Sequence<Unit> =
+      sequenceOf(Unit)
 
     fun <A> empty(): SequenceK<A> = emptySequence<A>().k()
+
+    fun <A> just(a: A): SequenceK<A> = sequenceOf(a).k()
+
+    fun <B, C, D> mapN(
+      b: Sequence<B>,
+      c: Sequence<C>,
+      map: (B, C) -> D
+    ): Sequence<D> =
+      mapN(b, c, unit, unit, unit, unit, unit, unit, unit, unit) { b, c, _, _, _, _, _, _, _, _ -> map(b, c) }
+
+    fun <B, C, D, E> mapN(
+      b: Sequence<B>,
+      c: Sequence<C>,
+      d: Sequence<D>,
+      map: (B, C, D) -> E
+    ): Sequence<E> =
+      mapN(b, c, d, unit, unit, unit, unit, unit, unit, unit) { b, c, d, _, _, _, _, _, _, _ -> map(b, c, d) }
+
+    fun <B, C, D, E, F> mapN(
+      b: Sequence<B>,
+      c: Sequence<C>,
+      d: Sequence<D>,
+      e: Sequence<E>,
+      map: (B, C, D, E) -> F
+    ): Sequence<F> =
+      mapN(b, c, d, e, unit, unit, unit, unit, unit, unit) { b, c, d, e, _, _, _, _, _, _ -> map(b, c, d, e) }
+
+    fun <B, C, D, E, F, G> mapN(
+      b: Sequence<B>,
+      c: Sequence<C>,
+      d: Sequence<D>,
+      e: Sequence<E>,
+      f: Sequence<F>,
+      map: (B, C, D, E, F) -> G
+    ): Sequence<G> =
+      mapN(b, c, d, e, f, unit, unit, unit, unit, unit) { b, c, d, e, f, _, _, _, _, _ -> map(b, c, d, e, f) }
+
+    fun <B, C, D, E, F, G, H> mapN(
+      b: Sequence<B>,
+      c: Sequence<C>,
+      d: Sequence<D>,
+      e: Sequence<E>,
+      f: Sequence<F>,
+      g: Sequence<G>,
+      map: (B, C, D, E, F, G) -> H
+    ): Sequence<H> =
+      mapN(b, c, d, e, f, g, unit, unit, unit, unit) { b, c, d, e, f, g, _, _, _, _ -> map(b, c, d, e, f, g) }
+
+    fun <B, C, D, E, F, G, H, I> mapN(
+      b: Sequence<B>,
+      c: Sequence<C>,
+      d: Sequence<D>,
+      e: Sequence<E>,
+      f: Sequence<F>,
+      g: Sequence<G>,
+      h: Sequence<H>,
+      map: (B, C, D, E, F, G, H) -> I
+    ): Sequence<I> =
+      mapN(b, c, d, e, f, g, h, unit, unit, unit) { b, c, d, e, f, g, h, _, _, _ -> map(b, c, d, e, f, g, h) }
+
+    fun <B, C, D, E, F, G, H, I, J> mapN(
+      b: Sequence<B>,
+      c: Sequence<C>,
+      d: Sequence<D>,
+      e: Sequence<E>,
+      f: Sequence<F>,
+      g: Sequence<G>,
+      h: Sequence<H>,
+      i: Sequence<I>,
+      map: (B, C, D, E, F, G, H, I) -> J
+    ): Sequence<J> =
+      mapN(b, c, d, e, f, g, h, i, unit, unit) { b, c, d, e, f, g, h, i, _, _ -> map(b, c, d, e, f, g, h, i) }
+
+    fun <B, C, D, E, F, G, H, I, J, K> mapN(
+      b: Sequence<B>,
+      c: Sequence<C>,
+      d: Sequence<D>,
+      e: Sequence<E>,
+      f: Sequence<F>,
+      g: Sequence<G>,
+      h: Sequence<H>,
+      i: Sequence<I>,
+      j: Sequence<J>,
+      map: (B, C, D, E, F, G, H, I, J) -> K
+    ): Sequence<K> =
+      mapN(b, c, d, e, f, g, h, i, j, unit) { b, c, d, e, f, g, h, i, j, _ -> map(b, c, d, e, f, g, h, i, j) }
+
+    fun <B, C, D, E, F, G, H, I, J, K, L> mapN(
+      b: Sequence<B>,
+      c: Sequence<C>,
+      d: Sequence<D>,
+      e: Sequence<E>,
+      f: Sequence<F>,
+      g: Sequence<G>,
+      h: Sequence<H>,
+      i: Sequence<I>,
+      j: Sequence<J>,
+      k: Sequence<K>,
+      map: (B, C, D, E, F, G, H, I, J, K) -> L
+    ): Sequence<L> =
+      b.flatMap { bb ->
+        c.flatMap { cc ->
+          d.flatMap { dd ->
+            e.flatMap { ee ->
+              f.flatMap { ff ->
+                g.flatMap { gg ->
+                  h.flatMap { hh ->
+                    i.flatMap { ii ->
+                      j.flatMap { jj ->
+                        k.map { kk ->
+                          map(bb, cc, dd, ee, ff, gg, hh, ii, jj, kk)
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
 
     fun <A, B> tailRecM(a: A, f: (A) -> SequenceKOf<Either<A, B>>): SequenceK<B> {
       tailrec fun <A, B> go(
@@ -117,6 +240,30 @@ data class SequenceK<out A>(val sequence: Sequence<A>) : SequenceKOf<A>, Sequenc
       val buf = mutableListOf<B>()
       go(buf, f, f(a).fix())
       return SequenceK(buf.asSequence())
+    }
+
+    fun <A, B> tailRecM(a: A, f: (A) -> Sequence<Either<A, B>>): Sequence<B> {
+      tailrec fun <A, B> go(
+        buf: MutableList<B>,
+        f: (A) -> Sequence<Either<A, B>>,
+        v: Sequence<Either<A, B>>
+      ) {
+        if (v.any()) {
+          when (val head: Either<A, B> = v.first()) {
+            is Either.Right -> {
+              buf += head.b
+              go(buf, f, v.drop(1))
+            }
+            is Either.Left -> {
+              go(buf, f, (f(head.a) + v.drop(1)))
+            }
+          }
+        }
+      }
+
+      val buf = mutableListOf<B>()
+      go(buf, f, f(a))
+      return buf.asSequence()
     }
   }
 }

--- a/arrow-core-data/src/main/kotlin/arrow/core/SequenceK.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/SequenceK.kt
@@ -87,10 +87,6 @@ data class SequenceK<out A>(val sequence: Sequence<A>) : SequenceKOf<A>, Sequenc
 
   companion object {
 
-    @PublishedApi
-    internal val unit: Sequence<Unit> =
-      sequenceOf(Unit)
-
     fun <A> empty(): SequenceK<A> = emptySequence<A>().k()
 
     fun <A> just(a: A): SequenceK<A> = sequenceOf(a).k()
@@ -100,7 +96,7 @@ data class SequenceK<out A>(val sequence: Sequence<A>) : SequenceKOf<A>, Sequenc
       c: Sequence<C>,
       map: (B, C) -> D
     ): Sequence<D> =
-      mapN(b, c, unit, unit, unit, unit, unit, unit, unit, unit) { b, c, _, _, _, _, _, _, _, _ -> map(b, c) }
+      mapN(b, c, sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit)) { b, c, _, _, _, _, _, _, _, _ -> map(b, c) }
 
     fun <B, C, D, E> mapN(
       b: Sequence<B>,
@@ -108,7 +104,7 @@ data class SequenceK<out A>(val sequence: Sequence<A>) : SequenceKOf<A>, Sequenc
       d: Sequence<D>,
       map: (B, C, D) -> E
     ): Sequence<E> =
-      mapN(b, c, d, unit, unit, unit, unit, unit, unit, unit) { b, c, d, _, _, _, _, _, _, _ -> map(b, c, d) }
+      mapN(b, c, d, sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit)) { b, c, d, _, _, _, _, _, _, _ -> map(b, c, d) }
 
     fun <B, C, D, E, F> mapN(
       b: Sequence<B>,
@@ -117,7 +113,7 @@ data class SequenceK<out A>(val sequence: Sequence<A>) : SequenceKOf<A>, Sequenc
       e: Sequence<E>,
       map: (B, C, D, E) -> F
     ): Sequence<F> =
-      mapN(b, c, d, e, unit, unit, unit, unit, unit, unit) { b, c, d, e, _, _, _, _, _, _ -> map(b, c, d, e) }
+      mapN(b, c, d, e, sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit)) { b, c, d, e, _, _, _, _, _, _ -> map(b, c, d, e) }
 
     fun <B, C, D, E, F, G> mapN(
       b: Sequence<B>,
@@ -127,7 +123,7 @@ data class SequenceK<out A>(val sequence: Sequence<A>) : SequenceKOf<A>, Sequenc
       f: Sequence<F>,
       map: (B, C, D, E, F) -> G
     ): Sequence<G> =
-      mapN(b, c, d, e, f, unit, unit, unit, unit, unit) { b, c, d, e, f, _, _, _, _, _ -> map(b, c, d, e, f) }
+      mapN(b, c, d, e, f, sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit)) { b, c, d, e, f, _, _, _, _, _ -> map(b, c, d, e, f) }
 
     fun <B, C, D, E, F, G, H> mapN(
       b: Sequence<B>,
@@ -138,7 +134,7 @@ data class SequenceK<out A>(val sequence: Sequence<A>) : SequenceKOf<A>, Sequenc
       g: Sequence<G>,
       map: (B, C, D, E, F, G) -> H
     ): Sequence<H> =
-      mapN(b, c, d, e, f, g, unit, unit, unit, unit) { b, c, d, e, f, g, _, _, _, _ -> map(b, c, d, e, f, g) }
+      mapN(b, c, d, e, f, g, sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit)) { b, c, d, e, f, g, _, _, _, _ -> map(b, c, d, e, f, g) }
 
     fun <B, C, D, E, F, G, H, I> mapN(
       b: Sequence<B>,
@@ -150,7 +146,7 @@ data class SequenceK<out A>(val sequence: Sequence<A>) : SequenceKOf<A>, Sequenc
       h: Sequence<H>,
       map: (B, C, D, E, F, G, H) -> I
     ): Sequence<I> =
-      mapN(b, c, d, e, f, g, h, unit, unit, unit) { b, c, d, e, f, g, h, _, _, _ -> map(b, c, d, e, f, g, h) }
+      mapN(b, c, d, e, f, g, h, sequenceOf(Unit), sequenceOf(Unit), sequenceOf(Unit)) { b, c, d, e, f, g, h, _, _, _ -> map(b, c, d, e, f, g, h) }
 
     fun <B, C, D, E, F, G, H, I, J> mapN(
       b: Sequence<B>,
@@ -163,7 +159,7 @@ data class SequenceK<out A>(val sequence: Sequence<A>) : SequenceKOf<A>, Sequenc
       i: Sequence<I>,
       map: (B, C, D, E, F, G, H, I) -> J
     ): Sequence<J> =
-      mapN(b, c, d, e, f, g, h, i, unit, unit) { b, c, d, e, f, g, h, i, _, _ -> map(b, c, d, e, f, g, h, i) }
+      mapN(b, c, d, e, f, g, h, i, sequenceOf(Unit), sequenceOf(Unit)) { b, c, d, e, f, g, h, i, _, _ -> map(b, c, d, e, f, g, h, i) }
 
     fun <B, C, D, E, F, G, H, I, J, K> mapN(
       b: Sequence<B>,
@@ -177,7 +173,7 @@ data class SequenceK<out A>(val sequence: Sequence<A>) : SequenceKOf<A>, Sequenc
       j: Sequence<J>,
       map: (B, C, D, E, F, G, H, I, J) -> K
     ): Sequence<K> =
-      mapN(b, c, d, e, f, g, h, i, j, unit) { b, c, d, e, f, g, h, i, j, _ -> map(b, c, d, e, f, g, h, i, j) }
+      mapN(b, c, d, e, f, g, h, i, j, sequenceOf(Unit)) { b, c, d, e, f, g, h, i, j, _ -> map(b, c, d, e, f, g, h, i, j) }
 
     fun <B, C, D, E, F, G, H, I, J, K, L> mapN(
       b: Sequence<B>,

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/align/SequenceKAlign.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/align/SequenceKAlign.kt
@@ -38,7 +38,7 @@ object Sequence {
     "NOTHING_TO_INLINE"
   )
   @Deprecated(
-    "Align typeclasses is deprecated. Use concrete methods on Sequence",
+    "Align typeclass is deprecated. Use concrete methods on Sequence",
     level = DeprecationLevel.WARNING
   )
   inline fun align(): SequenceKAlign = align_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/align/SequenceKAlign.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/align/SequenceKAlign.kt
@@ -1,10 +1,6 @@
 package arrow.core.extensions.sequence.align
 
 import arrow.core.extensions.SequenceKAlign
-import kotlin.Deprecated
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 import kotlin.sequences.Sequence
 
 @JvmName("empty")
@@ -17,8 +13,7 @@ import kotlin.sequences.Sequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "empty()",
-  "arrow.core.extensions.sequence.align.Sequence.empty"
+    "emptySequence<A>()"
   ),
   DeprecationLevel.WARNING
 )
@@ -33,9 +28,17 @@ fun <A> empty(): Sequence<A> =
 @PublishedApi()
 internal val align_singleton: SequenceKAlign = object : arrow.core.extensions.SequenceKAlign {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
+  )
+  @Deprecated(
+    "Align typeclasses is deprecated. Use concrete methods on Sequence",
+    level = DeprecationLevel.WARNING
   )
   inline fun align(): SequenceKAlign = align_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/alternative/SequenceKAlternative.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/alternative/SequenceKAlternative.kt
@@ -4,13 +4,6 @@ import arrow.Kind
 import arrow.core.ForSequenceK
 import arrow.core.Option
 import arrow.core.extensions.SequenceKAlternative
-import kotlin.Boolean
-import kotlin.Deprecated
-import kotlin.Function0
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.Unit
-import kotlin.jvm.JvmName
 import kotlin.sequences.Sequence
 
 @JvmName("some")
@@ -23,8 +16,8 @@ import kotlin.sequences.Sequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "some()",
-  "arrow.core.some"
+    "this.some()",
+    "arrow.core.some"
   ),
   DeprecationLevel.WARNING
 )
@@ -44,8 +37,8 @@ fun <A> Sequence<A>.some(): Sequence<Sequence<A>> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "many()",
-  "arrow.core.many"
+    "this.many()",
+    "arrow.core.many"
   ),
   DeprecationLevel.WARNING
 )
@@ -65,8 +58,7 @@ fun <A> Sequence<A>.many(): Sequence<Sequence<A>> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "alt(arg1)",
-  "arrow.core.alt"
+    "this + arg1"
   ),
   DeprecationLevel.WARNING
 )
@@ -85,8 +77,7 @@ infix fun <A> Sequence<A>.alt(arg1: Sequence<A>): Sequence<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "orElse(arg1)",
-  "arrow.core.orElse"
+    "this + arg1"
   ),
   DeprecationLevel.WARNING
 )
@@ -106,8 +97,7 @@ fun <A> Sequence<A>.orElse(arg1: Sequence<A>): Sequence<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "combineK(arg1)",
-  "arrow.core.combineK"
+    "this + arg1"
   ),
   DeprecationLevel.WARNING
 )
@@ -127,8 +117,8 @@ fun <A> Sequence<A>.combineK(arg1: Sequence<A>): Sequence<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "optional()",
-  "arrow.core.optional"
+    "this.map(::Some) + sequenceOf(None)",
+    "arrow.core.None", "arrow.core.Some"
   ),
   DeprecationLevel.WARNING
 )
@@ -148,8 +138,7 @@ fun <A> Sequence<A>.optional(): Sequence<Option<A>> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "guard(arg0)",
-  "arrow.core.extensions.sequence.alternative.Sequence.guard"
+    "if (arg0) sequenceOf(Unit) else emptySequence()"
   ),
   DeprecationLevel.WARNING
 )
@@ -167,8 +156,7 @@ fun guard(arg0: Boolean): Sequence<Unit> = arrow.core.extensions.sequence.altern
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "lazyOrElse(arg1)",
-  "arrow.core.lazyOrElse"
+    "this + arg1()"
   ),
   DeprecationLevel.WARNING
 )
@@ -184,9 +172,17 @@ fun <A> Sequence<A>.lazyOrElse(arg1: Function0<Kind<ForSequenceK, A>>): Sequence
 internal val alternative_singleton: SequenceKAlternative = object :
     arrow.core.extensions.SequenceKAlternative {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
+  )
+  @Deprecated(
+    "Alternative typeclass is deprecated. Use concrete methods on Sequence",
+    level = DeprecationLevel.WARNING
   )
   inline fun alternative(): SequenceKAlternative = alternative_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/applicative/SequenceKApplicative.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/applicative/SequenceKApplicative.kt
@@ -2,14 +2,6 @@ package arrow.core.extensions.sequence.applicative
 
 import arrow.core.extensions.SequenceKApplicative
 import arrow.typeclasses.Monoid
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.Int
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.Unit
-import kotlin.collections.List
-import kotlin.jvm.JvmName
 import kotlin.sequences.Sequence
 
 @JvmName("just1")
@@ -22,8 +14,7 @@ import kotlin.sequences.Sequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "just()",
-  "arrow.core.just"
+    "sequenceOf(this)"
   ),
   DeprecationLevel.WARNING
 )
@@ -42,8 +33,7 @@ fun <A> A.just(): Sequence<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "unit()",
-  "arrow.core.extensions.sequence.applicative.Sequence.unit"
+    "sequenceOf(Unit)"
   ),
   DeprecationLevel.WARNING
 )
@@ -61,8 +51,7 @@ fun unit(): Sequence<Unit> = arrow.core.extensions.sequence.applicative.Sequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg1)",
-  "arrow.core.map"
+    "this.map(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -81,8 +70,8 @@ fun <A, B> Sequence<A>.map(arg1: Function1<A, B>): Sequence<B> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "replicate(arg1)",
-  "arrow.core.replicate"
+    "this.replicate(arg1)",
+    "arrow.core.replicate"
   ),
   DeprecationLevel.WARNING
 )
@@ -102,8 +91,8 @@ fun <A> Sequence<A>.replicate(arg1: Int): Sequence<List<A>> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "replicate(arg1, arg2)",
-  "arrow.core.replicate"
+    "this.replicate(arg1, arg2)",
+    "arrow.core.replicate"
   ),
   DeprecationLevel.WARNING
 )
@@ -119,9 +108,17 @@ fun <A> Sequence<A>.replicate(arg1: Int, arg2: Monoid<A>): Sequence<A> =
 internal val applicative_singleton: SequenceKApplicative = object :
     arrow.core.extensions.SequenceKApplicative {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
+  )
+  @Deprecated(
+    "Applicative typeclass is deprecated. Use concrete methods on Sequence",
+    level = DeprecationLevel.WARNING
   )
   inline fun applicative(): SequenceKApplicative = applicative_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/apply/SequenceKApply.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/apply/SequenceKApply.kt
@@ -13,11 +13,6 @@ import arrow.core.Tuple7
 import arrow.core.Tuple8
 import arrow.core.Tuple9
 import arrow.core.extensions.SequenceKApply
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 import kotlin.sequences.Sequence
 
 @JvmName("ap")
@@ -30,8 +25,8 @@ import kotlin.sequences.Sequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "ap(arg1)",
-  "arrow.core.ap"
+    "this.ap(arg1)",
+    "arrow.core.ap"
   ),
   DeprecationLevel.WARNING
 )
@@ -50,8 +45,8 @@ fun <A, B> Sequence<A>.ap(arg1: Sequence<Function1<A, B>>): Sequence<B> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "apEval(arg1)",
-  "arrow.core.apEval"
+    "this.apEval(arg1)",
+    "arrow.core.apEval"
   ),
   DeprecationLevel.WARNING
 )
@@ -71,8 +66,8 @@ fun <A, B> Sequence<A>.apEval(arg1: Eval<Kind<ForSequenceK, Function1<A, B>>>):
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map2Eval(arg1, arg2)",
-  "arrow.core.map2Eval"
+    "this.zipEval(arg1, arg2)",
+    "arrow.core.zipEval"
   ),
   DeprecationLevel.WARNING
 )
@@ -94,8 +89,8 @@ fun <A, B, Z> Sequence<A>.map2Eval(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg0, arg1, arg2)",
-  "arrow.core.extensions.sequence.apply.Sequence.map"
+    "SequenceK.mapN(arg0, arg1) { a, b -> arg2(Tuple2(a, b)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
 )
@@ -118,8 +113,8 @@ fun <A, B, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2)",
-  "arrow.core.extensions.sequence.apply.Sequence.mapN"
+    "SequenceK.mapN(arg0, arg1) { a, b -> arg2(Tuple2(a, b)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
 )
@@ -142,8 +137,8 @@ fun <A, B, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg0, arg1, arg2, arg3)",
-  "arrow.core.extensions.sequence.apply.Sequence.map"
+    "SequenceK.mapN(arg0, arg1, arg2) { a, b, c -> arg2(Tuple3(a, b, c)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
 )
@@ -168,8 +163,8 @@ fun <A, B, C, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2, arg3)",
-  "arrow.core.extensions.sequence.apply.Sequence.mapN"
+    "SequenceK.mapN(arg0, arg1, arg2) { a, b, c -> arg2(Tuple3(a, b, c)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
 )
@@ -194,8 +189,8 @@ fun <A, B, C, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg0, arg1, arg2, arg3, arg4)",
-  "arrow.core.extensions.sequence.apply.Sequence.map"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3) { a, b, c, d -> arg2(Tuple4(a, b, c, d)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
 )
@@ -221,8 +216,8 @@ fun <A, B, C, D, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2, arg3, arg4)",
-  "arrow.core.extensions.sequence.apply.Sequence.mapN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3) { a, b, c, d -> arg2(Tuple4(a, b, c, d)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
 )
@@ -248,8 +243,8 @@ fun <A, B, C, D, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg0, arg1, arg2, arg3, arg4, arg5)",
-  "arrow.core.extensions.sequence.apply.Sequence.map"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg2(Tuple5(a, b, c, d, e)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
 )
@@ -276,8 +271,8 @@ fun <A, B, C, D, E, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2, arg3, arg4, arg5)",
-  "arrow.core.extensions.sequence.apply.Sequence.mapN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg2(Tuple5(a, b, c, d, e)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
 )
@@ -304,8 +299,8 @@ fun <A, B, C, D, E, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-  "arrow.core.extensions.sequence.apply.Sequence.map"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> arg2(Tuple6(a, b, c, d, e, f)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
 )
@@ -333,8 +328,8 @@ fun <A, B, C, D, E, FF, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-  "arrow.core.extensions.sequence.apply.Sequence.mapN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> arg2(Tuple6(a, b, c, d, e, f)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
 )
@@ -362,8 +357,8 @@ fun <A, B, C, D, E, FF, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-  "arrow.core.extensions.sequence.apply.Sequence.map"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> arg2(Tuple7(a, b, c, d, e, f, g)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
 )
@@ -392,8 +387,8 @@ fun <A, B, C, D, E, FF, G, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-  "arrow.core.extensions.sequence.apply.Sequence.mapN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> arg2(Tuple7(a, b, c, d, e, f, g)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
 )
@@ -422,8 +417,8 @@ fun <A, B, C, D, E, FF, G, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-  "arrow.core.extensions.sequence.apply.Sequence.map"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> arg2(Tuple8(a, b, c, d, e, f, g, h)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
 )
@@ -453,8 +448,8 @@ fun <A, B, C, D, E, FF, G, H, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-  "arrow.core.extensions.sequence.apply.Sequence.mapN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> arg2(Tuple8(a, b, c, d, e, f, g, h)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
 )
@@ -484,8 +479,8 @@ fun <A, B, C, D, E, FF, G, H, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-  "arrow.core.extensions.sequence.apply.Sequence.map"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, f, g, h, i -> arg2(Tuple9(a, b, c, d, e, f, g, h, i)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
 )
@@ -516,8 +511,8 @@ fun <A, B, C, D, E, FF, G, H, I, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-  "arrow.core.extensions.sequence.apply.Sequence.mapN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, f, g, h, i -> arg2(Tuple9(a, b, c, d, e, f, g, h, i)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
 )
@@ -548,8 +543,8 @@ fun <A, B, C, D, E, FF, G, H, I, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)",
-  "arrow.core.extensions.sequence.apply.Sequence.map"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, f, g, h, i, j -> arg2(Tuple10(a, b, c, d, e, f, g, h, i, j)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
 )
@@ -581,8 +576,8 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)",
-  "arrow.core.extensions.sequence.apply.Sequence.mapN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, f, g, h, i, j -> arg2(Tuple10(a, b, c, d, e, f, g, h, i, j)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
 )
@@ -614,8 +609,7 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map2(arg1, arg2)",
-  "arrow.core.map2"
+    "this.zip(arg1) { a, b -> arg2(Tuple2(a, b)) }"
   ),
   DeprecationLevel.WARNING
 )
@@ -635,8 +629,8 @@ fun <A, B, Z> Sequence<A>.map2(arg1: Sequence<B>, arg2: Function1<Tuple2<A, B>, 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.zip(arg1) { a, b -> Tuple2(a, b) }",
+    "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
 )
@@ -656,8 +650,8 @@ fun <A, B> Sequence<A>.product(arg1: Sequence<B>): Sequence<Tuple2<A, B>> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.zip(arg1) { (a, b), z -> Tuple3(a, b, z) }",
+    "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
 )
@@ -677,8 +671,8 @@ fun <A, B, Z> Sequence<Tuple2<A, B>>.product(arg1: Sequence<Z>): Sequence<Tuple3
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.zip(arg1) { (a, b, c), z -> Tuple4(a, b, c, z) }",
+    "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
 )
@@ -698,8 +692,8 @@ fun <A, B, C, Z> Sequence<Tuple3<A, B, C>>.product(arg1: Sequence<Z>): Sequence<
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.zip(arg1) { (a, b, c, d), z -> Tuple5(a, b, c, d, z) }",
+    "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
 )
@@ -719,8 +713,8 @@ fun <A, B, C, D, Z> Sequence<Tuple4<A, B, C, D>>.product(arg1: Sequence<Z>): Seq
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.zip(arg1) { (a, b, c, d, e), z -> Tuple6(a, b, c, d, e, z) }",
+    "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
 )
@@ -740,8 +734,8 @@ fun <A, B, C, D, E, Z> Sequence<Tuple5<A, B, C, D, E>>.product(arg1: Sequence<Z>
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.zip(arg1) { (a, b, c, d, e, f), z -> Tuple7(a, b, c, d, e, f, z) }",
+    "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
 )
@@ -762,8 +756,8 @@ fun <A, B, C, D, E, FF, Z> Sequence<Tuple6<A, B, C, D, E, FF>>.product(arg1: Seq
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.zip(arg1) { (a, b, c, d, e, f, g), z -> Tuple8(a, b, c, d, e, f, g, z) }",
+    "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
 )
@@ -784,8 +778,8 @@ fun <A, B, C, D, E, FF, G, Z> Sequence<Tuple7<A, B, C, D, E, FF, G>>.product(arg
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.zip(arg1) { (a, b, c, d, e, f, g, h), z -> Tuple9(a, b, c, d, e, f, g, h, z) }",
+    "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
 )
@@ -806,8 +800,8 @@ fun <A, B, C, D, E, FF, G, H, Z> Sequence<Tuple8<A, B, C, D, E, FF, G,
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.zip(arg1) { (a, b, c, d, e, f, g, h, i), z -> Tuple10(a, b, c, d, e, f, g, h, i, z) }",
+    "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
 )
@@ -829,8 +823,8 @@ fun <A, B, C, D, E, FF, G, H, I, Z> Sequence<Tuple9<A, B, C, D, E, FF, G, H,
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1)",
-  "arrow.core.extensions.sequence.apply.Sequence.tupled"
+    "SequenceK.mapN(arg0, arg1) { a, b -> Tuple2(a, b) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
 )
@@ -850,8 +844,8 @@ fun <A, B> tupled(arg0: Sequence<A>, arg1: Sequence<B>): Sequence<Tuple2<A, B>> 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1)",
-  "arrow.core.extensions.sequence.apply.Sequence.tupledN"
+    "SequenceK.mapN(arg0, arg1) { a, b -> Tuple2(a, b) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
 )
@@ -871,8 +865,8 @@ fun <A, B> tupledN(arg0: Sequence<A>, arg1: Sequence<B>): Sequence<Tuple2<A, B>>
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1, arg2)",
-  "arrow.core.extensions.sequence.apply.Sequence.tupled"
+    "SequenceK.mapN(arg0, arg1, arg2) { a, b, c -> Tuple3(a, b, c) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
 )
@@ -896,8 +890,8 @@ fun <A, B, C> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1, arg2)",
-  "arrow.core.extensions.sequence.apply.Sequence.tupledN"
+    "SequenceK.mapN(arg0, arg1, arg2) { a, b, c -> Tuple3(a, b, c) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
 )
@@ -921,8 +915,8 @@ fun <A, B, C> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1, arg2, arg3)",
-  "arrow.core.extensions.sequence.apply.Sequence.tupled"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
 )
@@ -947,8 +941,8 @@ fun <A, B, C, D> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1, arg2, arg3)",
-  "arrow.core.extensions.sequence.apply.Sequence.tupledN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
 )
@@ -973,8 +967,8 @@ fun <A, B, C, D> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1, arg2, arg3, arg4)",
-  "arrow.core.extensions.sequence.apply.Sequence.tupled"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
 )
@@ -1000,8 +994,8 @@ fun <A, B, C, D, E> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1, arg2, arg3, arg4)",
-  "arrow.core.extensions.sequence.apply.Sequence.tupledN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
 )
@@ -1027,8 +1021,8 @@ fun <A, B, C, D, E> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1, arg2, arg3, arg4, arg5)",
-  "arrow.core.extensions.sequence.apply.Sequence.tupled"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> Tuple6(a, b, c, d, e, f) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
 )
@@ -1055,8 +1049,8 @@ fun <A, B, C, D, E, FF> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1, arg2, arg3, arg4, arg5)",
-  "arrow.core.extensions.sequence.apply.Sequence.tupledN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> Tuple6(a, b, c, d, e, f) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
 )
@@ -1083,8 +1077,8 @@ fun <A, B, C, D, E, FF> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-  "arrow.core.extensions.sequence.apply.Sequence.tupled"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> Tuple7(a, b, c, d, e, f, g) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
 )
@@ -1112,8 +1106,8 @@ fun <A, B, C, D, E, FF, G> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-  "arrow.core.extensions.sequence.apply.Sequence.tupledN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> Tuple7(a, b, c, d, e, f, g) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
 )
@@ -1141,8 +1135,8 @@ fun <A, B, C, D, E, FF, G> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-  "arrow.core.extensions.sequence.apply.Sequence.tupled"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> Tuple8(a, b, c, d, e, f, g, h) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
 )
@@ -1171,8 +1165,8 @@ fun <A, B, C, D, E, FF, G, H> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-  "arrow.core.extensions.sequence.apply.Sequence.tupledN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> Tuple8(a, b, c, d, e, f, g, h) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
 )
@@ -1201,8 +1195,8 @@ fun <A, B, C, D, E, FF, G, H> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-  "arrow.core.extensions.sequence.apply.Sequence.tupled"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, f, g, h, i -> Tuple9(a, b, c, d, e, f, g, h, i) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
 )
@@ -1232,8 +1226,8 @@ fun <A, B, C, D, E, FF, G, H, I> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-  "arrow.core.extensions.sequence.apply.Sequence.tupledN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, f, g, h, i -> Tuple9(a, b, c, d, e, f, g, h, i) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
 )
@@ -1263,8 +1257,8 @@ fun <A, B, C, D, E, FF, G, H, I> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-  "arrow.core.extensions.sequence.apply.Sequence.tupled"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, f, g, h, i, j -> Tuple10(a, b, c, d, e, f, g, h, i, j) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
 )
@@ -1295,8 +1289,8 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-  "arrow.core.extensions.sequence.apply.Sequence.tupledN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, f, g, h, i, j -> Tuple10(a, b, c, d, e, f, g, h, i, j) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
 )
@@ -1327,8 +1321,7 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "followedBy(arg1)",
-  "arrow.core.followedBy"
+    "this.flatMap { arg1 }"
   ),
   DeprecationLevel.WARNING
 )
@@ -1348,8 +1341,8 @@ fun <A, B> Sequence<A>.followedBy(arg1: Sequence<B>): Sequence<B> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "apTap(arg1)",
-  "arrow.core.apTap"
+    "SequenceK.mapN(this, arg1) { left, _ -> left }",
+    "arrow.core.SequenceK"
   ),
   DeprecationLevel.WARNING
 )
@@ -1365,9 +1358,17 @@ fun <A, B> Sequence<A>.apTap(arg1: Sequence<B>): Sequence<A> =
 @PublishedApi()
 internal val apply_singleton: SequenceKApply = object : arrow.core.extensions.SequenceKApply {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
+  )
+  @Deprecated(
+    "Apply typeclass is deprecated. Use concrete methods on Sequence",
+    level = DeprecationLevel.WARNING
   )
   inline fun apply(): SequenceKApply = apply_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/crosswalk/SequenceKCrosswalk.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/crosswalk/SequenceKCrosswalk.kt
@@ -4,11 +4,6 @@ import arrow.Kind
 import arrow.core.ForSequenceK
 import arrow.core.extensions.SequenceKCrosswalk
 import arrow.typeclasses.Align
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 import kotlin.sequences.Sequence
 
 @JvmName("crosswalk")
@@ -19,12 +14,8 @@ import kotlin.sequences.Sequence
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "crosswalk(arg0, arg1, arg2)",
-  "arrow.core.extensions.sequence.crosswalk.Sequence.crosswalk"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated. Replace with crosswalk, crosswalkMap or crosswalkNull from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <F, A, B> crosswalk(
   arg0: Align<F>,
@@ -43,12 +34,8 @@ fun <F, A, B> crosswalk(
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "sequenceL(arg0, arg1)",
-  "arrow.core.extensions.sequence.crosswalk.Sequence.sequenceL"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated. Replace with sequenceEither or sequenceValidated from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <F, A> sequenceL(arg0: Align<F>, arg1: Sequence<Kind<F, A>>): Kind<F, Kind<ForSequenceK, A>> =
     arrow.core.extensions.sequence.crosswalk.Sequence
@@ -63,9 +50,17 @@ fun <F, A> sequenceL(arg0: Align<F>, arg1: Sequence<Kind<F, A>>): Kind<F, Kind<F
 internal val crosswalk_singleton: SequenceKCrosswalk = object :
     arrow.core.extensions.SequenceKCrosswalk {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
+  )
+  @Deprecated(
+    "Crosswalk typeclass is deprecated. Use concrete methods on Sequence",
+    level = DeprecationLevel.WARNING
   )
   inline fun crosswalk(): SequenceKCrosswalk = crosswalk_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/eqK/SequenceKEqK.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/eqK/SequenceKEqK.kt
@@ -16,7 +16,7 @@ import kotlin.sequences.Sequence
 @Deprecated(
   "Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0",
   ReplaceWith(
-    "this == arg1"
+    "this.toList() == arg1.toList()"
   ),
   DeprecationLevel.WARNING
 )

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/eqK/SequenceKEqK.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/eqK/SequenceKEqK.kt
@@ -4,11 +4,6 @@ import arrow.Kind
 import arrow.core.ForSequenceK
 import arrow.core.extensions.SequenceKEqK
 import arrow.typeclasses.Eq
-import kotlin.Boolean
-import kotlin.Deprecated
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 import kotlin.sequences.Sequence
 
 @JvmName("eqK")
@@ -19,10 +14,9 @@ import kotlin.sequences.Sequence
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
+  "Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0",
   ReplaceWith(
-  "eqK(arg1, arg2)",
-  "arrow.core.eqK"
+    "this == arg1"
   ),
   DeprecationLevel.WARNING
 )
@@ -39,12 +33,8 @@ fun <A> Sequence<A>.eqK(arg1: Sequence<A>, arg2: Eq<A>): Boolean =
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "liftEq(arg0)",
-  "arrow.core.extensions.sequence.eqK.Sequence.liftEq"
-  ),
-  DeprecationLevel.WARNING
+  "Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0",
+  level = DeprecationLevel.WARNING
 )
 fun <A> liftEq(arg0: Eq<A>): Eq<Kind<ForSequenceK, A>> = arrow.core.extensions.sequence.eqK.Sequence
    .eqK()
@@ -56,9 +46,17 @@ fun <A> liftEq(arg0: Eq<A>): Eq<Kind<ForSequenceK, A>> = arrow.core.extensions.s
 @PublishedApi()
 internal val eqK_singleton: SequenceKEqK = object : arrow.core.extensions.SequenceKEqK {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
+  )
+  @Deprecated(
+    "Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0",
+    level = DeprecationLevel.WARNING
   )
   inline fun eqK(): SequenceKEqK = eqK_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/foldable/SequenceKFoldable.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/foldable/SequenceKFoldable.kt
@@ -221,7 +221,7 @@ fun <A> orEmpty(arg0: Applicative<ForSequenceK>, arg1: Monoid<A>): Sequence<A> =
 )
 @Deprecated(
   "@extension kinded projected functions are deprecated. Replace with traverseEither_ or traverseValidated_ from arrow.core.*",
-  level= DeprecationLevel.WARNING
+  level = DeprecationLevel.WARNING
 )
 fun <G, A, B> Sequence<A>.traverse_(arg1: Applicative<G>, arg2: Function1<A, Kind<G, B>>): Kind<G,
     Unit> = arrow.core.extensions.sequence.foldable.Sequence.foldable().run {
@@ -237,7 +237,7 @@ fun <G, A, B> Sequence<A>.traverse_(arg1: Applicative<G>, arg2: Function1<A, Kin
 )
 @Deprecated(
   "@extension kinded projected functions are deprecated. Replace with sequenceEither_ or sequenceValidated_ from arrow.core.*",
-  level= DeprecationLevel.WARNING
+  level = DeprecationLevel.WARNING
 )
 fun <G, A> Sequence<Kind<G, A>>.sequence_(arg1: Applicative<G>): Kind<G, Unit> =
     arrow.core.extensions.sequence.foldable.Sequence.foldable().run {

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/foldable/SequenceKFoldable.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/foldable/SequenceKFoldable.kt
@@ -8,16 +8,6 @@ import arrow.core.extensions.SequenceKFoldable
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Monad
 import arrow.typeclasses.Monoid
-import kotlin.Boolean
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.Function2
-import kotlin.Long
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.Unit
-import kotlin.collections.List
-import kotlin.jvm.JvmName
 import kotlin.sequences.Sequence
 
 @JvmName("foldLeft")
@@ -30,8 +20,7 @@ import kotlin.sequences.Sequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "foldLeft(arg1, arg2)",
-  "arrow.core.foldLeft"
+    "this.fold(arg1, arg2)"
   ),
   DeprecationLevel.WARNING
 )
@@ -50,8 +39,8 @@ fun <A, B> Sequence<A>.foldLeft(arg1: B, arg2: Function2<B, A, B>): B =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "foldRight(arg1, arg2)",
-  "arrow.core.foldRight"
+    "this.foldRight(arg1, arg2)",
+    "arrow.core.foldRight"
   ),
   DeprecationLevel.WARNING
 )
@@ -70,8 +59,7 @@ fun <A, B> Sequence<A>.foldRight(arg1: Eval<B>, arg2: Function2<A, Eval<B>, Eval
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "fold(arg1)",
-  "arrow.core.fold"
+    "this.fold(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -90,8 +78,8 @@ fun <A> Sequence<A>.fold(arg1: Monoid<A>): A =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "reduceLeftToOption(arg1, arg2)",
-  "arrow.core.reduceLeftToOption"
+    "Option.fromNullable(this.reduceOrNull(arg1, arg2))",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -111,8 +99,8 @@ fun <A, B> Sequence<A>.reduceLeftToOption(arg1: Function1<A, B>, arg2: Function2
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "reduceRightToOption(arg1, arg2)",
-  "arrow.core.reduceRightToOption"
+    "this.reduceRightEvalOrNull(arg1, arg2).map { Option.fromNullable(it) }",
+    "arrow.core.Option", "arrow.core.reduceRightEvalOrNull"
   ),
   DeprecationLevel.WARNING
 )
@@ -134,8 +122,8 @@ fun <A, B> Sequence<A>.reduceRightToOption(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "reduceLeftOption(arg1)",
-  "arrow.core.reduceLeftOption"
+    "Option.fromNullable(this.reduceOrNull({ it }, arg1))",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -175,8 +163,8 @@ fun <A> Sequence<A>.reduceRightOption(arg1: Function2<A, Eval<A>, Eval<A>>): Eva
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "combineAll(arg1)",
-  "arrow.core.combineAll"
+    "this.combineAll(arg1)",
+    "arrow.core.combineAll"
   ),
   DeprecationLevel.WARNING
 )
@@ -195,8 +183,8 @@ fun <A> Sequence<A>.combineAll(arg1: Monoid<A>): A =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "foldMap(arg1, arg2)",
-  "arrow.core.foldMap"
+    "this.foldMap(arg1, arg2)",
+    "arrow.core.foldMap"
   ),
   DeprecationLevel.WARNING
 )
@@ -215,8 +203,7 @@ fun <A, B> Sequence<A>.foldMap(arg1: Monoid<B>, arg2: Function1<A, B>): B =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "orEmpty(arg0, arg1)",
-  "arrow.core.extensions.sequence.foldable.Sequence.orEmpty"
+    "sequenceOf(arg1.empty())"
   ),
   DeprecationLevel.WARNING
 )
@@ -233,12 +220,8 @@ fun <A> orEmpty(arg0: Applicative<ForSequenceK>, arg1: Monoid<A>): Sequence<A> =
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "traverse_(arg1, arg2)",
-  "arrow.core.traverse_"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated. Replace with traverseEither_ or traverseValidated_ from arrow.core.*",
+  level= DeprecationLevel.WARNING
 )
 fun <G, A, B> Sequence<A>.traverse_(arg1: Applicative<G>, arg2: Function1<A, Kind<G, B>>): Kind<G,
     Unit> = arrow.core.extensions.sequence.foldable.Sequence.foldable().run {
@@ -253,12 +236,8 @@ fun <G, A, B> Sequence<A>.traverse_(arg1: Applicative<G>, arg2: Function1<A, Kin
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "sequence_(arg1)",
-  "arrow.core.sequence_"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated. Replace with sequenceEither_ or sequenceValidated_ from arrow.core.*",
+  level= DeprecationLevel.WARNING
 )
 fun <G, A> Sequence<Kind<G, A>>.sequence_(arg1: Applicative<G>): Kind<G, Unit> =
     arrow.core.extensions.sequence.foldable.Sequence.foldable().run {
@@ -275,8 +254,8 @@ fun <G, A> Sequence<Kind<G, A>>.sequence_(arg1: Applicative<G>): Kind<G, Unit> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "find(arg1)",
-  "arrow.core.find"
+    "Option.fromNullable(this.firstOrNull(arg1))",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -295,8 +274,7 @@ fun <A> Sequence<A>.find(arg1: Function1<A, Boolean>): Option<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "exists(arg1)",
-  "arrow.core.exists"
+    "this.any(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -315,8 +293,7 @@ fun <A> Sequence<A>.exists(arg1: Function1<A, Boolean>): Boolean =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "forAll(arg1)",
-  "arrow.core.forAll"
+    "this.all(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -335,8 +312,7 @@ fun <A> Sequence<A>.forAll(arg1: Function1<A, Boolean>): Boolean =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "all(arg1)",
-  "arrow.core.all"
+    "this.all(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -355,8 +331,7 @@ fun <A> Sequence<A>.all(arg1: Function1<A, Boolean>): Boolean =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "isEmpty()",
-  "arrow.core.isEmpty"
+    "this.none()"
   ),
   DeprecationLevel.WARNING
 )
@@ -375,8 +350,7 @@ fun <A> Sequence<A>.isEmpty(): Boolean =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "nonEmpty()",
-  "arrow.core.nonEmpty"
+    "this.any()"
   ),
   DeprecationLevel.WARNING
 )
@@ -395,8 +369,7 @@ fun <A> Sequence<A>.nonEmpty(): Boolean =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "isNotEmpty()",
-  "arrow.core.isNotEmpty"
+    "this.any()"
   ),
   DeprecationLevel.WARNING
 )
@@ -415,8 +388,7 @@ fun <A> Sequence<A>.isNotEmpty(): Boolean =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "size(arg1)",
-  "arrow.core.size"
+    "this.count()"
   ),
   DeprecationLevel.WARNING
 )
@@ -433,12 +405,8 @@ fun <A> Sequence<A>.size(arg1: Monoid<Long>): Long =
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "foldMapA(arg1, arg2, arg3)",
-  "arrow.core.foldMapA"
-  ),
-  DeprecationLevel.WARNING
+  "Applicative typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 fun <G, A, B, AP : Applicative<G>, MO : Monoid<B>> Sequence<A>.foldMapA(
   arg1: AP,
@@ -457,12 +425,8 @@ fun <G, A, B, AP : Applicative<G>, MO : Monoid<B>> Sequence<A>.foldMapA(
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "foldMapM(arg1, arg2, arg3)",
-  "arrow.core.foldMapM"
-  ),
-  DeprecationLevel.WARNING
+  "Monad typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 fun <G, A, B, MA : Monad<G>, MO : Monoid<B>> Sequence<A>.foldMapM(
   arg1: MA,
@@ -481,12 +445,8 @@ fun <G, A, B, MA : Monad<G>, MO : Monoid<B>> Sequence<A>.foldMapM(
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "foldM(arg1, arg2, arg3)",
-  "arrow.core.foldM"
-  ),
-  DeprecationLevel.WARNING
+  "Monad typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 fun <G, A, B> Sequence<A>.foldM(
   arg1: Monad<G>,
@@ -506,8 +466,8 @@ fun <G, A, B> Sequence<A>.foldM(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "get(arg1)",
-  "arrow.core.get"
+    "Option.fromNullable(this.elementAtOrNull(arg1))",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -526,8 +486,8 @@ fun <A> Sequence<A>.get(arg1: Long): Option<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "firstOption()",
-  "arrow.core.firstOption"
+    "Option.fromNullable(this.firstOrNull())",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -546,8 +506,8 @@ fun <A> Sequence<A>.firstOption(): Option<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "firstOption(arg1)",
-  "arrow.core.firstOption"
+    "Option.fromNullable(this.firstOrNull(arg1))",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -566,8 +526,8 @@ fun <A> Sequence<A>.firstOption(arg1: Function1<A, Boolean>): Option<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "firstOrNone()",
-  "arrow.core.firstOrNone"
+    "Option.fromNullable(this.firstOrNull())",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -586,8 +546,8 @@ fun <A> Sequence<A>.firstOrNone(): Option<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "firstOrNone(arg1)",
-  "arrow.core.firstOrNone"
+    "Option.fromNullable(this.firstOrNull(arg1))",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -606,8 +566,7 @@ fun <A> Sequence<A>.firstOrNone(arg1: Function1<A, Boolean>): Option<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "toList()",
-  "arrow.core.toList"
+    "this.toList()"
   ),
   DeprecationLevel.WARNING
 )
@@ -623,9 +582,17 @@ fun <A> Sequence<A>.toList(): List<A> =
 internal val foldable_singleton: SequenceKFoldable = object :
     arrow.core.extensions.SequenceKFoldable {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
+  )
+  @Deprecated(
+    "Foldable typeclass is deprecated. Use concrete methods on Sequence",
+    level = DeprecationLevel.WARNING
   )
   inline fun foldable(): SequenceKFoldable = foldable_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/functor/SequenceKFunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/functor/SequenceKFunctor.kt
@@ -4,12 +4,6 @@ import arrow.Kind
 import arrow.core.ForSequenceK
 import arrow.core.Tuple2
 import arrow.core.extensions.SequenceKFunctor
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.Unit
-import kotlin.jvm.JvmName
 import kotlin.sequences.Sequence
 
 /**
@@ -43,8 +37,7 @@ import kotlin.sequences.Sequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg1)",
-  "arrow.core.map"
+    "this.map(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -63,8 +56,7 @@ fun <A, B> Sequence<A>.map(arg1: Function1<A, B>): Sequence<B> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "imap(arg1, arg2)",
-  "arrow.core.imap"
+    "this.map(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -106,8 +98,7 @@ fun <A, B> Sequence<A>.imap(arg1: Function1<A, B>, arg2: Function1<B, A>): Seque
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "lift(arg0)",
-  "arrow.core.extensions.sequence.functor.Sequence.lift"
+    "{ s: Sequence<A> -> s.map(arg0) }"
   ),
   DeprecationLevel.WARNING
 )
@@ -127,8 +118,8 @@ fun <A, B> lift(arg0: Function1<A, B>): Function1<Kind<ForSequenceK, A>, Kind<Fo
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "void()",
-  "arrow.core.void"
+    "this.void()",
+    "arrow.core.void"
   ),
   DeprecationLevel.WARNING
 )
@@ -170,8 +161,8 @@ fun <A> Sequence<A>.void(): Sequence<Unit> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "fproduct(arg1)",
-  "arrow.core.fproduct"
+    "this.fproduct(arg1)",
+    "arrow.core.fproduct"
   ),
   DeprecationLevel.WARNING
 )
@@ -213,8 +204,8 @@ fun <A, B> Sequence<A>.fproduct(arg1: Function1<A, B>): Sequence<Tuple2<A, B>> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapConst(arg1)",
-  "arrow.core.mapConst"
+    "this.mapConst(arg1)",
+    "arrow.core.mapConst"
   ),
   DeprecationLevel.WARNING
 )
@@ -236,8 +227,8 @@ fun <A, B> Sequence<A>.mapConst(arg1: B): Sequence<B> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapConst(arg1)",
-  "arrow.core.mapConst"
+    "arg1.mapConst(this)",
+    "arrow.core.mapConst"
   ),
   DeprecationLevel.WARNING
 )
@@ -278,8 +269,8 @@ fun <A, B> A.mapConst(arg1: Sequence<B>): Sequence<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupleLeft(arg1)",
-  "arrow.core.tupleLeft"
+    "this.tupleLeft(arg1)",
+    "arrow.core.tupleLeft"
   ),
   DeprecationLevel.WARNING
 )
@@ -321,8 +312,8 @@ fun <A, B> Sequence<A>.tupleLeft(arg1: B): Sequence<Tuple2<B, A>> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupleRight(arg1)",
-  "arrow.core.tupleRight"
+    "this.tupleRight(arg1)",
+    "arrow.core.tupleRight"
   ),
   DeprecationLevel.WARNING
 )
@@ -365,8 +356,8 @@ fun <A, B> Sequence<A>.tupleRight(arg1: B): Sequence<Tuple2<A, B>> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "widen()",
-  "arrow.core.widen"
+    "this.widen()",
+    "arrow.core.widen"
   ),
   DeprecationLevel.WARNING
 )
@@ -382,10 +373,18 @@ fun <B, A : B> Sequence<A>.widen(): Sequence<B> =
 internal val functor_singleton: SequenceKFunctor = object : arrow.core.extensions.SequenceKFunctor
     {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
 
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
+  )
+  @Deprecated(
+    "Functor typeclass is deprecated. Use concrete methods on Sequence",
+    level = DeprecationLevel.WARNING
   )
   inline fun functor(): SequenceKFunctor = functor_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/functor/SequenceKFunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/functor/SequenceKFunctor.kt
@@ -135,12 +135,8 @@ fun <A> Sequence<A>.void(): Sequence<Unit> =
  *  Kind<F, A> -> Kind<F, Tuple2<A, B>>
  *
  *  ```kotlin:ank:playground
- *  import arrow.core.*
- * import arrow.core.extensions.sequencek.functor.*
- * import arrow.core.*
- *
- *
  *  import arrow.core.extensions.sequencek.applicative.just
+ *  import arrow.core.fproduct
  *
  *  fun main(args: Array<String>) {
  *   val result =
@@ -178,12 +174,8 @@ fun <A, B> Sequence<A>.fproduct(arg1: Function1<A, B>): Sequence<Tuple2<A, B>> =
  *  Kind<F, A> -> Kind<F, B>
  *
  *  ```kotlin:ank:playground
- *  import arrow.core.*
- * import arrow.core.extensions.sequencek.functor.*
- * import arrow.core.*
- *
- *
- *  import arrow.core.extensions.sequencek.applicative.just
+ *  import arrow.core.extensions.sequence.applicative.just
+ *  import arrow.core.mapConst
  *
  *  fun main(args: Array<String>) {
  *   val result =
@@ -243,12 +235,8 @@ fun <A, B> A.mapConst(arg1: Sequence<B>): Sequence<A> =
  *  Kind<F, A> -> Kind<F, Tuple2<B, A>>
  *
  *  ```kotlin:ank:playground
- *  import arrow.core.*
- * import arrow.core.extensions.sequencek.functor.*
- * import arrow.core.*
- *
- *
- *  import arrow.core.extensions.sequencek.applicative.just
+ *  import arrow.core.extensions.sequence.applicative.just
+ *  import arrow.core.tupleLeft
  *
  *  fun main(args: Array<String>) {
  *   val result =
@@ -286,12 +274,8 @@ fun <A, B> Sequence<A>.tupleLeft(arg1: B): Sequence<Tuple2<B, A>> =
  *  Kind<F, A> -> Kind<F, Tuple2<A, B>>
  *
  *  ```kotlin:ank:playground
- *  import arrow.core.*
- * import arrow.core.extensions.sequencek.functor.*
- * import arrow.core.*
- *
- *
- *  import arrow.core.extensions.sequencek.applicative.just
+ *  import arrow.core.extensions.sequence.applicative.just
+ *  import arrow.core.tupleRight
  *
  *  fun main(args: Array<String>) {
  *   val result =
@@ -329,18 +313,15 @@ fun <A, B> Sequence<A>.tupleRight(arg1: B): Sequence<Tuple2<A, B>> =
  *  Kind<F, A> -> Kind<F, B>
  *
  *  ```kotlin:ank:playground
- *  import arrow.core.*
- * import arrow.core.extensions.sequencek.functor.*
- * import arrow.core.*
- *
- *
- *  import arrow.core.extensions.sequencek.applicative.just
  *  import arrow.Kind
+ *  import arrow.core.extensions.sequence.applicative.just
+ *  import arrow.core.k
+ *  import arrow.core.widen
  *
  *  fun main(args: Array<String>) {
  *   val result: Kind<*, CharSequence> =
  *   //sampleStart
- *   "Hello".just().map({ "$it World" }).widen()
+ *   "Hello".just().map { "$it World" }.widen().k()
  *   //sampleEnd
  *   println(result)
  *  }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/functorFilter/SequenceKFunctorFilter.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/functorFilter/SequenceKFunctorFilter.kt
@@ -2,13 +2,6 @@ package arrow.core.extensions.sequence.functorFilter
 
 import arrow.core.Option
 import arrow.core.extensions.SequenceKFunctorFilter
-import java.lang.Class
-import kotlin.Boolean
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 import kotlin.sequences.Sequence
 
 @JvmName("filterMap")
@@ -21,8 +14,7 @@ import kotlin.sequences.Sequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "filterMap(arg1)",
-  "arrow.core.filterMap"
+    "this.mapNotNull { arg1(it).orNull() }"
   ),
   DeprecationLevel.WARNING
 )
@@ -41,8 +33,7 @@ fun <A, B> Sequence<A>.filterMap(arg1: Function1<A, Option<B>>): Sequence<B> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "flattenOption()",
-  "arrow.core.flattenOption"
+    "this.mapNotNull { it.orNull() }"
   ),
   DeprecationLevel.WARNING
 )
@@ -61,8 +52,7 @@ fun <A> Sequence<Option<A>>.flattenOption(): Sequence<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "filter(arg1)",
-  "arrow.core.filter"
+    "this.filter(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -81,8 +71,7 @@ fun <A> Sequence<A>.filter(arg1: Function1<A, Boolean>): Sequence<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "filterIsInstance(arg1)",
-  "arrow.core.filterIsInstance"
+    "this.filterIsInstance<B>()"
   ),
   DeprecationLevel.WARNING
 )
@@ -99,9 +88,17 @@ fun <A, B> Sequence<A>.filterIsInstance(arg1: Class<B>): Sequence<B> =
 internal val functorFilter_singleton: SequenceKFunctorFilter = object :
     arrow.core.extensions.SequenceKFunctorFilter {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
+  )
+  @Deprecated(
+    "FunctorFilter typeclass is deprecated. Use concrete methods on Sequence",
+    level = DeprecationLevel.WARNING
   )
   inline fun functorFilter(): SequenceKFunctorFilter = functorFilter_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/monad/SequenceKMonad.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/monad/SequenceKMonad.kt
@@ -6,13 +6,6 @@ import arrow.core.Eval
 import arrow.core.ForSequenceK
 import arrow.core.Tuple2
 import arrow.core.extensions.SequenceKMonad
-import kotlin.Boolean
-import kotlin.Deprecated
-import kotlin.Function0
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 import kotlin.sequences.Sequence
 
 @JvmName("flatMap")
@@ -25,8 +18,7 @@ import kotlin.sequences.Sequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "flatMap(arg1)",
-  "arrow.core.flatMap"
+    "this.flatMap(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -45,8 +37,8 @@ fun <A, B> Sequence<A>.flatMap(arg1: Function1<A, Kind<ForSequenceK, B>>): Seque
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tailRecM(arg0, arg1)",
-  "arrow.core.extensions.sequence.monad.Sequence.tailRecM"
+    "SequenceK.tailRecM(arg0, arg1)",
+    "arrow.core.SequenceK"
   ),
   DeprecationLevel.WARNING
 )
@@ -65,8 +57,7 @@ fun <A, B> tailRecM(arg0: A, arg1: Function1<A, Kind<ForSequenceK, Either<A, B>>
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg1)",
-  "arrow.core.map"
+    "this.map(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -88,8 +79,8 @@ fun <A, B> Sequence<A>.map(arg1: Function1<A, B>): Sequence<B> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "ap(arg1)",
-  "arrow.core.ap"
+    "this.ap(arg1)",
+    "arrow.core.ap"
   ),
   DeprecationLevel.WARNING
 )
@@ -108,8 +99,8 @@ fun <A, B> Sequence<A>.ap(arg1: Sequence<Function1<A, B>>): Sequence<B> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "flatten()",
-  "arrow.core.flatten"
+    "this.flatten()",
+    "arrow.core.flatten"
   ),
   DeprecationLevel.WARNING
 )
@@ -128,8 +119,7 @@ fun <A> Sequence<Sequence<A>>.flatten(): Sequence<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "followedBy(arg1)",
-  "arrow.core.followedBy"
+    "this.flatMap { arg1 }"
   ),
   DeprecationLevel.WARNING
 )
@@ -149,8 +139,7 @@ fun <A, B> Sequence<A>.followedBy(arg1: Sequence<B>): Sequence<B> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "apTap(arg1)",
-  "arrow.core.apTap"
+    "this.flatMap { a -> arg1.map { a } }"
   ),
   DeprecationLevel.WARNING
 )
@@ -170,8 +159,7 @@ fun <A, B> Sequence<A>.apTap(arg1: Sequence<B>): Sequence<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "followedByEval(arg1)",
-  "arrow.core.followedByEval"
+    "this.flatMap { arg1.value() }"
   ),
   DeprecationLevel.WARNING
 )
@@ -191,8 +179,7 @@ fun <A, B> Sequence<A>.followedByEval(arg1: Eval<Kind<ForSequenceK, B>>): Sequen
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "effectM(arg1)",
-  "arrow.core.effectM"
+    "this.flatMap { a -> arg1(a).map { a } }"
   ),
   DeprecationLevel.WARNING
 )
@@ -211,8 +198,7 @@ fun <A, B> Sequence<A>.effectM(arg1: Function1<A, Kind<ForSequenceK, B>>): Seque
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "flatTap(arg1)",
-  "arrow.core.flatTap"
+    "this.flatMap { a -> arg1(a).map { a } }"
   ),
   DeprecationLevel.WARNING
 )
@@ -231,8 +217,7 @@ fun <A, B> Sequence<A>.flatTap(arg1: Function1<A, Kind<ForSequenceK, B>>): Seque
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "productL(arg1)",
-  "arrow.core.productL"
+    "this.flatMap { a -> arg1.map { a } }"
   ),
   DeprecationLevel.WARNING
 )
@@ -252,8 +237,7 @@ fun <A, B> Sequence<A>.productL(arg1: Sequence<B>): Sequence<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "forEffect(arg1)",
-  "arrow.core.forEffect"
+    "this.flatMap { a -> arg1.map { a } }"
   ),
   DeprecationLevel.WARNING
 )
@@ -273,8 +257,7 @@ fun <A, B> Sequence<A>.forEffect(arg1: Sequence<B>): Sequence<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "productLEval(arg1)",
-  "arrow.core.productLEval"
+    "this.flatMap { a -> arg1.value().map { a } }"
   ),
   DeprecationLevel.WARNING
 )
@@ -293,8 +276,7 @@ fun <A, B> Sequence<A>.productLEval(arg1: Eval<Kind<ForSequenceK, B>>): Sequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "forEffectEval(arg1)",
-  "arrow.core.forEffectEval"
+    "this.flatMap { a -> arg1.value().map { a } }"
   ),
   DeprecationLevel.WARNING
 )
@@ -313,8 +295,8 @@ fun <A, B> Sequence<A>.forEffectEval(arg1: Eval<Kind<ForSequenceK, B>>): Sequenc
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mproduct(arg1)",
-  "arrow.core.mproduct"
+    "this.flatMap { a -> arg1(a).map { b -> Tuple2(a, b) } }",
+    "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
 )
@@ -334,8 +316,8 @@ fun <A, B> Sequence<A>.mproduct(arg1: Function1<A, Kind<ForSequenceK, B>>): Sequ
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "ifM(arg1, arg2)",
-  "arrow.core.ifM"
+    "this.ifM(arg1, arg2)",
+    "arrow.core.ifM"
   ),
   DeprecationLevel.WARNING
 )
@@ -357,8 +339,8 @@ fun <B> Sequence<Boolean>.ifM(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "selectM(arg1)",
-  "arrow.core.selectM"
+    "this.selectM(arg1)",
+    "arrow.core.selectM"
   ),
   DeprecationLevel.WARNING
 )
@@ -378,8 +360,8 @@ fun <A, B> Sequence<Either<A, B>>.selectM(arg1: Sequence<Function1<A, B>>): Sequ
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "select(arg1)",
-  "arrow.core.select"
+    "this.selectM(arg1)",
+    "arrow.core.selectM"
   ),
   DeprecationLevel.WARNING
 )
@@ -395,6 +377,10 @@ fun <A, B> Sequence<Either<A, B>>.select(arg1: Sequence<Function1<A, B>>): Seque
 @PublishedApi()
 internal val monad_singleton: SequenceKMonad = object : arrow.core.extensions.SequenceKMonad {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
   /**
    *  [Monad] abstract over the ability to declare sequential computations that are dependent in the order or
@@ -410,5 +396,9 @@ object Sequence {
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
+  )
+  @Deprecated(
+    "Monad typeclass is deprecated. Use concrete methods on Sequence",
+    level = DeprecationLevel.WARNING
   )
   inline fun monad(): SequenceKMonad = monad_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/monadCombine/SequenceKMonadCombine.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/monadCombine/SequenceKMonadCombine.kt
@@ -6,10 +6,6 @@ import arrow.core.Tuple2
 import arrow.core.extensions.SequenceKMonadCombine
 import arrow.typeclasses.Bifoldable
 import arrow.typeclasses.Foldable
-import kotlin.Deprecated
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 import kotlin.sequences.Sequence
 
 @JvmName("unite")
@@ -20,12 +16,8 @@ import kotlin.sequences.Sequence
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "unite(arg1)",
-  "arrow.core.unite"
-  ),
-  DeprecationLevel.WARNING
+  "Foldable typeclass is deprecated. Replace with uniteEither or uniteValidated from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <G, A> Sequence<Kind<G, A>>.unite(arg1: Foldable<G>): Sequence<A> =
     arrow.core.extensions.sequence.monadCombine.Sequence.monadCombine().run {
@@ -40,12 +32,8 @@ fun <G, A> Sequence<Kind<G, A>>.unite(arg1: Foldable<G>): Sequence<A> =
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "separate(arg1)",
-  "arrow.core.separate"
-  ),
-  DeprecationLevel.WARNING
+  "Bifoldable typeclass is deprecated. Replace with separateEither or separateValidated from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <G, A, B> Sequence<Kind<Kind<G, A>, B>>.separate(arg1: Bifoldable<G>): Tuple2<Kind<ForSequenceK,
     A>, Kind<ForSequenceK, B>> =
@@ -62,9 +50,17 @@ fun <G, A, B> Sequence<Kind<Kind<G, A>, B>>.separate(arg1: Bifoldable<G>): Tuple
 internal val monadCombine_singleton: SequenceKMonadCombine = object :
     arrow.core.extensions.SequenceKMonadCombine {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
+  )
+  @Deprecated(
+    "MonadCombine typeclass is deprecated. Use concrete methods on Sequence",
+    level = DeprecationLevel.WARNING
   )
   inline fun monadCombine(): SequenceKMonadCombine = monadCombine_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/monadFilter/SequenceKMonadFilter.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/monadFilter/SequenceKMonadFilter.kt
@@ -4,11 +4,6 @@ import arrow.core.ForSequenceK
 import arrow.core.Option
 import arrow.core.extensions.SequenceKMonadFilter
 import arrow.typeclasses.MonadFilterSyntax
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 import kotlin.sequences.Sequence
 
 @JvmName("filterMap")
@@ -21,8 +16,7 @@ import kotlin.sequences.Sequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "filterMap(arg1)",
-  "arrow.core.filterMap"
+    "this.mapNotNull { arg1(it).orNull() }"
   ),
   DeprecationLevel.WARNING
 )
@@ -39,12 +33,8 @@ fun <A, B> Sequence<A>.filterMap(arg1: Function1<A, Option<B>>): Sequence<B> =
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "bindingFilter(arg0)",
-  "arrow.core.extensions.sequence.monadFilter.Sequence.bindingFilter"
-  ),
-  DeprecationLevel.WARNING
+  "Monad bindings are deprecated",
+  level = DeprecationLevel.WARNING
 )
 fun <B> bindingFilter(arg0: suspend MonadFilterSyntax<ForSequenceK>.() -> B): Sequence<B> =
     arrow.core.extensions.sequence.monadFilter.Sequence
@@ -58,9 +48,17 @@ fun <B> bindingFilter(arg0: suspend MonadFilterSyntax<ForSequenceK>.() -> B): Se
 internal val monadFilter_singleton: SequenceKMonadFilter = object :
     arrow.core.extensions.SequenceKMonadFilter {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
+  )
+  @Deprecated(
+    "MonadFilter typeclass is deprecated. Use concrete methods on Sequence",
+    level = DeprecationLevel.WARNING
   )
   inline fun monadFilter(): SequenceKMonadFilter = monadFilter_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/monadLogic/SequenceKMonadLogic.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/monadLogic/SequenceKMonadLogic.kt
@@ -5,12 +5,6 @@ import arrow.core.ForSequenceK
 import arrow.core.Option
 import arrow.core.Tuple2
 import arrow.core.extensions.SequenceKMonadLogic
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.Unit
-import kotlin.jvm.JvmName
 import kotlin.sequences.Sequence
 
 @JvmName("splitM")
@@ -23,8 +17,8 @@ import kotlin.sequences.Sequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "splitM()",
-  "arrow.core.splitM"
+    "this.split()",
+    "arrow.core.split"
   ),
   DeprecationLevel.WARNING
 )
@@ -45,8 +39,8 @@ fun <A> Sequence<A>.splitM(): Sequence<Option<Tuple2<Kind<ForSequenceK, A>, A>>>
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "interleave(arg1)",
-  "arrow.core.interleave"
+    "this.interleave(arg1)",
+    "arrow.core.interleave"
   ),
   DeprecationLevel.WARNING
 )
@@ -66,8 +60,8 @@ fun <A> Sequence<A>.interleave(arg1: Sequence<A>): Sequence<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "unweave(arg1)",
-  "arrow.core.unweave"
+    "this.unweave(arg1)",
+    "arrow.core.unweave"
   ),
   DeprecationLevel.WARNING
 )
@@ -86,8 +80,8 @@ fun <A, B> Sequence<A>.unweave(arg1: Function1<A, Kind<ForSequenceK, B>>): Seque
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "ifThen(arg1, arg2)",
-  "arrow.core.ifThen"
+    "this.ifThen(arg1, arg2)",
+    "arrow.core.ifThen"
   ),
   DeprecationLevel.WARNING
 )
@@ -107,8 +101,8 @@ fun <A, B> Sequence<A>.ifThen(arg1: Sequence<B>, arg2: Function1<A, Kind<ForSequ
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "once()",
-  "arrow.core.once"
+    "this.once()",
+    "arrow.core.once"
   ),
   DeprecationLevel.WARNING
 )
@@ -127,8 +121,7 @@ fun <A> Sequence<A>.once(): Sequence<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "voidIfValue()",
-  "arrow.core.voidIfValue"
+    "this.firstOrNull()?.let { emptySequence() } ?: sequenceOf(Unit)"
   ),
   DeprecationLevel.WARNING
 )
@@ -144,9 +137,17 @@ fun <A> Sequence<A>.voidIfValue(): Sequence<Unit> =
 internal val monadLogic_singleton: SequenceKMonadLogic = object :
     arrow.core.extensions.SequenceKMonadLogic {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
+  )
+  @Deprecated(
+    "MonadLogic typeclass is deprecated. Use concrete methods on Sequence",
+    level = DeprecationLevel.WARNING
   )
   inline fun monadLogic(): SequenceKMonadLogic = monadLogic_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/monadPlus/SequenceKMonadPlus.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/monadPlus/SequenceKMonadPlus.kt
@@ -1,10 +1,6 @@
 package arrow.core.extensions.sequence.monadPlus
 
 import arrow.core.extensions.SequenceKMonadPlus
-import kotlin.Deprecated
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 import kotlin.sequences.Sequence
 
 @JvmName("zeroM")
@@ -17,8 +13,7 @@ import kotlin.sequences.Sequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "zeroM()",
-  "arrow.core.extensions.sequence.monadPlus.Sequence.zeroM"
+    "emptySequence<A>()"
   ),
   DeprecationLevel.WARNING
 )
@@ -36,8 +31,7 @@ fun <A> zeroM(): Sequence<A> = arrow.core.extensions.sequence.monadPlus.Sequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "plusM(arg1)",
-  "arrow.core.plusM"
+    "this + arg1"
   ),
   DeprecationLevel.WARNING
 )
@@ -54,9 +48,17 @@ fun <A> Sequence<A>.plusM(arg1: Sequence<A>): Sequence<A> =
 internal val monadPlus_singleton: SequenceKMonadPlus = object :
     arrow.core.extensions.SequenceKMonadPlus {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
+  )
+  @Deprecated(
+    "MonadPlus typeclass is deprecated. Use concrete methods on Sequence",
+    level = DeprecationLevel.WARNING
   )
   inline fun monadPlus(): SequenceKMonadPlus = monadPlus_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/monoid/SequenceKMonoid.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/monoid/SequenceKMonoid.kt
@@ -58,7 +58,8 @@ object Sequence {
     "NOTHING_TO_INLINE"
   )
   @Deprecated(
-    "Monoid typeclass is deprecated. Use concrete methods on Sequence",
+    "@extension kinded projected functions are deprecated",
+    ReplaceWith("Monoid.sequence<A>()", "arrow.core.sequence", "arrow.typeclasses.Monoid"),
     level = DeprecationLevel.WARNING
   )
   inline fun <A> monoid(): SequenceKMonoid<A> = monoid_singleton as

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/monoid/SequenceKMonoid.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/monoid/SequenceKMonoid.kt
@@ -2,13 +2,6 @@ package arrow.core.extensions.sequence.monoid
 
 import arrow.core.SequenceK
 import arrow.core.extensions.SequenceKMonoid
-import kotlin.Any
-import kotlin.Deprecated
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.collections.Collection
-import kotlin.collections.List
-import kotlin.jvm.JvmName
 import kotlin.sequences.Sequence
 
 @JvmName("combineAll")
@@ -21,8 +14,7 @@ import kotlin.sequences.Sequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "combineAll()",
-  "arrow.core.combineAll"
+    "this.fold(emptySequence()) { acc, l -> acc + l }"
   ),
   DeprecationLevel.WARNING
 )
@@ -41,8 +33,7 @@ fun <A> Collection<SequenceK<A>>.combineAll(): Sequence<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "combineAll(arg0)",
-  "arrow.core.extensions.sequence.monoid.Sequence.combineAll"
+    "arg0.fold(emptySequence()) { acc, l -> acc + l }"
   ),
   DeprecationLevel.WARNING
 )
@@ -57,10 +48,18 @@ fun <A> combineAll(arg0: List<SequenceK<A>>): Sequence<A> =
 @PublishedApi()
 internal val monoid_singleton: SequenceKMonoid<Any?> = object : SequenceKMonoid<Any?> {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
+  )
+  @Deprecated(
+    "Monoid typeclass is deprecated. Use concrete methods on Sequence",
+    level = DeprecationLevel.WARNING
   )
   inline fun <A> monoid(): SequenceKMonoid<A> = monoid_singleton as
       arrow.core.extensions.SequenceKMonoid<A>}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/monoidK/SequenceKMonoidK.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/monoidK/SequenceKMonoidK.kt
@@ -4,10 +4,6 @@ import arrow.Kind
 import arrow.core.ForSequenceK
 import arrow.core.extensions.SequenceKMonoidK
 import arrow.typeclasses.Monoid
-import kotlin.Deprecated
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 @JvmName("algebra")
 @Suppress(
@@ -19,8 +15,8 @@ import kotlin.jvm.JvmName
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "algebra()",
-  "arrow.core.extensions.sequence.monoidK.Sequence.algebra"
+    "Monoid.sequence<A>()",
+    "arrow.core.sequence", "arrow.typeclasses.Monoid"
   ),
   DeprecationLevel.WARNING
 )
@@ -35,9 +31,17 @@ fun <A> algebra(): Monoid<Kind<ForSequenceK, A>> = arrow.core.extensions.sequenc
 internal val monoidK_singleton: SequenceKMonoidK = object : arrow.core.extensions.SequenceKMonoidK
     {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
+  )
+  @Deprecated(
+    "MonoidK typeclass is deprecated. Use concrete methods on Sequence",
+    level = DeprecationLevel.WARNING
   )
   inline fun monoidK(): SequenceKMonoidK = monoidK_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/monoidal/SequenceKMonoidal.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/monoidal/SequenceKMonoidal.kt
@@ -1,10 +1,6 @@
 package arrow.core.extensions.sequence.monoidal
 
 import arrow.core.extensions.SequenceKMonoidal
-import kotlin.Deprecated
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 import kotlin.sequences.Sequence
 
 @JvmName("identity")
@@ -17,8 +13,7 @@ import kotlin.sequences.Sequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "identity()",
-  "arrow.core.extensions.sequence.monoidal.Sequence.identity"
+    "emptySequence<A>()"
   ),
   DeprecationLevel.WARNING
 )
@@ -33,9 +28,17 @@ fun <A> identity(): Sequence<A> = arrow.core.extensions.sequence.monoidal.Sequen
 internal val monoidal_singleton: SequenceKMonoidal = object :
     arrow.core.extensions.SequenceKMonoidal {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
+  )
+  @Deprecated(
+    "Monoidal typeclass is deprecated. Use concrete methods on Sequence",
+    level = DeprecationLevel.WARNING
   )
   inline fun monoidal(): SequenceKMonoidal = monoidal_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/repeat/SequenceKRepeat.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/repeat/SequenceKRepeat.kt
@@ -1,10 +1,6 @@
 package arrow.core.extensions.sequence.repeat
 
 import arrow.core.extensions.SequenceKRepeat
-import kotlin.Deprecated
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 import kotlin.sequences.Sequence
 
 @JvmName("repeat")
@@ -17,8 +13,7 @@ import kotlin.sequences.Sequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "repeat(a)",
-  "arrow.core.extensions.sequence.repeat.Sequence.repeat"
+    "generateSequence { a }"
   ),
   DeprecationLevel.WARNING
 )
@@ -32,9 +27,17 @@ fun <A> repeat(a: A): Sequence<A> = arrow.core.extensions.sequence.repeat.Sequen
 @PublishedApi()
 internal val repeat_singleton: SequenceKRepeat = object : arrow.core.extensions.SequenceKRepeat {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
+  )
+  @Deprecated(
+    "Repeat typeclass is deprecated. Use concrete methods on Sequence",
+    level = DeprecationLevel.WARNING
   )
   inline fun repeat(): SequenceKRepeat = repeat_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/semialign/SequenceKSemialign.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/semialign/SequenceKSemialign.kt
@@ -5,12 +5,6 @@ import arrow.core.Option
 import arrow.core.Tuple2
 import arrow.core.extensions.SequenceKSemialign
 import arrow.typeclasses.Semigroup
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.Function2
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 import kotlin.sequences.Sequence
 
 @JvmName("align")
@@ -23,8 +17,8 @@ import kotlin.sequences.Sequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "align(arg0, arg1)",
-  "arrow.core.extensions.sequence.semialign.Sequence.align"
+    "arg0.align(arg1)",
+    "arrow.core.align"
   ),
   DeprecationLevel.WARNING
 )
@@ -44,8 +38,8 @@ fun <A, B> align(arg0: Sequence<A>, arg1: Sequence<B>): Sequence<Ior<A, B>> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "alignWith(arg0, arg1, arg2)",
-  "arrow.core.extensions.sequence.semialign.Sequence.alignWith"
+    "arg0.align(arg1, arg2)",
+    "arrow.core.align"
   ),
   DeprecationLevel.WARNING
 )
@@ -68,8 +62,8 @@ fun <A, B, C> alignWith(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "salign(arg1, arg2)",
-  "arrow.core.salign"
+    "this.align(arg1, arg2)",
+    "arrow.core.align"
   ),
   DeprecationLevel.WARNING
 )
@@ -89,8 +83,8 @@ fun <A> Sequence<A>.salign(arg1: Semigroup<A>, arg2: Sequence<A>): Sequence<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "padZip(arg1)",
-  "arrow.core.padZip"
+    "this.padZip(arg1)",
+    "arrow.core.padZip"
   ),
   DeprecationLevel.WARNING
 )
@@ -110,8 +104,8 @@ fun <A, B> Sequence<A>.padZip(arg1: Sequence<B>): Sequence<Tuple2<Option<A>, Opt
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "padZipWith(arg1, arg2)",
-  "arrow.core.padZipWith"
+    "this.padZip(arg1, arg2)",
+    "arrow.core.padZip"
   ),
   DeprecationLevel.WARNING
 )
@@ -128,9 +122,17 @@ fun <A, B, C> Sequence<A>.padZipWith(arg1: Sequence<B>, arg2: Function2<Option<A
 internal val semialign_singleton: SequenceKSemialign = object :
     arrow.core.extensions.SequenceKSemialign {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
+  )
+  @Deprecated(
+    "Semialign typeclass is deprecated. Use concrete methods on Sequence",
+    level = DeprecationLevel.WARNING
   )
   inline fun semialign(): SequenceKSemialign = semialign_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/semigroup/SequenceKSemigroup.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/semigroup/SequenceKSemigroup.kt
@@ -1,11 +1,6 @@
 package arrow.core.extensions.sequence.semigroup
 
 import arrow.core.extensions.SequenceKSemigroup
-import kotlin.Any
-import kotlin.Deprecated
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 import kotlin.sequences.Sequence
 
 @JvmName("plus")
@@ -18,8 +13,7 @@ import kotlin.sequences.Sequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "plus(arg1)",
-  "arrow.core.plus"
+    "this + arg1"
   ),
   DeprecationLevel.WARNING
 )
@@ -38,8 +32,7 @@ operator fun <A> Sequence<A>.plus(arg1: Sequence<A>): Sequence<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "maybeCombine(arg1)",
-  "arrow.core.maybeCombine"
+    "(arg1?.plus(this) ?: emptySequence<A>())"
   ),
   DeprecationLevel.WARNING
 )
@@ -55,10 +48,22 @@ fun <A> Sequence<A>.maybeCombine(arg1: Sequence<A>): Sequence<A> =
 @PublishedApi()
 internal val semigroup_singleton: SequenceKSemigroup<Any?> = object : SequenceKSemigroup<Any?> {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
+  )
+  @Deprecated(
+    "@extension projected functions are deprecated",
+    ReplaceWith(
+      "Semigroup.sequence<A>()",
+      "arrow.core.sequence", "arrow.typeclasses.Semigroup"
+    ),
+    DeprecationLevel.WARNING
   )
   inline fun <A> semigroup(): SequenceKSemigroup<A> = semigroup_singleton as
       arrow.core.extensions.SequenceKSemigroup<A>}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/semigroupK/SequenceKSemigroupK.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/semigroupK/SequenceKSemigroupK.kt
@@ -4,10 +4,6 @@ import arrow.Kind
 import arrow.core.ForSequenceK
 import arrow.core.extensions.SequenceKSemigroupK
 import arrow.typeclasses.Semigroup
-import kotlin.Deprecated
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 import kotlin.sequences.Sequence
 
 @JvmName("combineK")
@@ -20,8 +16,7 @@ import kotlin.sequences.Sequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "combineK(arg1)",
-  "arrow.core.combineK"
+    "this + arg1"
   ),
   DeprecationLevel.WARNING
 )
@@ -41,8 +36,8 @@ fun <A> Sequence<A>.combineK(arg1: Sequence<A>): Sequence<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "algebra()",
-  "arrow.core.extensions.sequence.semigroupK.Sequence.algebra"
+    "Semigroup.sequence<A>()",
+    "arrow.core.sequence", "arrow.typeclasses.Semigroup"
   ),
   DeprecationLevel.WARNING
 )
@@ -58,9 +53,17 @@ fun <A> algebra(): Semigroup<Kind<ForSequenceK, A>> =
 internal val semigroupK_singleton: SequenceKSemigroupK = object :
     arrow.core.extensions.SequenceKSemigroupK {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
+  )
+  @Deprecated(
+    "SemigroupK typeclass is deprecated. Use concrete methods on Sequence",
+    level = DeprecationLevel.WARNING
   )
   inline fun semigroupK(): SequenceKSemigroupK = semigroupK_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/semigroupal/SequenceKSemigroupal.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/semigroupal/SequenceKSemigroupal.kt
@@ -2,10 +2,6 @@ package arrow.core.extensions.sequence.semigroupal
 
 import arrow.core.Tuple2
 import arrow.core.extensions.SequenceKSemigroupal
-import kotlin.Deprecated
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 import kotlin.sequences.Sequence
 
 /**
@@ -21,8 +17,7 @@ import kotlin.sequences.Sequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.zip(arg1, ::Pair)"
   ),
   DeprecationLevel.WARNING
 )
@@ -45,8 +40,7 @@ fun <A, B> Sequence<A>.product(arg1: Sequence<B>): Sequence<Tuple2<A, B>> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "times(arg1)",
-  "arrow.core.times"
+    "this.zip(arg1, ::Pair)"
   ),
   DeprecationLevel.WARNING
 )
@@ -63,6 +57,10 @@ operator fun <A, B> Sequence<A>.times(arg1: Sequence<B>): Sequence<Tuple2<A, B>>
 internal val semigroupal_singleton: SequenceKSemigroupal = object :
     arrow.core.extensions.SequenceKSemigroupal {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
   /**
    *  The [Semigroupal] type class for a given type `F` can be seen as an abstraction over the [cartesian product](https://en.wikipedia.org/wiki/Cartesian_product).
@@ -156,5 +154,9 @@ object Sequence {
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
+  )
+  @Deprecated(
+    "Semigroupal typeclass is deprecated. Use concrete methods on Sequence",
+    level = DeprecationLevel.WARNING
   )
   inline fun semigroupal(): SequenceKSemigroupal = semigroupal_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/traverse/SequenceKTraverse.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/traverse/SequenceKTraverse.kt
@@ -5,11 +5,6 @@ import arrow.core.ForSequenceK
 import arrow.core.extensions.SequenceKTraverse
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Monad
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 import kotlin.sequences.Sequence
 
 @JvmName("traverse")
@@ -20,12 +15,8 @@ import kotlin.sequences.Sequence
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "traverse(arg1, arg2)",
-  "arrow.core.traverse"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated. Replace with traverseEither or traverseValidated from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <G, A, B> Sequence<A>.traverse(arg1: Applicative<G>, arg2: Function1<A, Kind<G, B>>): Kind<G,
     Kind<ForSequenceK, B>> = arrow.core.extensions.sequence.traverse.Sequence.traverse().run {
@@ -41,12 +32,8 @@ fun <G, A, B> Sequence<A>.traverse(arg1: Applicative<G>, arg2: Function1<A, Kind
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "sequence(arg1)",
-  "arrow.core.sequence"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated. Replace with sequenceEither or sequenceValidated from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <G, A> Sequence<Kind<G, A>>.sequence(arg1: Applicative<G>): Kind<G, Kind<ForSequenceK, A>> =
     arrow.core.extensions.sequence.traverse.Sequence.traverse().run {
@@ -64,8 +51,7 @@ fun <G, A> Sequence<Kind<G, A>>.sequence(arg1: Applicative<G>): Kind<G, Kind<For
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg1)",
-  "arrow.core.map"
+    "this.map(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -82,12 +68,8 @@ fun <A, B> Sequence<A>.map(arg1: Function1<A, B>): Sequence<B> =
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "flatTraverse(arg1, arg2, arg3)",
-  "arrow.core.flatTraverse"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated. Replace with flatTraverseEither or flatTraverseValidated from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <G, A, B> Sequence<A>.flatTraverse(
   arg1: Monad<ForSequenceK>,
@@ -106,9 +88,17 @@ fun <G, A, B> Sequence<A>.flatTraverse(
 internal val traverse_singleton: SequenceKTraverse = object :
     arrow.core.extensions.SequenceKTraverse {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
+  )
+  @Deprecated(
+    "Traverse typeclass is deprecated. Use concrete methods on Sequence",
+    level = DeprecationLevel.WARNING
   )
   inline fun traverse(): SequenceKTraverse = traverse_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/unalign/SequenceKUnalign.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/unalign/SequenceKUnalign.kt
@@ -68,7 +68,7 @@ object Sequence {
     "NOTHING_TO_INLINE"
   )
   @Deprecated(
-    "Unalign typeclasses is deprecated. Use concrete methods on Sequence",
+    "Unalign typeclass is deprecated. Use concrete methods on Sequence",
     level = DeprecationLevel.WARNING
   )
   inline fun unalign(): SequenceKUnalign = unalign_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/unalign/SequenceKUnalign.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/unalign/SequenceKUnalign.kt
@@ -5,11 +5,6 @@ import arrow.core.ForSequenceK
 import arrow.core.Ior
 import arrow.core.Tuple2
 import arrow.core.extensions.SequenceKUnalign
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 import kotlin.sequences.Sequence
 
 @JvmName("unalign")
@@ -22,8 +17,8 @@ import kotlin.sequences.Sequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "unalign(arg0)",
-  "arrow.core.extensions.sequence.unalign.Sequence.unalign"
+    "arg0.unalign()",
+    "arrow.core.unalign"
   ),
   DeprecationLevel.WARNING
 )
@@ -43,8 +38,8 @@ fun <A, B> unalign(arg0: Sequence<Ior<A, B>>): Tuple2<Kind<ForSequenceK, A>, Kin
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "unalignWith(arg0, arg1)",
-  "arrow.core.extensions.sequence.unalign.Sequence.unalignWith"
+    "arg0.unalign(arg1)",
+    "arrow.core.unalign"
   ),
   DeprecationLevel.WARNING
 )
@@ -63,9 +58,17 @@ fun <A, B, C> unalignWith(arg0: Sequence<C>, arg1: Function1<C, Ior<A, B>>):
 internal val unalign_singleton: SequenceKUnalign = object : arrow.core.extensions.SequenceKUnalign
     {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
+  )
+  @Deprecated(
+    "Unalign typeclasses is deprecated. Use concrete methods on Sequence",
+    level = DeprecationLevel.WARNING
   )
   inline fun unalign(): SequenceKUnalign = unalign_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/unzip/SequenceKUnzip.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/unzip/SequenceKUnzip.kt
@@ -4,11 +4,6 @@ import arrow.Kind
 import arrow.core.ForSequenceK
 import arrow.core.Tuple2
 import arrow.core.extensions.SequenceKUnzip
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 import kotlin.sequences.Sequence
 
 @JvmName("unzip")
@@ -21,8 +16,8 @@ import kotlin.sequences.Sequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "unzip()",
-  "arrow.core.unzip"
+    "this.unzip()",
+    "arrow.core.unzip"
   ),
   DeprecationLevel.WARNING
 )
@@ -43,8 +38,8 @@ fun <A, B> Sequence<Tuple2<A, B>>.unzip(): Tuple2<Kind<ForSequenceK, A>, Kind<Fo
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "unzipWith(arg1)",
-  "arrow.core.unzipWith"
+    "this.unzip { c -> val t = arg1(c);  t.a to t.b }",
+    "arrow.core.andThen", "arrow.core.to", "arrow.core.unzip"
   ),
   DeprecationLevel.WARNING
 )
@@ -61,9 +56,18 @@ fun <A, B, C> Sequence<C>.unzipWith(arg1: Function1<C, Tuple2<A, B>>): Tuple2<Ki
 @PublishedApi()
 internal val unzip_singleton: SequenceKUnzip = object : arrow.core.extensions.SequenceKUnzip {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
   )
-  inline fun unzip(): SequenceKUnzip = unzip_singleton}
+  @Deprecated(
+    "Unzip typeclasses is deprecated. Use concrete methods on Sequence",
+    level = DeprecationLevel.WARNING
+  )
+  inline fun unzip(): SequenceKUnzip = unzip_singleton
+}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/unzip/SequenceKUnzip.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/unzip/SequenceKUnzip.kt
@@ -66,7 +66,7 @@ object Sequence {
     "NOTHING_TO_INLINE"
   )
   @Deprecated(
-    "Unzip typeclasses is deprecated. Use concrete methods on Sequence",
+    "Unzip typeclass is deprecated. Use concrete methods on Sequence",
     level = DeprecationLevel.WARNING
   )
   inline fun unzip(): SequenceKUnzip = unzip_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/zip/SequenceKZip.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/zip/SequenceKZip.kt
@@ -60,7 +60,7 @@ object Sequence {
     "NOTHING_TO_INLINE"
   )
   @Deprecated(
-    "Zip typeclasses is deprecated. Use concrete methods on Sequence",
+    "Zip typeclass is deprecated. Use concrete methods on Sequence",
     level = DeprecationLevel.WARNING
   )
   inline fun zip(): SequenceKZip = zip_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/zip/SequenceKZip.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequence/zip/SequenceKZip.kt
@@ -2,11 +2,6 @@ package arrow.core.extensions.sequence.zip
 
 import arrow.core.Tuple2
 import arrow.core.extensions.SequenceKZip
-import kotlin.Deprecated
-import kotlin.Function2
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 import kotlin.sequences.Sequence
 
 @JvmName("zip")
@@ -19,8 +14,7 @@ import kotlin.sequences.Sequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "zip(arg1)",
-  "arrow.core.zip"
+    "this.zip(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -40,8 +34,7 @@ fun <A, B> Sequence<A>.zip(arg1: Sequence<B>): Sequence<Tuple2<A, B>> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "zipWith(arg1, arg2)",
-  "arrow.core.zipWith"
+    "this.zip(arg1, arg2)"
   ),
   DeprecationLevel.WARNING
 )
@@ -57,9 +50,17 @@ fun <A, B, C> Sequence<A>.zipWith(arg1: Sequence<B>, arg2: Function2<A, B, C>): 
 @PublishedApi()
 internal val zip_singleton: SequenceKZip = object : arrow.core.extensions.SequenceKZip {}
 
+@Deprecated(
+  "Receiver Sequence object is deprecated, prefer to turn Sequence functions into top-level functions",
+  level = DeprecationLevel.WARNING
+)
 object Sequence {
   @Suppress(
     "UNCHECKED_CAST",
     "NOTHING_TO_INLINE"
+  )
+  @Deprecated(
+    "Zip typeclasses is deprecated. Use concrete methods on Sequence",
+    level = DeprecationLevel.WARNING
   )
   inline fun zip(): SequenceKZip = zip_singleton}

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequenceK.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequenceK.kt
@@ -31,7 +31,6 @@ import arrow.core.fix
 import arrow.core.k
 import arrow.core.some
 import arrow.core.toT
-import arrow.extension
 import arrow.typeclasses.Align
 import arrow.typeclasses.Alternative
 import arrow.typeclasses.Applicative
@@ -66,28 +65,23 @@ import arrow.typeclasses.Zip
 import arrow.typeclasses.hashWithSalt
 import arrow.core.combineK as sequenceCombineK
 
-@extension
 interface SequenceKSemigroup<A> : Semigroup<SequenceK<A>> {
   override fun SequenceK<A>.combine(b: SequenceK<A>): SequenceK<A> = (this.sequence + b.sequence).k()
 }
 
-@extension
 interface SequenceKSemigroupal : Semigroupal<ForSequenceK> {
   override fun <A, B> Kind<ForSequenceK, A>.product(fb: Kind<ForSequenceK, B>): Kind<ForSequenceK, Tuple2<A, B>> =
     fb.fix().ap(this.map { a: A -> { b: B -> Tuple2(a, b) } })
 }
 
-@extension
 interface SequenceKMonoidal : Monoidal<ForSequenceK>, SequenceKSemigroupal {
   override fun <A> identity(): Kind<ForSequenceK, A> = SequenceK.empty()
 }
 
-@extension
 interface SequenceKMonoid<A> : Monoid<SequenceK<A>>, SequenceKSemigroup<A> {
   override fun empty(): SequenceK<A> = emptySequence<A>().k()
 }
 
-@extension
 interface SequenceKEq<A> : Eq<SequenceK<A>> {
 
   fun EQ(): Eq<A>
@@ -103,19 +97,16 @@ interface SequenceKEq<A> : Eq<SequenceK<A>> {
   }
 }
 
-@extension
 interface SequenceKShow<A> : Show<SequenceK<A>> {
   fun SA(): Show<A>
   override fun SequenceK<A>.show(): String = show(SA())
 }
 
-@extension
 interface SequenceKFunctor : Functor<ForSequenceK> {
   override fun <A, B> Kind<ForSequenceK, A>.map(f: (A) -> B): SequenceK<B> =
     fix().map(f)
 }
 
-@extension
 interface SequenceKApply : Apply<ForSequenceK> {
   override fun <A, B> Kind<ForSequenceK, A>.ap(ff: Kind<ForSequenceK, (A) -> B>): SequenceK<B> =
     fix().ap(ff)
@@ -127,7 +118,6 @@ interface SequenceKApply : Apply<ForSequenceK> {
     fix().map2(fb, f)
 }
 
-@extension
 interface SequenceKApplicative : Applicative<ForSequenceK>, SequenceKApply {
   override fun <A, B> Kind<ForSequenceK, A>.ap(ff: Kind<ForSequenceK, (A) -> B>): SequenceK<B> =
     fix().ap(ff)
@@ -142,7 +132,6 @@ interface SequenceKApplicative : Applicative<ForSequenceK>, SequenceKApply {
     SequenceK.just(a)
 }
 
-@extension
 interface SequenceKMonad : Monad<ForSequenceK> {
   override fun <A, B> Kind<ForSequenceK, A>.ap(ff: Kind<ForSequenceK, (A) -> B>): SequenceK<B> =
     fix().ap(ff)
@@ -163,7 +152,6 @@ interface SequenceKMonad : Monad<ForSequenceK> {
     SequenceK.just(a)
 }
 
-@extension
 interface SequenceKFoldable : Foldable<ForSequenceK> {
   override fun <A, B> Kind<ForSequenceK, A>.foldLeft(b: B, f: (B, A) -> B): B =
     fix().foldLeft(b, f)
@@ -183,19 +171,16 @@ interface SequenceKFoldable : Foldable<ForSequenceK> {
     else fix().drop(idx.toInt()).firstOption()
 }
 
-@extension
 interface SequenceKTraverse : Traverse<ForSequenceK>, SequenceKFoldable {
   override fun <G, A, B> Kind<ForSequenceK, A>.traverse(AP: Applicative<G>, f: (A) -> Kind<G, B>): Kind<G, SequenceK<B>> =
     fix().traverse(AP, f)
 }
 
-@extension
 interface SequenceKSemigroupK : SemigroupK<ForSequenceK> {
   override fun <A> Kind<ForSequenceK, A>.combineK(y: Kind<ForSequenceK, A>): SequenceK<A> =
     fix().sequenceCombineK(y)
 }
 
-@extension
 interface SequenceKMonoidK : MonoidK<ForSequenceK> {
   override fun <A> empty(): SequenceK<A> =
     SequenceK.empty()
@@ -204,7 +189,6 @@ interface SequenceKMonoidK : MonoidK<ForSequenceK> {
     fix().sequenceCombineK(y)
 }
 
-@extension
 interface SequenceKHash<A> : Hash<SequenceK<A>> {
   fun HA(): Hash<A>
 
@@ -214,7 +198,6 @@ interface SequenceKHash<A> : Hash<SequenceK<A>> {
       .let { (hash, size) -> hash.hashWithSalt(size) }
 }
 
-@extension
 interface SequenceKOrder<A> : Order<SequenceK<A>> {
   fun OA(): Order<A>
   override fun SequenceK<A>.compare(b: SequenceK<A>): Ordering =
@@ -226,13 +209,11 @@ interface SequenceKOrder<A> : Order<SequenceK<A>> {
       }.value()
 }
 
-@extension
 interface SequenceKFunctorFilter : FunctorFilter<ForSequenceK>, SequenceKFunctor {
   override fun <A, B> Kind<ForSequenceK, A>.filterMap(f: (A) -> Option<B>): SequenceK<B> =
     fix().filterMap(f)
 }
 
-@extension
 interface SequenceKMonadFilter : MonadFilter<ForSequenceK> {
   override fun <A> empty(): SequenceK<A> =
     SequenceK.empty()
@@ -259,7 +240,6 @@ interface SequenceKMonadFilter : MonadFilter<ForSequenceK> {
     SequenceK.just(a)
 }
 
-@extension
 interface SequenceKMonadCombine : MonadCombine<ForSequenceK>, SequenceKAlternative {
   override fun <A> empty(): SequenceK<A> =
     SequenceK.empty()
@@ -289,7 +269,6 @@ interface SequenceKMonadCombine : MonadCombine<ForSequenceK>, SequenceKAlternati
 fun <A> SequenceK.Companion.fx(c: suspend MonadSyntax<ForSequenceK>.() -> A): SequenceK<A> =
   SequenceK.monad().fx.monad(c).fix()
 
-@extension
 interface SequenceKAlternative : Alternative<ForSequenceK>, SequenceKApplicative {
   override fun <A> empty(): Kind<ForSequenceK, A> = emptySequence<A>().k()
   override fun <A> Kind<ForSequenceK, A>.orElse(b: Kind<ForSequenceK, A>): Kind<ForSequenceK, A> =
@@ -320,7 +299,6 @@ interface SequenceKAlternative : Alternative<ForSequenceK>, SequenceKApplicative
     }.k()
 }
 
-@extension
 interface SequenceKSemialign : Semialign<ForSequenceK>, SequenceKFunctor {
   override fun <A, B> align(a: Kind<ForSequenceK, A>, b: Kind<ForSequenceK, B>): Kind<ForSequenceK, Ior<A, B>> =
     object : Sequence<Ior<A, B>> {
@@ -339,12 +317,10 @@ interface SequenceKSemialign : Semialign<ForSequenceK>, SequenceKFunctor {
     }.k()
 }
 
-@extension
 interface SequenceKAlign : Align<ForSequenceK>, SequenceKSemialign {
   override fun <A> empty(): Kind<ForSequenceK, A> = emptySequence<A>().k()
 }
 
-@extension
 interface SequenceKUnalign : Unalign<ForSequenceK>, SequenceKSemialign {
   override fun <A, B> unalign(ior: Kind<ForSequenceK, Ior<A, B>>): Tuple2<Kind<ForSequenceK, A>, Kind<ForSequenceK, B>> =
     ior.fix().let { seq ->
@@ -355,7 +331,6 @@ interface SequenceKUnalign : Unalign<ForSequenceK>, SequenceKSemialign {
     }
 }
 
-@extension
 interface SequenceKZip : Zip<ForSequenceK>, SequenceKSemialign {
   override fun <A, B> Kind<ForSequenceK, A>.zip(other: Kind<ForSequenceK, B>): Kind<ForSequenceK, Tuple2<A, B>> =
     object : Sequence<Tuple2<A, B>> {
@@ -372,7 +347,6 @@ interface SequenceKZip : Zip<ForSequenceK>, SequenceKSemialign {
     }.k()
 }
 
-@extension
 interface SequenceKRepeat : Repeat<ForSequenceK>, SequenceKZip {
   override fun <A> repeat(a: A): Kind<ForSequenceK, A> =
     object : Sequence<A> {
@@ -384,7 +358,6 @@ interface SequenceKRepeat : Repeat<ForSequenceK>, SequenceKZip {
     }.k()
 }
 
-@extension
 interface SequenceKUnzip : Unzip<ForSequenceK>, SequenceKZip {
   override fun <A, B> Kind<ForSequenceK, Tuple2<A, B>>.unzip(): Tuple2<Kind<ForSequenceK, A>, Kind<ForSequenceK, B>> =
     this.fix().let { seq ->
@@ -392,7 +365,6 @@ interface SequenceKUnzip : Unzip<ForSequenceK>, SequenceKZip {
     }
 }
 
-@extension
 interface SequenceKCrosswalk : Crosswalk<ForSequenceK>, SequenceKFunctor, SequenceKFoldable {
   override fun <F, A, B> crosswalk(ALIGN: Align<F>, a: Kind<ForSequenceK, A>, fa: (A) -> Kind<F, B>): Kind<F, Kind<ForSequenceK, B>> =
     a.fix().sequence.toList().k().let { list ->
@@ -406,13 +378,11 @@ interface SequenceKCrosswalk : Crosswalk<ForSequenceK>, SequenceKFunctor, Sequen
     }
 }
 
-@extension
 interface SequenceKEqK : EqK<ForSequenceK> {
   override fun <A> Kind<ForSequenceK, A>.eqK(other: Kind<ForSequenceK, A>, EQ: Eq<A>): Boolean =
     SequenceK.eq(EQ).run { this@eqK.fix().eqv(other.fix()) }
 }
 
-@extension
 interface SequenceKMonadPlus : MonadPlus<ForSequenceK>, SequenceKMonad, SequenceKAlternative {
   override fun <A, B> Kind<ForSequenceK, A>.ap(ff: Kind<ForSequenceK, (A) -> B>): SequenceK<B> =
     fix().ap(ff)
@@ -427,7 +397,6 @@ interface SequenceKMonadPlus : MonadPlus<ForSequenceK>, SequenceKMonad, Sequence
     SequenceK.just(a)
 }
 
-@extension
 interface SequenceKMonadLogic : MonadLogic<ForSequenceK>, SequenceKMonadPlus {
   override fun <A> Kind<ForSequenceK, A>.splitM(): Kind<ForSequenceK, Option<Tuple2<Kind<ForSequenceK, A>, A>>> =
     SequenceK.just(firstOption().map { a -> fix().sequence.drop(1).k() toT a })

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequenceK.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequenceK.kt
@@ -65,19 +65,37 @@ import arrow.typeclasses.Zip
 import arrow.typeclasses.hashWithSalt
 import arrow.core.combineK as sequenceCombineK
 
+@Deprecated(
+  "Typeclass instance have been moved to the companion object of the typeclass.",
+  ReplaceWith("Semigroup.sequence()", "arrow.core.sequence", "arrow.typeclasses.Semigroup"),
+  DeprecationLevel.WARNING
+)
 interface SequenceKSemigroup<A> : Semigroup<SequenceK<A>> {
   override fun SequenceK<A>.combine(b: SequenceK<A>): SequenceK<A> = (this.sequence + b.sequence).k()
 }
 
+@Deprecated(
+  message = "Semigroupal typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
+)
 interface SequenceKSemigroupal : Semigroupal<ForSequenceK> {
   override fun <A, B> Kind<ForSequenceK, A>.product(fb: Kind<ForSequenceK, B>): Kind<ForSequenceK, Tuple2<A, B>> =
     fb.fix().ap(this.map { a: A -> { b: B -> Tuple2(a, b) } })
 }
 
+@Deprecated(
+  message = "Monoidal typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
+)
 interface SequenceKMonoidal : Monoidal<ForSequenceK>, SequenceKSemigroupal {
   override fun <A> identity(): Kind<ForSequenceK, A> = SequenceK.empty()
 }
 
+@Deprecated(
+  "Typeclass instance have been moved to the companion object of the typeclass.",
+  ReplaceWith("Monoid.sequence()", "arrow.core.sequence", "arrow.typeclasses.Monoid"),
+  DeprecationLevel.WARNING
+)
 interface SequenceKMonoid<A> : Monoid<SequenceK<A>>, SequenceKSemigroup<A> {
   override fun empty(): SequenceK<A> = emptySequence<A>().k()
 }
@@ -102,11 +120,19 @@ interface SequenceKShow<A> : Show<SequenceK<A>> {
   override fun SequenceK<A>.show(): String = show(SA())
 }
 
+@Deprecated(
+  message = "Functor typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
+)
 interface SequenceKFunctor : Functor<ForSequenceK> {
   override fun <A, B> Kind<ForSequenceK, A>.map(f: (A) -> B): SequenceK<B> =
     fix().map(f)
 }
 
+@Deprecated(
+  message = "Apply typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
+)
 interface SequenceKApply : Apply<ForSequenceK> {
   override fun <A, B> Kind<ForSequenceK, A>.ap(ff: Kind<ForSequenceK, (A) -> B>): SequenceK<B> =
     fix().ap(ff)
@@ -118,6 +144,10 @@ interface SequenceKApply : Apply<ForSequenceK> {
     fix().map2(fb, f)
 }
 
+@Deprecated(
+  message = "Applicative typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
+)
 interface SequenceKApplicative : Applicative<ForSequenceK>, SequenceKApply {
   override fun <A, B> Kind<ForSequenceK, A>.ap(ff: Kind<ForSequenceK, (A) -> B>): SequenceK<B> =
     fix().ap(ff)
@@ -132,6 +162,10 @@ interface SequenceKApplicative : Applicative<ForSequenceK>, SequenceKApply {
     SequenceK.just(a)
 }
 
+@Deprecated(
+  message = "Monad typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
+)
 interface SequenceKMonad : Monad<ForSequenceK> {
   override fun <A, B> Kind<ForSequenceK, A>.ap(ff: Kind<ForSequenceK, (A) -> B>): SequenceK<B> =
     fix().ap(ff)
@@ -152,6 +186,10 @@ interface SequenceKMonad : Monad<ForSequenceK> {
     SequenceK.just(a)
 }
 
+@Deprecated(
+  message = "Foldable typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
+)
 interface SequenceKFoldable : Foldable<ForSequenceK> {
   override fun <A, B> Kind<ForSequenceK, A>.foldLeft(b: B, f: (B, A) -> B): B =
     fix().foldLeft(b, f)
@@ -171,16 +209,28 @@ interface SequenceKFoldable : Foldable<ForSequenceK> {
     else fix().drop(idx.toInt()).firstOption()
 }
 
+@Deprecated(
+  message = "Traverse typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
+)
 interface SequenceKTraverse : Traverse<ForSequenceK>, SequenceKFoldable {
   override fun <G, A, B> Kind<ForSequenceK, A>.traverse(AP: Applicative<G>, f: (A) -> Kind<G, B>): Kind<G, SequenceK<B>> =
     fix().traverse(AP, f)
 }
 
+@Deprecated(
+  message = "SemigroupK typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
+)
 interface SequenceKSemigroupK : SemigroupK<ForSequenceK> {
   override fun <A> Kind<ForSequenceK, A>.combineK(y: Kind<ForSequenceK, A>): SequenceK<A> =
     fix().sequenceCombineK(y)
 }
 
+@Deprecated(
+  message = "MonoidK typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
+)
 interface SequenceKMonoidK : MonoidK<ForSequenceK> {
   override fun <A> empty(): SequenceK<A> =
     SequenceK.empty()
@@ -209,11 +259,19 @@ interface SequenceKOrder<A> : Order<SequenceK<A>> {
       }.value()
 }
 
+@Deprecated(
+  message = "FunctorFilter typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
+)
 interface SequenceKFunctorFilter : FunctorFilter<ForSequenceK>, SequenceKFunctor {
   override fun <A, B> Kind<ForSequenceK, A>.filterMap(f: (A) -> Option<B>): SequenceK<B> =
     fix().filterMap(f)
 }
 
+@Deprecated(
+  message = "MonadFilter typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
+)
 interface SequenceKMonadFilter : MonadFilter<ForSequenceK> {
   override fun <A> empty(): SequenceK<A> =
     SequenceK.empty()
@@ -240,6 +298,10 @@ interface SequenceKMonadFilter : MonadFilter<ForSequenceK> {
     SequenceK.just(a)
 }
 
+@Deprecated(
+  message = "MonadCombine typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
+)
 interface SequenceKMonadCombine : MonadCombine<ForSequenceK>, SequenceKAlternative {
   override fun <A> empty(): SequenceK<A> =
     SequenceK.empty()
@@ -269,6 +331,10 @@ interface SequenceKMonadCombine : MonadCombine<ForSequenceK>, SequenceKAlternati
 fun <A> SequenceK.Companion.fx(c: suspend MonadSyntax<ForSequenceK>.() -> A): SequenceK<A> =
   SequenceK.monad().fx.monad(c).fix()
 
+@Deprecated(
+  message = "Alternative typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
+)
 interface SequenceKAlternative : Alternative<ForSequenceK>, SequenceKApplicative {
   override fun <A> empty(): Kind<ForSequenceK, A> = emptySequence<A>().k()
   override fun <A> Kind<ForSequenceK, A>.orElse(b: Kind<ForSequenceK, A>): Kind<ForSequenceK, A> =
@@ -299,6 +365,10 @@ interface SequenceKAlternative : Alternative<ForSequenceK>, SequenceKApplicative
     }.k()
 }
 
+@Deprecated(
+  message = "Semialign typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
+)
 interface SequenceKSemialign : Semialign<ForSequenceK>, SequenceKFunctor {
   override fun <A, B> align(a: Kind<ForSequenceK, A>, b: Kind<ForSequenceK, B>): Kind<ForSequenceK, Ior<A, B>> =
     object : Sequence<Ior<A, B>> {
@@ -317,10 +387,18 @@ interface SequenceKSemialign : Semialign<ForSequenceK>, SequenceKFunctor {
     }.k()
 }
 
+@Deprecated(
+  message = "Align typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
+)
 interface SequenceKAlign : Align<ForSequenceK>, SequenceKSemialign {
   override fun <A> empty(): Kind<ForSequenceK, A> = emptySequence<A>().k()
 }
 
+@Deprecated(
+  message = "Unalign typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
+)
 interface SequenceKUnalign : Unalign<ForSequenceK>, SequenceKSemialign {
   override fun <A, B> unalign(ior: Kind<ForSequenceK, Ior<A, B>>): Tuple2<Kind<ForSequenceK, A>, Kind<ForSequenceK, B>> =
     ior.fix().let { seq ->
@@ -331,6 +409,10 @@ interface SequenceKUnalign : Unalign<ForSequenceK>, SequenceKSemialign {
     }
 }
 
+@Deprecated(
+  message = "Zip typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
+)
 interface SequenceKZip : Zip<ForSequenceK>, SequenceKSemialign {
   override fun <A, B> Kind<ForSequenceK, A>.zip(other: Kind<ForSequenceK, B>): Kind<ForSequenceK, Tuple2<A, B>> =
     object : Sequence<Tuple2<A, B>> {
@@ -347,6 +429,10 @@ interface SequenceKZip : Zip<ForSequenceK>, SequenceKSemialign {
     }.k()
 }
 
+@Deprecated(
+  message = "Repeat typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
+)
 interface SequenceKRepeat : Repeat<ForSequenceK>, SequenceKZip {
   override fun <A> repeat(a: A): Kind<ForSequenceK, A> =
     object : Sequence<A> {
@@ -358,6 +444,10 @@ interface SequenceKRepeat : Repeat<ForSequenceK>, SequenceKZip {
     }.k()
 }
 
+@Deprecated(
+  message = "Unzip typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
+)
 interface SequenceKUnzip : Unzip<ForSequenceK>, SequenceKZip {
   override fun <A, B> Kind<ForSequenceK, Tuple2<A, B>>.unzip(): Tuple2<Kind<ForSequenceK, A>, Kind<ForSequenceK, B>> =
     this.fix().let { seq ->
@@ -365,6 +455,10 @@ interface SequenceKUnzip : Unzip<ForSequenceK>, SequenceKZip {
     }
 }
 
+@Deprecated(
+  message = "Crosswalk typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
+)
 interface SequenceKCrosswalk : Crosswalk<ForSequenceK>, SequenceKFunctor, SequenceKFoldable {
   override fun <F, A, B> crosswalk(ALIGN: Align<F>, a: Kind<ForSequenceK, A>, fa: (A) -> Kind<F, B>): Kind<F, Kind<ForSequenceK, B>> =
     a.fix().sequence.toList().k().let { list ->
@@ -378,11 +472,19 @@ interface SequenceKCrosswalk : Crosswalk<ForSequenceK>, SequenceKFunctor, Sequen
     }
 }
 
+@Deprecated(
+  message = "EqK typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
+)
 interface SequenceKEqK : EqK<ForSequenceK> {
   override fun <A> Kind<ForSequenceK, A>.eqK(other: Kind<ForSequenceK, A>, EQ: Eq<A>): Boolean =
     SequenceK.eq(EQ).run { this@eqK.fix().eqv(other.fix()) }
 }
 
+@Deprecated(
+  message = "MonadPlus typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
+)
 interface SequenceKMonadPlus : MonadPlus<ForSequenceK>, SequenceKMonad, SequenceKAlternative {
   override fun <A, B> Kind<ForSequenceK, A>.ap(ff: Kind<ForSequenceK, (A) -> B>): SequenceK<B> =
     fix().ap(ff)
@@ -397,6 +499,10 @@ interface SequenceKMonadPlus : MonadPlus<ForSequenceK>, SequenceKMonad, Sequence
     SequenceK.just(a)
 }
 
+@Deprecated(
+  message = "MonadLogic typeclass is deprecated and will be removed in 0.13.0. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
+)
 interface SequenceKMonadLogic : MonadLogic<ForSequenceK>, SequenceKMonadPlus {
   override fun <A> Kind<ForSequenceK, A>.splitM(): Kind<ForSequenceK, Option<Tuple2<Kind<ForSequenceK, A>, A>>> =
     SequenceK.just(firstOption().map { a -> fix().sequence.drop(1).k() toT a })

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/align/SequenceKAlign.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/align/SequenceKAlign.kt
@@ -3,10 +3,6 @@ package arrow.core.extensions.sequencek.align
 import arrow.core.SequenceK
 import arrow.core.SequenceK.Companion
 import arrow.core.extensions.SequenceKAlign
-import kotlin.Deprecated
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -24,8 +20,7 @@ internal val align_singleton: SequenceKAlign = object : arrow.core.extensions.Se
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "empty()",
-  "arrow.core.SequenceK.empty"
+    "emptySequence<A>()"
   ),
   DeprecationLevel.WARNING
 )
@@ -36,5 +31,9 @@ fun <A> empty(): SequenceK<A> = arrow.core.SequenceK
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Align typeclasses is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.align(): SequenceKAlign = align_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/align/SequenceKAlign.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/align/SequenceKAlign.kt
@@ -33,7 +33,7 @@ fun <A> empty(): SequenceK<A> = arrow.core.SequenceK
   "NOTHING_TO_INLINE"
 )
 @Deprecated(
-  "Align typeclasses is deprecated. Use concrete methods on Sequence",
+  "Align typeclass is deprecated. Use concrete methods on Sequence",
   level = DeprecationLevel.WARNING
 )
 inline fun Companion.align(): SequenceKAlign = align_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/alternative/SequenceKAlternative.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/alternative/SequenceKAlternative.kt
@@ -6,13 +6,6 @@ import arrow.core.Option
 import arrow.core.SequenceK
 import arrow.core.SequenceK.Companion
 import arrow.core.extensions.SequenceKAlternative
-import kotlin.Boolean
-import kotlin.Deprecated
-import kotlin.Function0
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.Unit
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -31,8 +24,8 @@ internal val alternative_singleton: SequenceKAlternative = object :
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "some()",
-  "arrow.core.some"
+    "this.some()",
+    "arrow.core.some"
   ),
   DeprecationLevel.WARNING
 )
@@ -51,8 +44,8 @@ fun <A> Kind<ForSequenceK, A>.some(): SequenceK<SequenceK<A>> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "many()",
-  "arrow.core.many"
+    "this.many()",
+    "arrow.core.many"
   ),
   DeprecationLevel.WARNING
 )
@@ -71,8 +64,7 @@ fun <A> Kind<ForSequenceK, A>.many(): SequenceK<SequenceK<A>> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "alt(arg1)",
-  "arrow.core.alt"
+    "this + arg1"
   ),
   DeprecationLevel.WARNING
 )
@@ -91,8 +83,7 @@ infix fun <A> Kind<ForSequenceK, A>.alt(arg1: Kind<ForSequenceK, A>): SequenceK<
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "orElse(arg1)",
-  "arrow.core.orElse"
+    "this + arg1"
   ),
   DeprecationLevel.WARNING
 )
@@ -111,8 +102,7 @@ fun <A> Kind<ForSequenceK, A>.orElse(arg1: Kind<ForSequenceK, A>): SequenceK<A> 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "combineK(arg1)",
-  "arrow.core.combineK"
+    "this + arg1"
   ),
   DeprecationLevel.WARNING
 )
@@ -131,8 +121,8 @@ fun <A> Kind<ForSequenceK, A>.combineK(arg1: Kind<ForSequenceK, A>): SequenceK<A
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "optional()",
-  "arrow.core.optional"
+    "this.map(::Some) + sequenceOf(None)",
+    "arrow.core.None", "arrow.core.Some"
   ),
   DeprecationLevel.WARNING
 )
@@ -151,8 +141,7 @@ fun <A> Kind<ForSequenceK, A>.optional(): SequenceK<Option<A>> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "guard(arg0)",
-  "arrow.core.SequenceK.guard"
+    "if (arg0) sequenceOf(Unit) else emptySequence()"
   ),
   DeprecationLevel.WARNING
 )
@@ -170,8 +159,7 @@ fun guard(arg0: Boolean): SequenceK<Unit> = arrow.core.SequenceK
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "lazyOrElse(arg1)",
-  "arrow.core.lazyOrElse"
+    "this + arg1()"
   ),
   DeprecationLevel.WARNING
 )
@@ -183,5 +171,9 @@ fun <A> Kind<ForSequenceK, A>.lazyOrElse(arg1: Function0<Kind<ForSequenceK, A>>)
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Alternative typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.alternative(): SequenceKAlternative = alternative_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/applicative/SequenceKApplicative.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/applicative/SequenceKApplicative.kt
@@ -6,14 +6,6 @@ import arrow.core.SequenceK
 import arrow.core.SequenceK.Companion
 import arrow.core.extensions.SequenceKApplicative
 import arrow.typeclasses.Monoid
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.Int
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.Unit
-import kotlin.collections.List
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -32,8 +24,7 @@ internal val applicative_singleton: SequenceKApplicative = object :
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "just()",
-  "arrow.core.just"
+    "sequenceOf(this)"
   ),
   DeprecationLevel.WARNING
 )
@@ -51,8 +42,7 @@ fun <A> A.just(): SequenceK<A> = arrow.core.SequenceK.applicative().run {
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "unit()",
-  "arrow.core.SequenceK.unit"
+    "sequenceOf(Unit)"
   ),
   DeprecationLevel.WARNING
 )
@@ -70,8 +60,7 @@ fun unit(): SequenceK<Unit> = arrow.core.SequenceK
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg1)",
-  "arrow.core.map"
+    "this.map(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -90,8 +79,8 @@ fun <A, B> Kind<ForSequenceK, A>.map(arg1: Function1<A, B>): SequenceK<B> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "replicate(arg1)",
-  "arrow.core.replicate"
+    "this.replicate(arg1)",
+    "arrow.core.replicate"
   ),
   DeprecationLevel.WARNING
 )
@@ -110,8 +99,8 @@ fun <A> Kind<ForSequenceK, A>.replicate(arg1: Int): SequenceK<List<A>> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "replicate(arg1, arg2)",
-  "arrow.core.replicate"
+    "this.replicate(arg1, arg2)",
+    "arrow.core.replicate"
   ),
   DeprecationLevel.WARNING
 )
@@ -123,5 +112,9 @@ fun <A> Kind<ForSequenceK, A>.replicate(arg1: Int, arg2: Monoid<A>): SequenceK<A
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Applicative typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.applicative(): SequenceKApplicative = applicative_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/apply/SequenceKApply.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/apply/SequenceKApply.kt
@@ -15,11 +15,6 @@ import arrow.core.Tuple7
 import arrow.core.Tuple8
 import arrow.core.Tuple9
 import arrow.core.extensions.SequenceKApply
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -37,8 +32,8 @@ internal val apply_singleton: SequenceKApply = object : arrow.core.extensions.Se
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "ap(arg1)",
-  "arrow.core.ap"
+    "this.ap(arg1)",
+    "arrow.core.ap"
   ),
   DeprecationLevel.WARNING
 )
@@ -57,8 +52,8 @@ fun <A, B> Kind<ForSequenceK, A>.ap(arg1: Kind<ForSequenceK, Function1<A, B>>): 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "apEval(arg1)",
-  "arrow.core.apEval"
+    "this.apEval(arg1)",
+    "arrow.core.apEval"
   ),
   DeprecationLevel.WARNING
 )
@@ -77,8 +72,8 @@ fun <A, B> Kind<ForSequenceK, A>.apEval(arg1: Eval<Kind<ForSequenceK, Function1<
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map2Eval(arg1, arg2)",
-  "arrow.core.map2Eval"
+    "this.zipEval(arg1, arg2)",
+    "arrow.core.zipEval"
   ),
   DeprecationLevel.WARNING
 )
@@ -101,8 +96,8 @@ fun <A, B, Z> Kind<ForSequenceK, A>.map2Eval(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg0, arg1, arg2)",
-  "arrow.core.SequenceK.map"
+    "SequenceK.mapN(arg0, arg1) { a, b -> arg2(Tuple2(a, b)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
 )
@@ -124,8 +119,8 @@ fun <A, B, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2)",
-  "arrow.core.SequenceK.mapN"
+    "SequenceK.mapN(arg0, arg1) { a, b -> arg2(Tuple2(a, b)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
 )
@@ -147,8 +142,8 @@ fun <A, B, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg0, arg1, arg2, arg3)",
-  "arrow.core.SequenceK.map"
+    "SequenceK.mapN(arg0, arg1, arg2) { a, b, c -> arg2(Tuple3(a, b, c)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
 )
@@ -171,8 +166,8 @@ fun <A, B, C, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2, arg3)",
-  "arrow.core.SequenceK.mapN"
+    "SequenceK.mapN(arg0, arg1, arg2) { a, b, c -> arg2(Tuple3(a, b, c)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
 )
@@ -195,8 +190,8 @@ fun <A, B, C, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg0, arg1, arg2, arg3, arg4)",
-  "arrow.core.SequenceK.map"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3) { a, b, c, d -> arg2(Tuple4(a, b, c, d)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
 )
@@ -220,8 +215,8 @@ fun <A, B, C, D, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2, arg3, arg4)",
-  "arrow.core.SequenceK.mapN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3) { a, b, c, d -> arg2(Tuple4(a, b, c, d)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
 )
@@ -245,8 +240,8 @@ fun <A, B, C, D, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg0, arg1, arg2, arg3, arg4, arg5)",
-  "arrow.core.SequenceK.map"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg2(Tuple5(a, b, c, d, e)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
 )
@@ -271,8 +266,8 @@ fun <A, B, C, D, E, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2, arg3, arg4, arg5)",
-  "arrow.core.SequenceK.mapN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg2(Tuple5(a, b, c, d, e)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
 )
@@ -297,8 +292,8 @@ fun <A, B, C, D, E, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-  "arrow.core.SequenceK.map"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> arg2(Tuple6(a, b, c, d, e, f)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
 )
@@ -324,8 +319,8 @@ fun <A, B, C, D, E, FF, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-  "arrow.core.SequenceK.mapN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> arg2(Tuple6(a, b, c, d, e, f)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
 )
@@ -351,8 +346,8 @@ fun <A, B, C, D, E, FF, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-  "arrow.core.SequenceK.map"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> arg2(Tuple7(a, b, c, d, e, f, g)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
 )
@@ -380,8 +375,8 @@ fun <A, B, C, D, E, FF, G, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-  "arrow.core.SequenceK.mapN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> arg2(Tuple7(a, b, c, d, e, f, g)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
 )
@@ -409,8 +404,8 @@ fun <A, B, C, D, E, FF, G, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-  "arrow.core.SequenceK.map"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> arg2(Tuple8(a, b, c, d, e, f, g, h)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
 )
@@ -439,8 +434,8 @@ fun <A, B, C, D, E, FF, G, H, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-  "arrow.core.SequenceK.mapN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> arg2(Tuple8(a, b, c, d, e, f, g, h)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
 )
@@ -469,8 +464,8 @@ fun <A, B, C, D, E, FF, G, H, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-  "arrow.core.SequenceK.map"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, f, g, h, i -> arg2(Tuple9(a, b, c, d, e, f, g, h, i)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
 )
@@ -500,8 +495,8 @@ fun <A, B, C, D, E, FF, G, H, I, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-  "arrow.core.SequenceK.mapN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, f, g, h, i -> arg2(Tuple9(a, b, c, d, e, f, g, h, i)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
 )
@@ -531,8 +526,8 @@ fun <A, B, C, D, E, FF, G, H, I, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)",
-  "arrow.core.SequenceK.map"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, f, g, h, i, j -> arg2(Tuple10(a, b, c, d, e, f, g, h, i, j)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
 )
@@ -563,8 +558,8 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)",
-  "arrow.core.SequenceK.mapN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, f, g, h, i, j -> arg2(Tuple10(a, b, c, d, e, f, g, h, i, j)) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
 )
@@ -595,8 +590,7 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map2(arg1, arg2)",
-  "arrow.core.map2"
+    "this.zip(arg1) { a, b -> arg2(Tuple2(a, b)) }"
   ),
   DeprecationLevel.WARNING
 )
@@ -617,8 +611,8 @@ fun <A, B, Z> Kind<ForSequenceK, A>.map2(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.zip(arg1) { a, b -> Tuple2(a, b) }",
+    "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
 )
@@ -637,8 +631,8 @@ fun <A, B> Kind<ForSequenceK, A>.product(arg1: Kind<ForSequenceK, B>): SequenceK
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.zip(arg1) { (a, b), z -> Tuple3(a, b, z) }",
+    "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
 )
@@ -657,8 +651,8 @@ fun <A, B, Z> Kind<ForSequenceK, Tuple2<A, B>>.product(arg1: Kind<ForSequenceK, 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.zip(arg1) { (a, b, c), z -> Tuple4(a, b, c, z) }",
+    "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
 )
@@ -677,8 +671,8 @@ fun <A, B, C, Z> Kind<ForSequenceK, Tuple3<A, B, C>>.product(arg1: Kind<ForSeque
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.zip(arg1) { (a, b, c, d), z -> Tuple5(a, b, c, d, z) }",
+    "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
 )
@@ -698,8 +692,8 @@ fun <A, B, C, D, Z> Kind<ForSequenceK, Tuple4<A, B, C, D>>.product(arg1: Kind<Fo
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.zip(arg1) { (a, b, c, d, e), z -> Tuple6(a, b, c, d, e, z) }",
+    "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
 )
@@ -720,8 +714,8 @@ fun <A, B, C, D, E, Z> Kind<ForSequenceK, Tuple5<A, B, C, D, E>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.zip(arg1) { (a, b, c, d, e, f), z -> Tuple7(a, b, c, d, e, f, z) }",
+    "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
 )
@@ -742,8 +736,8 @@ fun <A, B, C, D, E, FF, Z> Kind<ForSequenceK, Tuple6<A, B, C, D, E,
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.zip(arg1) { (a, b, c, d, e, f, g), z -> Tuple8(a, b, c, d, e, f, g, z) }",
+    "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
 )
@@ -764,8 +758,8 @@ fun <A, B, C, D, E, FF, G, Z> Kind<ForSequenceK, Tuple7<A, B, C, D, E, FF,
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.zip(arg1) { (a, b, c, d, e, f, g, h), z -> Tuple9(a, b, c, d, e, f, g, h, z) }",
+    "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
 )
@@ -786,8 +780,8 @@ fun <A, B, C, D, E, FF, G, H, Z> Kind<ForSequenceK, Tuple8<A, B, C, D, E, FF, G,
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.zip(arg1) { (a, b, c, d, e, f, g, h, i), z -> Tuple10(a, b, c, d, e, f, g, h, i, z) }",
+    "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
 )
@@ -808,8 +802,8 @@ fun <A, B, C, D, E, FF, G, H, I, Z> Kind<ForSequenceK, Tuple9<A, B, C, D, E, FF,
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1)",
-  "arrow.core.SequenceK.tupled"
+    "SequenceK.mapN(arg0, arg1) { a, b -> Tuple2(a, b) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
 )
@@ -828,8 +822,8 @@ fun <A, B> tupled(arg0: Kind<ForSequenceK, A>, arg1: Kind<ForSequenceK, B>): Seq
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1)",
-  "arrow.core.SequenceK.tupledN"
+    "SequenceK.mapN(arg0, arg1) { a, b -> Tuple2(a, b) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
 )
@@ -848,8 +842,8 @@ fun <A, B> tupledN(arg0: Kind<ForSequenceK, A>, arg1: Kind<ForSequenceK, B>): Se
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1, arg2)",
-  "arrow.core.SequenceK.tupled"
+    "SequenceK.mapN(arg0, arg1, arg2) { a, b, c -> Tuple3(a, b, c) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
 )
@@ -871,8 +865,8 @@ fun <A, B, C> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1, arg2)",
-  "arrow.core.SequenceK.tupledN"
+    "SequenceK.mapN(arg0, arg1, arg2) { a, b, c -> Tuple3(a, b, c) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
 )
@@ -894,8 +888,8 @@ fun <A, B, C> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1, arg2, arg3)",
-  "arrow.core.SequenceK.tupled"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
 )
@@ -919,8 +913,8 @@ fun <A, B, C, D> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1, arg2, arg3)",
-  "arrow.core.SequenceK.tupledN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
 )
@@ -944,8 +938,8 @@ fun <A, B, C, D> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1, arg2, arg3, arg4)",
-  "arrow.core.SequenceK.tupled"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
 )
@@ -970,8 +964,8 @@ fun <A, B, C, D, E> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1, arg2, arg3, arg4)",
-  "arrow.core.SequenceK.tupledN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
 )
@@ -996,8 +990,8 @@ fun <A, B, C, D, E> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1, arg2, arg3, arg4, arg5)",
-  "arrow.core.SequenceK.tupled"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> Tuple6(a, b, c, d, e, f) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
 )
@@ -1023,8 +1017,8 @@ fun <A, B, C, D, E, FF> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1, arg2, arg3, arg4, arg5)",
-  "arrow.core.SequenceK.tupledN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> Tuple6(a, b, c, d, e, f) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
 )
@@ -1050,8 +1044,8 @@ fun <A, B, C, D, E, FF> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-  "arrow.core.SequenceK.tupled"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> Tuple7(a, b, c, d, e, f, g) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
 )
@@ -1078,8 +1072,8 @@ fun <A, B, C, D, E, FF, G> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6)",
-  "arrow.core.SequenceK.tupledN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> Tuple7(a, b, c, d, e, f, g) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
 )
@@ -1106,8 +1100,8 @@ fun <A, B, C, D, E, FF, G> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-  "arrow.core.SequenceK.tupled"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> Tuple8(a, b, c, d, e, f, g, h) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
 )
@@ -1135,8 +1129,8 @@ fun <A, B, C, D, E, FF, G, H> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)",
-  "arrow.core.SequenceK.tupledN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> Tuple8(a, b, c, d, e, f, g, h) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
 )
@@ -1164,8 +1158,8 @@ fun <A, B, C, D, E, FF, G, H> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-  "arrow.core.SequenceK.tupled"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, f, g, h, i -> Tuple9(a, b, c, d, e, f, g, h, i) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
 )
@@ -1194,8 +1188,8 @@ fun <A, B, C, D, E, FF, G, H, I> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)",
-  "arrow.core.SequenceK.tupledN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, f, g, h, i -> Tuple9(a, b, c, d, e, f, g, h, i) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
 )
@@ -1224,8 +1218,8 @@ fun <A, B, C, D, E, FF, G, H, I> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupled(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-  "arrow.core.SequenceK.tupled"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, f, g, h, i, j -> Tuple10(a, b, c, d, e, f, g, h, i, j) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
 )
@@ -1256,8 +1250,8 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupledN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)",
-  "arrow.core.SequenceK.tupledN"
+    "SequenceK.mapN(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, f, g, h, i, j -> Tuple10(a, b, c, d, e, f, g, h, i, j) }",
+    "arrow.core.SequenceK", "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
 )
@@ -1288,8 +1282,7 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "followedBy(arg1)",
-  "arrow.core.followedBy"
+    "this.flatMap { arg1 }"
   ),
   DeprecationLevel.WARNING
 )
@@ -1308,8 +1301,8 @@ fun <A, B> Kind<ForSequenceK, A>.followedBy(arg1: Kind<ForSequenceK, B>): Sequen
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "apTap(arg1)",
-  "arrow.core.apTap"
+    "SequenceK.mapN(this, arg1) { left, _ -> left }",
+    "arrow.core.SequenceK"
   ),
   DeprecationLevel.WARNING
 )
@@ -1321,5 +1314,9 @@ fun <A, B> Kind<ForSequenceK, A>.apTap(arg1: Kind<ForSequenceK, B>): SequenceK<A
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Apply typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.apply(): SequenceKApply = apply_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/crosswalk/SequenceKCrosswalk.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/crosswalk/SequenceKCrosswalk.kt
@@ -5,11 +5,6 @@ import arrow.core.ForSequenceK
 import arrow.core.SequenceK.Companion
 import arrow.core.extensions.SequenceKCrosswalk
 import arrow.typeclasses.Align
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -26,12 +21,8 @@ internal val crosswalk_singleton: SequenceKCrosswalk = object :
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "crosswalk(arg0, arg1, arg2)",
-  "arrow.core.SequenceK.crosswalk"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated. Replace with crosswalk, crosswalkMap or crosswalkNull from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <F, A, B> crosswalk(
   arg0: Align<F>,
@@ -49,12 +40,8 @@ fun <F, A, B> crosswalk(
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "sequenceL(arg0, arg1)",
-  "arrow.core.SequenceK.sequenceL"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated. Replace with sequenceEither or sequenceValidated from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <F, A> sequenceL(arg0: Align<F>, arg1: Kind<ForSequenceK, Kind<F, A>>): Kind<F,
     Kind<ForSequenceK, A>> = arrow.core.SequenceK
@@ -64,5 +51,9 @@ fun <F, A> sequenceL(arg0: Align<F>, arg1: Kind<ForSequenceK, Kind<F, A>>): Kind
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Crosswalk typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.crosswalk(): SequenceKCrosswalk = crosswalk_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/eqK/SequenceKEqK.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/eqK/SequenceKEqK.kt
@@ -5,11 +5,6 @@ import arrow.core.ForSequenceK
 import arrow.core.SequenceK.Companion
 import arrow.core.extensions.SequenceKEqK
 import arrow.typeclasses.Eq
-import kotlin.Boolean
-import kotlin.Deprecated
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -25,10 +20,9 @@ internal val eqK_singleton: SequenceKEqK = object : arrow.core.extensions.Sequen
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
+  "Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0",
   ReplaceWith(
-  "eqK(arg1, arg2)",
-  "arrow.core.eqK"
+    "this == arg1"
   ),
   DeprecationLevel.WARNING
 )
@@ -45,12 +39,8 @@ fun <A> Kind<ForSequenceK, A>.eqK(arg1: Kind<ForSequenceK, A>, arg2: Eq<A>): Boo
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "liftEq(arg0)",
-  "arrow.core.SequenceK.liftEq"
-  ),
-  DeprecationLevel.WARNING
+  "Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0",
+  level = DeprecationLevel.WARNING
 )
 fun <A> liftEq(arg0: Eq<A>): Eq<Kind<ForSequenceK, A>> = arrow.core.SequenceK
    .eqK()
@@ -59,5 +49,9 @@ fun <A> liftEq(arg0: Eq<A>): Eq<Kind<ForSequenceK, A>> = arrow.core.SequenceK
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.eqK(): SequenceKEqK = eqK_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/eqK/SequenceKEqK.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/eqK/SequenceKEqK.kt
@@ -22,7 +22,7 @@ internal val eqK_singleton: SequenceKEqK = object : arrow.core.extensions.Sequen
 @Deprecated(
   "Kind/type constructors will be deprecated, so this typeclass will no longer be available from 0.13.0",
   ReplaceWith(
-    "this == arg1"
+    "this.toList() == arg1.toList()"
   ),
   DeprecationLevel.WARNING
 )

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/foldable/SequenceKFoldable.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/foldable/SequenceKFoldable.kt
@@ -227,7 +227,7 @@ fun <A> orEmpty(arg0: Applicative<ForSequenceK>, arg1: Monoid<A>): SequenceK<A> 
 )
 @Deprecated(
   "@extension kinded projected functions are deprecated. Replace with traverseEither_ or traverseValidated_ from arrow.core.*",
-  level= DeprecationLevel.WARNING
+  level = DeprecationLevel.WARNING
 )
 fun <G, A, B> Kind<ForSequenceK, A>.traverse_(arg1: Applicative<G>, arg2: Function1<A, Kind<G, B>>):
     Kind<G, Unit> = arrow.core.SequenceK.foldable().run {
@@ -243,7 +243,7 @@ fun <G, A, B> Kind<ForSequenceK, A>.traverse_(arg1: Applicative<G>, arg2: Functi
 )
 @Deprecated(
   "@extension kinded projected functions are deprecated. Replace with sequenceEither_ or sequenceValidated_ from arrow.core.*",
-  level= DeprecationLevel.WARNING
+  level = DeprecationLevel.WARNING
 )
 fun <G, A> Kind<ForSequenceK, Kind<G, A>>.sequence_(arg1: Applicative<G>): Kind<G, Unit> =
     arrow.core.SequenceK.foldable().run {

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/foldable/SequenceKFoldable.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/foldable/SequenceKFoldable.kt
@@ -10,16 +10,6 @@ import arrow.core.extensions.SequenceKFoldable
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Monad
 import arrow.typeclasses.Monoid
-import kotlin.Boolean
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.Function2
-import kotlin.Long
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.Unit
-import kotlin.collections.List
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -38,8 +28,7 @@ internal val foldable_singleton: SequenceKFoldable = object :
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "foldLeft(arg1, arg2)",
-  "arrow.core.foldLeft"
+    "this.fold(arg1, arg2)"
   ),
   DeprecationLevel.WARNING
 )
@@ -58,8 +47,8 @@ fun <A, B> Kind<ForSequenceK, A>.foldLeft(arg1: B, arg2: Function2<B, A, B>): B 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "foldRight(arg1, arg2)",
-  "arrow.core.foldRight"
+    "this.foldRight(arg1, arg2)",
+    "arrow.core.foldRight"
   ),
   DeprecationLevel.WARNING
 )
@@ -78,8 +67,7 @@ fun <A, B> Kind<ForSequenceK, A>.foldRight(arg1: Eval<B>, arg2: Function2<A, Eva
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "fold(arg1)",
-  "arrow.core.fold"
+    "this.fold(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -97,8 +85,8 @@ fun <A> Kind<ForSequenceK, A>.fold(arg1: Monoid<A>): A = arrow.core.SequenceK.fo
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "reduceLeftToOption(arg1, arg2)",
-  "arrow.core.reduceLeftToOption"
+    "Option.fromNullable(this.reduceOrNull(arg1, arg2))",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -119,8 +107,8 @@ fun <A, B> Kind<ForSequenceK, A>.reduceLeftToOption(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "reduceRightToOption(arg1, arg2)",
-  "arrow.core.reduceRightToOption"
+    "this.reduceRightEvalOrNull(arg1, arg2).map { Option.fromNullable(it) }",
+    "arrow.core.Option", "arrow.core.reduceRightEvalOrNull"
   ),
   DeprecationLevel.WARNING
 )
@@ -142,8 +130,8 @@ fun <A, B> Kind<ForSequenceK, A>.reduceRightToOption(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "reduceLeftOption(arg1)",
-  "arrow.core.reduceLeftOption"
+    "Option.fromNullable(this.reduceOrNull({ it }, arg1))",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -182,8 +170,8 @@ fun <A> Kind<ForSequenceK, A>.reduceRightOption(arg1: Function2<A, Eval<A>, Eval
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "combineAll(arg1)",
-  "arrow.core.combineAll"
+    "this.combineAll(arg1)",
+    "arrow.core.combineAll"
   ),
   DeprecationLevel.WARNING
 )
@@ -201,8 +189,8 @@ fun <A> Kind<ForSequenceK, A>.combineAll(arg1: Monoid<A>): A = arrow.core.Sequen
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "foldMap(arg1, arg2)",
-  "arrow.core.foldMap"
+    "this.foldMap(arg1, arg2)",
+    "arrow.core.foldMap"
   ),
   DeprecationLevel.WARNING
 )
@@ -221,8 +209,7 @@ fun <A, B> Kind<ForSequenceK, A>.foldMap(arg1: Monoid<B>, arg2: Function1<A, B>)
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "orEmpty(arg0, arg1)",
-  "arrow.core.SequenceK.orEmpty"
+    "sequenceOf(arg1.empty())"
   ),
   DeprecationLevel.WARNING
 )
@@ -239,12 +226,8 @@ fun <A> orEmpty(arg0: Applicative<ForSequenceK>, arg1: Monoid<A>): SequenceK<A> 
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "traverse_(arg1, arg2)",
-  "arrow.core.traverse_"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated. Replace with traverseEither_ or traverseValidated_ from arrow.core.*",
+  level= DeprecationLevel.WARNING
 )
 fun <G, A, B> Kind<ForSequenceK, A>.traverse_(arg1: Applicative<G>, arg2: Function1<A, Kind<G, B>>):
     Kind<G, Unit> = arrow.core.SequenceK.foldable().run {
@@ -259,12 +242,8 @@ fun <G, A, B> Kind<ForSequenceK, A>.traverse_(arg1: Applicative<G>, arg2: Functi
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "sequence_(arg1)",
-  "arrow.core.sequence_"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated. Replace with sequenceEither_ or sequenceValidated_ from arrow.core.*",
+  level= DeprecationLevel.WARNING
 )
 fun <G, A> Kind<ForSequenceK, Kind<G, A>>.sequence_(arg1: Applicative<G>): Kind<G, Unit> =
     arrow.core.SequenceK.foldable().run {
@@ -281,8 +260,8 @@ fun <G, A> Kind<ForSequenceK, Kind<G, A>>.sequence_(arg1: Applicative<G>): Kind<
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "find(arg1)",
-  "arrow.core.find"
+    "Option.fromNullable(this.firstOrNull(arg1))",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -301,8 +280,7 @@ fun <A> Kind<ForSequenceK, A>.find(arg1: Function1<A, Boolean>): Option<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "exists(arg1)",
-  "arrow.core.exists"
+    "this.any(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -321,8 +299,7 @@ fun <A> Kind<ForSequenceK, A>.exists(arg1: Function1<A, Boolean>): Boolean =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "forAll(arg1)",
-  "arrow.core.forAll"
+    "this.all(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -341,8 +318,7 @@ fun <A> Kind<ForSequenceK, A>.forAll(arg1: Function1<A, Boolean>): Boolean =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "all(arg1)",
-  "arrow.core.all"
+    "this.all(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -361,8 +337,7 @@ fun <A> Kind<ForSequenceK, A>.all(arg1: Function1<A, Boolean>): Boolean =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "isEmpty()",
-  "arrow.core.isEmpty"
+    "this.none()"
   ),
   DeprecationLevel.WARNING
 )
@@ -380,8 +355,7 @@ fun <A> Kind<ForSequenceK, A>.isEmpty(): Boolean = arrow.core.SequenceK.foldable
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "nonEmpty()",
-  "arrow.core.nonEmpty"
+    "this.any()"
   ),
   DeprecationLevel.WARNING
 )
@@ -399,8 +373,7 @@ fun <A> Kind<ForSequenceK, A>.nonEmpty(): Boolean = arrow.core.SequenceK.foldabl
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "isNotEmpty()",
-  "arrow.core.isNotEmpty"
+    "this.any()"
   ),
   DeprecationLevel.WARNING
 )
@@ -418,8 +391,7 @@ fun <A> Kind<ForSequenceK, A>.isNotEmpty(): Boolean = arrow.core.SequenceK.folda
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "size(arg1)",
-  "arrow.core.size"
+    "this.count()"
   ),
   DeprecationLevel.WARNING
 )
@@ -435,12 +407,8 @@ fun <A> Kind<ForSequenceK, A>.size(arg1: Monoid<Long>): Long = arrow.core.Sequen
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "foldMapA(arg1, arg2, arg3)",
-  "arrow.core.foldMapA"
-  ),
-  DeprecationLevel.WARNING
+  "Applicative typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 fun <G, A, B, AP : Applicative<G>, MO : Monoid<B>> Kind<ForSequenceK, A>.foldMapA(
   arg1: AP,
@@ -458,12 +426,8 @@ fun <G, A, B, AP : Applicative<G>, MO : Monoid<B>> Kind<ForSequenceK, A>.foldMap
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "foldMapM(arg1, arg2, arg3)",
-  "arrow.core.foldMapM"
-  ),
-  DeprecationLevel.WARNING
+  "Monad typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 fun <G, A, B, MA : Monad<G>, MO : Monoid<B>> Kind<ForSequenceK, A>.foldMapM(
   arg1: MA,
@@ -481,12 +445,8 @@ fun <G, A, B, MA : Monad<G>, MO : Monoid<B>> Kind<ForSequenceK, A>.foldMapM(
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "foldM(arg1, arg2, arg3)",
-  "arrow.core.foldM"
-  ),
-  DeprecationLevel.WARNING
+  "Monad typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 fun <G, A, B> Kind<ForSequenceK, A>.foldM(
   arg1: Monad<G>,
@@ -506,8 +466,8 @@ fun <G, A, B> Kind<ForSequenceK, A>.foldM(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "get(arg1)",
-  "arrow.core.get"
+    "Option.fromNullable(this.elementAtOrNull(arg1))",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -525,8 +485,8 @@ fun <A> Kind<ForSequenceK, A>.get(arg1: Long): Option<A> = arrow.core.SequenceK.
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "firstOption()",
-  "arrow.core.firstOption"
+    "Option.fromNullable(this.firstOrNull())",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -544,8 +504,8 @@ fun <A> Kind<ForSequenceK, A>.firstOption(): Option<A> = arrow.core.SequenceK.fo
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "firstOption(arg1)",
-  "arrow.core.firstOption"
+    "Option.fromNullable(this.firstOrNull(arg1))",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -564,8 +524,8 @@ fun <A> Kind<ForSequenceK, A>.firstOption(arg1: Function1<A, Boolean>): Option<A
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "firstOrNone()",
-  "arrow.core.firstOrNone"
+    "Option.fromNullable(this.firstOrNull())",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -583,8 +543,8 @@ fun <A> Kind<ForSequenceK, A>.firstOrNone(): Option<A> = arrow.core.SequenceK.fo
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "firstOrNone(arg1)",
-  "arrow.core.firstOrNone"
+    "Option.fromNullable(this.firstOrNull(arg1))",
+    "arrow.core.Option"
   ),
   DeprecationLevel.WARNING
 )
@@ -603,8 +563,7 @@ fun <A> Kind<ForSequenceK, A>.firstOrNone(arg1: Function1<A, Boolean>): Option<A
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "toList()",
-  "arrow.core.toList"
+    "this.toList()"
   ),
   DeprecationLevel.WARNING
 )
@@ -615,5 +574,9 @@ fun <A> Kind<ForSequenceK, A>.toList(): List<A> = arrow.core.SequenceK.foldable(
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Foldable typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.foldable(): SequenceKFoldable = foldable_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/functor/SequenceKFunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/functor/SequenceKFunctor.kt
@@ -142,12 +142,8 @@ fun <A> Kind<ForSequenceK, A>.void(): SequenceK<Unit> = arrow.core.SequenceK.fun
  *  Kind<F, A> -> Kind<F, Tuple2<A, B>>
  *
  *  ```kotlin:ank:playground
- *  import arrow.core.*
- * import arrow.core.extensions.sequencek.functor.*
- * import arrow.core.*
- *
- *
  *  import arrow.core.extensions.sequencek.applicative.just
+ *  import arrow.core.fproduct
  *
  *  fun main(args: Array<String>) {
  *   val result =
@@ -184,12 +180,8 @@ fun <A, B> Kind<ForSequenceK, A>.fproduct(arg1: Function1<A, B>): SequenceK<Tupl
  *  Kind<F, A> -> Kind<F, B>
  *
  *  ```kotlin:ank:playground
- *  import arrow.core.*
- * import arrow.core.extensions.sequencek.functor.*
- * import arrow.core.*
- *
- *
  *  import arrow.core.extensions.sequencek.applicative.just
+ *  import arrow.core.mapConst
  *
  *  fun main(args: Array<String>) {
  *   val result =
@@ -249,12 +241,8 @@ fun <A, B> A.mapConst(arg1: Kind<ForSequenceK, B>): SequenceK<A> =
  *  Kind<F, A> -> Kind<F, Tuple2<B, A>>
  *
  *  ```kotlin:ank:playground
- *  import arrow.core.*
- * import arrow.core.extensions.sequencek.functor.*
- * import arrow.core.*
- *
- *
  *  import arrow.core.extensions.sequencek.applicative.just
+ *  import arrow.core.tupleLeft
  *
  *  fun main(args: Array<String>) {
  *   val result =
@@ -291,12 +279,8 @@ fun <A, B> Kind<ForSequenceK, A>.tupleLeft(arg1: B): SequenceK<Tuple2<B, A>> =
  *  Kind<F, A> -> Kind<F, Tuple2<A, B>>
  *
  *  ```kotlin:ank:playground
- *  import arrow.core.*
- * import arrow.core.extensions.sequencek.functor.*
- * import arrow.core.*
- *
- *
  *  import arrow.core.extensions.sequencek.applicative.just
+ *  import arrow.core.tupleRight
  *
  *  fun main(args: Array<String>) {
  *   val result =
@@ -333,18 +317,15 @@ fun <A, B> Kind<ForSequenceK, A>.tupleRight(arg1: B): SequenceK<Tuple2<A, B>> =
  *  Kind<F, A> -> Kind<F, B>
  *
  *  ```kotlin:ank:playground
- *  import arrow.core.*
- * import arrow.core.extensions.sequencek.functor.*
- * import arrow.core.*
- *
- *
- *  import arrow.core.extensions.sequencek.applicative.just
  *  import arrow.Kind
+ *  import arrow.core.extensions.sequencek.applicative.just
+ *  import arrow.core.k
+ *  import arrow.core.widen
  *
  *  fun main(args: Array<String>) {
  *   val result: Kind<*, CharSequence> =
  *   //sampleStart
- *   "Hello".just().map({ "$it World" }).widen()
+ *   "Hello".just().map { "$it World" }.widen().k()
  *   //sampleEnd
  *   println(result)
  *  }

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/functor/SequenceKFunctor.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/functor/SequenceKFunctor.kt
@@ -6,12 +6,6 @@ import arrow.core.SequenceK
 import arrow.core.SequenceK.Companion
 import arrow.core.Tuple2
 import arrow.core.extensions.SequenceKFunctor
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.Unit
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -51,8 +45,7 @@ internal val functor_singleton: SequenceKFunctor = object : arrow.core.extension
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg1)",
-  "arrow.core.map"
+    "this.map(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -71,8 +64,7 @@ fun <A, B> Kind<ForSequenceK, A>.map(arg1: Function1<A, B>): SequenceK<B> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "imap(arg1, arg2)",
-  "arrow.core.imap"
+    "this.map(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -114,8 +106,7 @@ fun <A, B> Kind<ForSequenceK, A>.imap(arg1: Function1<A, B>, arg2: Function1<B, 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "lift(arg0)",
-  "arrow.core.SequenceK.lift"
+    "{ s: Sequence<A> -> s.map(arg0) }"
   ),
   DeprecationLevel.WARNING
 )
@@ -135,8 +126,8 @@ fun <A, B> lift(arg0: Function1<A, B>): Function1<Kind<ForSequenceK, A>, Kind<Fo
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "void()",
-  "arrow.core.void"
+    "this.void()",
+    "arrow.core.void"
   ),
   DeprecationLevel.WARNING
 )
@@ -177,8 +168,8 @@ fun <A> Kind<ForSequenceK, A>.void(): SequenceK<Unit> = arrow.core.SequenceK.fun
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "fproduct(arg1)",
-  "arrow.core.fproduct"
+    "this.fproduct(arg1)",
+    "arrow.core.fproduct"
   ),
   DeprecationLevel.WARNING
 )
@@ -219,8 +210,8 @@ fun <A, B> Kind<ForSequenceK, A>.fproduct(arg1: Function1<A, B>): SequenceK<Tupl
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapConst(arg1)",
-  "arrow.core.mapConst"
+    "this.mapConst(arg1)",
+    "arrow.core.mapConst"
   ),
   DeprecationLevel.WARNING
 )
@@ -242,8 +233,8 @@ fun <A, B> Kind<ForSequenceK, A>.mapConst(arg1: B): SequenceK<B> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mapConst(arg1)",
-  "arrow.core.mapConst"
+    "arg1.mapConst(this)",
+    "arrow.core.mapConst"
   ),
   DeprecationLevel.WARNING
 )
@@ -284,8 +275,8 @@ fun <A, B> A.mapConst(arg1: Kind<ForSequenceK, B>): SequenceK<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupleLeft(arg1)",
-  "arrow.core.tupleLeft"
+    "this.tupleLeft(arg1)",
+    "arrow.core.tupleLeft"
   ),
   DeprecationLevel.WARNING
 )
@@ -326,8 +317,8 @@ fun <A, B> Kind<ForSequenceK, A>.tupleLeft(arg1: B): SequenceK<Tuple2<B, A>> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tupleRight(arg1)",
-  "arrow.core.tupleRight"
+    "this.tupleRight(arg1)",
+    "arrow.core.tupleRight"
   ),
   DeprecationLevel.WARNING
 )
@@ -369,8 +360,8 @@ fun <A, B> Kind<ForSequenceK, A>.tupleRight(arg1: B): SequenceK<Tuple2<A, B>> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "widen()",
-  "arrow.core.widen"
+    "this.widen()",
+    "arrow.core.widen"
   ),
   DeprecationLevel.WARNING
 )
@@ -381,5 +372,9 @@ fun <B, A : B> Kind<ForSequenceK, A>.widen(): SequenceK<B> = arrow.core.Sequence
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Functor typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.functor(): SequenceKFunctor = functor_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/functorFilter/SequenceKFunctorFilter.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/functorFilter/SequenceKFunctorFilter.kt
@@ -6,13 +6,6 @@ import arrow.core.Option
 import arrow.core.SequenceK
 import arrow.core.SequenceK.Companion
 import arrow.core.extensions.SequenceKFunctorFilter
-import java.lang.Class
-import kotlin.Boolean
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -31,8 +24,7 @@ internal val functorFilter_singleton: SequenceKFunctorFilter = object :
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "filterMap(arg1)",
-  "arrow.core.filterMap"
+    "this.mapNotNull { arg1(it).orNull() }"
   ),
   DeprecationLevel.WARNING
 )
@@ -51,8 +43,7 @@ fun <A, B> Kind<ForSequenceK, A>.filterMap(arg1: Function1<A, Option<B>>): Seque
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "flattenOption()",
-  "arrow.core.flattenOption"
+    "this.mapNotNull { it.orNull() }"
   ),
   DeprecationLevel.WARNING
 )
@@ -71,8 +62,7 @@ fun <A> Kind<ForSequenceK, Option<A>>.flattenOption(): SequenceK<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "filter(arg1)",
-  "arrow.core.filter"
+    "this.filter(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -91,8 +81,7 @@ fun <A> Kind<ForSequenceK, A>.filter(arg1: Function1<A, Boolean>): SequenceK<A> 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "filterIsInstance(arg1)",
-  "arrow.core.filterIsInstance"
+    "this.filterIsInstance<B>()"
   ),
   DeprecationLevel.WARNING
 )
@@ -104,5 +93,9 @@ fun <A, B> Kind<ForSequenceK, A>.filterIsInstance(arg1: Class<B>): SequenceK<B> 
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "FunctorFilter typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.functorFilter(): SequenceKFunctorFilter = functorFilter_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/monad/SequenceKMonad.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/monad/SequenceKMonad.kt
@@ -8,13 +8,6 @@ import arrow.core.SequenceK
 import arrow.core.SequenceK.Companion
 import arrow.core.Tuple2
 import arrow.core.extensions.SequenceKMonad
-import kotlin.Boolean
-import kotlin.Deprecated
-import kotlin.Function0
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -32,8 +25,7 @@ internal val monad_singleton: SequenceKMonad = object : arrow.core.extensions.Se
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "flatMap(arg1)",
-  "arrow.core.flatMap"
+    "this.flatMap(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -52,8 +44,8 @@ fun <A, B> Kind<ForSequenceK, A>.flatMap(arg1: Function1<A, Kind<ForSequenceK, B
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "tailRecM(arg0, arg1)",
-  "arrow.core.SequenceK.tailRecM"
+    "SequenceK.tailRecM(arg0, arg1)",
+    "arrow.core.SequenceK"
   ),
   DeprecationLevel.WARNING
 )
@@ -72,8 +64,7 @@ fun <A, B> tailRecM(arg0: A, arg1: Function1<A, Kind<ForSequenceK, Either<A, B>>
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg1)",
-  "arrow.core.map"
+    "this.map(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -95,8 +86,8 @@ fun <A, B> Kind<ForSequenceK, A>.map(arg1: Function1<A, B>): SequenceK<B> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "ap(arg1)",
-  "arrow.core.ap"
+    "this.ap(arg1)",
+    "arrow.core.ap"
   ),
   DeprecationLevel.WARNING
 )
@@ -115,8 +106,8 @@ fun <A, B> Kind<ForSequenceK, A>.ap(arg1: Kind<ForSequenceK, Function1<A, B>>): 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "flatten()",
-  "arrow.core.flatten"
+    "this.flatten()",
+    "arrow.core.flatten"
   ),
   DeprecationLevel.WARNING
 )
@@ -135,8 +126,7 @@ fun <A> Kind<ForSequenceK, Kind<ForSequenceK, A>>.flatten(): SequenceK<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "followedBy(arg1)",
-  "arrow.core.followedBy"
+    "this.flatMap { arg1 }"
   ),
   DeprecationLevel.WARNING
 )
@@ -155,8 +145,7 @@ fun <A, B> Kind<ForSequenceK, A>.followedBy(arg1: Kind<ForSequenceK, B>): Sequen
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "apTap(arg1)",
-  "arrow.core.apTap"
+    "this.flatMap { a -> arg1.map { a } }"
   ),
   DeprecationLevel.WARNING
 )
@@ -175,8 +164,7 @@ fun <A, B> Kind<ForSequenceK, A>.apTap(arg1: Kind<ForSequenceK, B>): SequenceK<A
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "followedByEval(arg1)",
-  "arrow.core.followedByEval"
+    "this.flatMap { arg1.value() }"
   ),
   DeprecationLevel.WARNING
 )
@@ -195,8 +183,7 @@ fun <A, B> Kind<ForSequenceK, A>.followedByEval(arg1: Eval<Kind<ForSequenceK, B>
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "effectM(arg1)",
-  "arrow.core.effectM"
+    "this.flatMap { a -> arg1(a).map { a } }"
   ),
   DeprecationLevel.WARNING
 )
@@ -215,8 +202,7 @@ fun <A, B> Kind<ForSequenceK, A>.effectM(arg1: Function1<A, Kind<ForSequenceK, B
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "flatTap(arg1)",
-  "arrow.core.flatTap"
+    "this.flatMap { a -> arg1(a).map { a } }"
   ),
   DeprecationLevel.WARNING
 )
@@ -235,8 +221,7 @@ fun <A, B> Kind<ForSequenceK, A>.flatTap(arg1: Function1<A, Kind<ForSequenceK, B
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "productL(arg1)",
-  "arrow.core.productL"
+    "this.flatMap { a -> arg1.map { a } }"
   ),
   DeprecationLevel.WARNING
 )
@@ -255,8 +240,7 @@ fun <A, B> Kind<ForSequenceK, A>.productL(arg1: Kind<ForSequenceK, B>): Sequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "forEffect(arg1)",
-  "arrow.core.forEffect"
+    "this.flatMap { a -> arg1.map { a } }"
   ),
   DeprecationLevel.WARNING
 )
@@ -275,8 +259,7 @@ fun <A, B> Kind<ForSequenceK, A>.forEffect(arg1: Kind<ForSequenceK, B>): Sequenc
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "productLEval(arg1)",
-  "arrow.core.productLEval"
+    "this.flatMap { a -> arg1.value().map { a } }"
   ),
   DeprecationLevel.WARNING
 )
@@ -295,8 +278,7 @@ fun <A, B> Kind<ForSequenceK, A>.productLEval(arg1: Eval<Kind<ForSequenceK, B>>)
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "forEffectEval(arg1)",
-  "arrow.core.forEffectEval"
+    "this.flatMap { a -> arg1.value().map { a } }"
   ),
   DeprecationLevel.WARNING
 )
@@ -315,8 +297,8 @@ fun <A, B> Kind<ForSequenceK, A>.forEffectEval(arg1: Eval<Kind<ForSequenceK, B>>
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "mproduct(arg1)",
-  "arrow.core.mproduct"
+    "this.flatMap { a -> arg1(a).map { b -> Tuple2(a, b) } }",
+    "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
 )
@@ -335,8 +317,8 @@ fun <A, B> Kind<ForSequenceK, A>.mproduct(arg1: Function1<A, Kind<ForSequenceK, 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "ifM(arg1, arg2)",
-  "arrow.core.ifM"
+    "this.ifM(arg1, arg2)",
+    "arrow.core.ifM"
   ),
   DeprecationLevel.WARNING
 )
@@ -357,8 +339,8 @@ fun <B> Kind<ForSequenceK, Boolean>.ifM(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "selectM(arg1)",
-  "arrow.core.selectM"
+    "this.selectM(arg1)",
+    "arrow.core.selectM"
   ),
   DeprecationLevel.WARNING
 )
@@ -377,8 +359,8 @@ fun <A, B> Kind<ForSequenceK, Either<A, B>>.selectM(arg1: Kind<ForSequenceK, Fun
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "select(arg1)",
-  "arrow.core.select"
+    "this.selectM(arg1)",
+    "arrow.core.selectM"
   ),
   DeprecationLevel.WARNING
 )
@@ -401,5 +383,9 @@ fun <A, B> Kind<ForSequenceK, Either<A, B>>.select(arg1: Kind<ForSequenceK, Func
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Monad typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.monad(): SequenceKMonad = monad_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/monadCombine/SequenceKMonadCombine.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/monadCombine/SequenceKMonadCombine.kt
@@ -8,10 +8,6 @@ import arrow.core.Tuple2
 import arrow.core.extensions.SequenceKMonadCombine
 import arrow.typeclasses.Bifoldable
 import arrow.typeclasses.Foldable
-import kotlin.Deprecated
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -28,12 +24,8 @@ internal val monadCombine_singleton: SequenceKMonadCombine = object :
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "unite(arg1)",
-  "arrow.core.unite"
-  ),
-  DeprecationLevel.WARNING
+  "Foldable typeclass is deprecated. Replace with uniteEither or uniteValidated from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <G, A> Kind<ForSequenceK, Kind<G, A>>.unite(arg1: Foldable<G>): SequenceK<A> =
     arrow.core.SequenceK.monadCombine().run {
@@ -48,12 +40,8 @@ fun <G, A> Kind<ForSequenceK, Kind<G, A>>.unite(arg1: Foldable<G>): SequenceK<A>
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "separate(arg1)",
-  "arrow.core.separate"
-  ),
-  DeprecationLevel.WARNING
+  "Bifoldable typeclass is deprecated. Replace with separateEither or separateValidated from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <G, A, B> Kind<ForSequenceK, Kind<Kind<G, A>, B>>.separate(arg1: Bifoldable<G>):
     Tuple2<Kind<ForSequenceK, A>, Kind<ForSequenceK, B>> = arrow.core.SequenceK.monadCombine().run {
@@ -64,5 +52,9 @@ fun <G, A, B> Kind<ForSequenceK, Kind<Kind<G, A>, B>>.separate(arg1: Bifoldable<
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "MonadCombine typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.monadCombine(): SequenceKMonadCombine = monadCombine_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/monadFilter/SequenceKMonadFilter.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/monadFilter/SequenceKMonadFilter.kt
@@ -7,11 +7,6 @@ import arrow.core.SequenceK
 import arrow.core.SequenceK.Companion
 import arrow.core.extensions.SequenceKMonadFilter
 import arrow.typeclasses.MonadFilterSyntax
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -30,8 +25,7 @@ internal val monadFilter_singleton: SequenceKMonadFilter = object :
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "filterMap(arg1)",
-  "arrow.core.filterMap"
+    "this.mapNotNull { arg1(it).orNull() }"
   ),
   DeprecationLevel.WARNING
 )
@@ -48,12 +42,8 @@ fun <A, B> Kind<ForSequenceK, A>.filterMap(arg1: Function1<A, Option<B>>): Seque
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "bindingFilter(arg0)",
-  "arrow.core.SequenceK.bindingFilter"
-  ),
-  DeprecationLevel.WARNING
+  "Monad bindings are deprecated",
+  level = DeprecationLevel.WARNING
 )
 fun <B> bindingFilter(arg0: suspend MonadFilterSyntax<ForSequenceK>.() -> B): SequenceK<B> =
     arrow.core.SequenceK
@@ -63,5 +53,9 @@ fun <B> bindingFilter(arg0: suspend MonadFilterSyntax<ForSequenceK>.() -> B): Se
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "MonadFilter typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.monadFilter(): SequenceKMonadFilter = monadFilter_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/monadLogic/SequenceKMonadLogic.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/monadLogic/SequenceKMonadLogic.kt
@@ -7,12 +7,6 @@ import arrow.core.SequenceK
 import arrow.core.SequenceK.Companion
 import arrow.core.Tuple2
 import arrow.core.extensions.SequenceKMonadLogic
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.Unit
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -31,8 +25,8 @@ internal val monadLogic_singleton: SequenceKMonadLogic = object :
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "splitM()",
-  "arrow.core.splitM"
+    "this.split()",
+    "arrow.core.split"
   ),
   DeprecationLevel.WARNING
 )
@@ -53,8 +47,8 @@ fun <A> Kind<ForSequenceK, A>.splitM(): SequenceK<Option<Tuple2<Kind<ForSequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "interleave(arg1)",
-  "arrow.core.interleave"
+    "this.interleave(arg1)",
+    "arrow.core.interleave"
   ),
   DeprecationLevel.WARNING
 )
@@ -73,8 +67,8 @@ fun <A> Kind<ForSequenceK, A>.interleave(arg1: Kind<ForSequenceK, A>): SequenceK
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "unweave(arg1)",
-  "arrow.core.unweave"
+    "this.unweave(arg1)",
+    "arrow.core.unweave"
   ),
   DeprecationLevel.WARNING
 )
@@ -93,8 +87,8 @@ fun <A, B> Kind<ForSequenceK, A>.unweave(arg1: Function1<A, Kind<ForSequenceK, B
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "ifThen(arg1, arg2)",
-  "arrow.core.ifThen"
+    "this.ifThen(arg1, arg2)",
+    "arrow.core.ifThen"
   ),
   DeprecationLevel.WARNING
 )
@@ -115,8 +109,8 @@ fun <A, B> Kind<ForSequenceK, A>.ifThen(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "once()",
-  "arrow.core.once"
+    "this.once()",
+    "arrow.core.once"
   ),
   DeprecationLevel.WARNING
 )
@@ -134,8 +128,7 @@ fun <A> Kind<ForSequenceK, A>.once(): SequenceK<A> = arrow.core.SequenceK.monadL
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "voidIfValue()",
-  "arrow.core.voidIfValue"
+    "this.firstOrNull()?.let { emptySequence() } ?: sequenceOf(Unit)"
   ),
   DeprecationLevel.WARNING
 )
@@ -147,5 +140,9 @@ fun <A> Kind<ForSequenceK, A>.voidIfValue(): SequenceK<Unit> =
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "MonadLogic typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.monadLogic(): SequenceKMonadLogic = monadLogic_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/monadPlus/SequenceKMonadPlus.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/monadPlus/SequenceKMonadPlus.kt
@@ -5,10 +5,6 @@ import arrow.core.ForSequenceK
 import arrow.core.SequenceK
 import arrow.core.SequenceK.Companion
 import arrow.core.extensions.SequenceKMonadPlus
-import kotlin.Deprecated
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -27,8 +23,7 @@ internal val monadPlus_singleton: SequenceKMonadPlus = object :
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "zeroM()",
-  "arrow.core.SequenceK.zeroM"
+    "emptySequence<A>()"
   ),
   DeprecationLevel.WARNING
 )
@@ -46,8 +41,7 @@ fun <A> zeroM(): SequenceK<A> = arrow.core.SequenceK
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "plusM(arg1)",
-  "arrow.core.plusM"
+    "this + arg1"
   ),
   DeprecationLevel.WARNING
 )
@@ -59,5 +53,9 @@ fun <A> Kind<ForSequenceK, A>.plusM(arg1: Kind<ForSequenceK, A>): SequenceK<A> =
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "MonadPlus typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.monadPlus(): SequenceKMonadPlus = monadPlus_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/monoid/SequenceKMonoid.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/monoid/SequenceKMonoid.kt
@@ -3,13 +3,6 @@ package arrow.core.extensions.sequencek.monoid
 import arrow.core.SequenceK
 import arrow.core.SequenceK.Companion
 import arrow.core.extensions.SequenceKMonoid
-import kotlin.Any
-import kotlin.Deprecated
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.collections.Collection
-import kotlin.collections.List
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -27,8 +20,7 @@ internal val monoid_singleton: SequenceKMonoid<Any?> = object : SequenceKMonoid<
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "combineAll()",
-  "arrow.core.combineAll"
+    "this.fold(emptySequence()) { acc, l -> acc + l }"
   ),
   DeprecationLevel.WARNING
 )
@@ -46,8 +38,7 @@ fun <A> Collection<SequenceK<A>>.combineAll(): SequenceK<A> = arrow.core.Sequenc
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "combineAll(arg0)",
-  "arrow.core.SequenceK.combineAll"
+    "arg0.fold(emptySequence()) { acc, l -> acc + l }"
   ),
   DeprecationLevel.WARNING
 )
@@ -58,6 +49,10 @@ fun <A> combineAll(arg0: List<SequenceK<A>>): SequenceK<A> = arrow.core.Sequence
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Monoid typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 inline fun <A> Companion.monoid(): SequenceKMonoid<A> = monoid_singleton as
     arrow.core.extensions.SequenceKMonoid<A>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/monoid/SequenceKMonoid.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/monoid/SequenceKMonoid.kt
@@ -51,7 +51,8 @@ fun <A> combineAll(arg0: List<SequenceK<A>>): SequenceK<A> = arrow.core.Sequence
   "NOTHING_TO_INLINE"
 )
 @Deprecated(
-  "Monoid typeclass is deprecated. Use concrete methods on Sequence",
+  "@extension kinded projected functions are deprecated",
+  ReplaceWith("Monoid.sequence<A>()", "arrow.core.sequence", "arrow.typeclasses.Monoid"),
   level = DeprecationLevel.WARNING
 )
 inline fun <A> Companion.monoid(): SequenceKMonoid<A> = monoid_singleton as

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/monoidK/SequenceKMonoidK.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/monoidK/SequenceKMonoidK.kt
@@ -5,10 +5,6 @@ import arrow.core.ForSequenceK
 import arrow.core.SequenceK.Companion
 import arrow.core.extensions.SequenceKMonoidK
 import arrow.typeclasses.Monoid
-import kotlin.Deprecated
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -27,8 +23,8 @@ internal val monoidK_singleton: SequenceKMonoidK = object : arrow.core.extension
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "algebra()",
-  "arrow.core.SequenceK.algebra"
+    "Monoid.sequence<A>()",
+    "arrow.core.sequence", "arrow.typeclasses.Monoid"
   ),
   DeprecationLevel.WARNING
 )
@@ -39,5 +35,9 @@ fun <A> algebra(): Monoid<Kind<ForSequenceK, A>> = arrow.core.SequenceK
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "MonoidK typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.monoidK(): SequenceKMonoidK = monoidK_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/monoidal/SequenceKMonoidal.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/monoidal/SequenceKMonoidal.kt
@@ -3,10 +3,6 @@ package arrow.core.extensions.sequencek.monoidal
 import arrow.core.SequenceK
 import arrow.core.SequenceK.Companion
 import arrow.core.extensions.SequenceKMonoidal
-import kotlin.Deprecated
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -25,8 +21,7 @@ internal val monoidal_singleton: SequenceKMonoidal = object :
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "identity()",
-  "arrow.core.SequenceK.identity"
+    "emptySequence<A>()"
   ),
   DeprecationLevel.WARNING
 )
@@ -37,5 +32,9 @@ fun <A> identity(): SequenceK<A> = arrow.core.SequenceK
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Monoidal typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.monoidal(): SequenceKMonoidal = monoidal_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/repeat/SequenceKRepeat.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/repeat/SequenceKRepeat.kt
@@ -3,10 +3,6 @@ package arrow.core.extensions.sequencek.repeat
 import arrow.core.SequenceK
 import arrow.core.SequenceK.Companion
 import arrow.core.extensions.SequenceKRepeat
-import kotlin.Deprecated
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -24,8 +20,7 @@ internal val repeat_singleton: SequenceKRepeat = object : arrow.core.extensions.
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "repeat(a)",
-  "arrow.core.SequenceK.repeat"
+    "generateSequence { a }"
   ),
   DeprecationLevel.WARNING
 )
@@ -36,5 +31,9 @@ fun <A> repeat(a: A): SequenceK<A> = arrow.core.SequenceK
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Repeat typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.repeat(): SequenceKRepeat = repeat_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/semialign/SequenceKSemialign.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/semialign/SequenceKSemialign.kt
@@ -9,12 +9,6 @@ import arrow.core.SequenceK.Companion
 import arrow.core.Tuple2
 import arrow.core.extensions.SequenceKSemialign
 import arrow.typeclasses.Semigroup
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.Function2
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -33,8 +27,8 @@ internal val semialign_singleton: SequenceKSemialign = object :
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "align(arg0, arg1)",
-  "arrow.core.SequenceK.align"
+    "arg0.align(arg1)",
+    "arrow.core.align"
   ),
   DeprecationLevel.WARNING
 )
@@ -53,8 +47,8 @@ fun <A, B> align(arg0: Kind<ForSequenceK, A>, arg1: Kind<ForSequenceK, B>): Sequ
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "alignWith(arg0, arg1, arg2)",
-  "arrow.core.SequenceK.alignWith"
+    "arg0.align(arg1, arg2)",
+    "arrow.core.align"
   ),
   DeprecationLevel.WARNING
 )
@@ -76,8 +70,8 @@ fun <A, B, C> alignWith(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "salign(arg1, arg2)",
-  "arrow.core.salign"
+    "this.align(arg1, arg2)",
+    "arrow.core.align"
   ),
   DeprecationLevel.WARNING
 )
@@ -96,8 +90,8 @@ fun <A> Kind<ForSequenceK, A>.salign(arg1: Semigroup<A>, arg2: Kind<ForSequenceK
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "padZip(arg1)",
-  "arrow.core.padZip"
+    "this.padZip(arg1)",
+    "arrow.core.padZip"
   ),
   DeprecationLevel.WARNING
 )
@@ -117,8 +111,8 @@ fun <A, B> Kind<ForSequenceK, A>.padZip(arg1: Kind<ForSequenceK, B>): SequenceK<
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "padZipWith(arg1, arg2)",
-  "arrow.core.padZipWith"
+    "this.padZip(arg1, arg2)",
+    "arrow.core.padZip"
   ),
   DeprecationLevel.WARNING
 )
@@ -132,5 +126,9 @@ fun <A, B, C> Kind<ForSequenceK, A>.padZipWith(
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Semialign typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.semialign(): SequenceKSemialign = semialign_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/semigroup/SequenceKSemigroup.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/semigroup/SequenceKSemigroup.kt
@@ -3,11 +3,6 @@ package arrow.core.extensions.sequencek.semigroup
 import arrow.core.SequenceK
 import arrow.core.SequenceK.Companion
 import arrow.core.extensions.SequenceKSemigroup
-import kotlin.Any
-import kotlin.Deprecated
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -25,8 +20,7 @@ internal val semigroup_singleton: SequenceKSemigroup<Any?> = object : SequenceKS
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "plus(arg1)",
-  "arrow.core.plus"
+    "this + arg1"
   ),
   DeprecationLevel.WARNING
 )
@@ -45,8 +39,7 @@ operator fun <A> SequenceK<A>.plus(arg1: SequenceK<A>): SequenceK<A> =
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "maybeCombine(arg1)",
-  "arrow.core.maybeCombine"
+    "(arg1?.plus(this) ?: emptySequence<A>())"
   ),
   DeprecationLevel.WARNING
 )
@@ -58,6 +51,14 @@ fun <A> SequenceK<A>.maybeCombine(arg1: SequenceK<A>): SequenceK<A> =
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "@extension projected functions are deprecated",
+  ReplaceWith(
+    "Semigroup.sequence<A>()",
+    "arrow.core.sequence", "arrow.typeclasses.Semigroup"
+  ),
+  DeprecationLevel.WARNING
 )
 inline fun <A> Companion.semigroup(): SequenceKSemigroup<A> = semigroup_singleton as
     arrow.core.extensions.SequenceKSemigroup<A>

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/semigroupK/SequenceKSemigroupK.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/semigroupK/SequenceKSemigroupK.kt
@@ -6,10 +6,6 @@ import arrow.core.SequenceK
 import arrow.core.SequenceK.Companion
 import arrow.core.extensions.SequenceKSemigroupK
 import arrow.typeclasses.Semigroup
-import kotlin.Deprecated
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -28,8 +24,7 @@ internal val semigroupK_singleton: SequenceKSemigroupK = object :
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "combineK(arg1)",
-  "arrow.core.combineK"
+    "this + arg1"
   ),
   DeprecationLevel.WARNING
 )
@@ -48,8 +43,8 @@ fun <A> Kind<ForSequenceK, A>.combineK(arg1: Kind<ForSequenceK, A>): SequenceK<A
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "algebra()",
-  "arrow.core.SequenceK.algebra"
+    "Semigroup.sequence<A>()",
+    "arrow.core.sequence", "arrow.typeclasses.Semigroup"
   ),
   DeprecationLevel.WARNING
 )
@@ -60,5 +55,9 @@ fun <A> algebra(): Semigroup<Kind<ForSequenceK, A>> = arrow.core.SequenceK
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "SemigroupK typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.semigroupK(): SequenceKSemigroupK = semigroupK_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/semigroupal/SequenceKSemigroupal.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/semigroupal/SequenceKSemigroupal.kt
@@ -6,10 +6,6 @@ import arrow.core.SequenceK
 import arrow.core.SequenceK.Companion
 import arrow.core.Tuple2
 import arrow.core.extensions.SequenceKSemigroupal
-import kotlin.Deprecated
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -31,8 +27,7 @@ internal val semigroupal_singleton: SequenceKSemigroupal = object :
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "product(arg1)",
-  "arrow.core.product"
+    "this.zip(arg1, ::Pair)"
   ),
   DeprecationLevel.WARNING
 )
@@ -54,8 +49,7 @@ fun <A, B> Kind<ForSequenceK, A>.product(arg1: Kind<ForSequenceK, B>): SequenceK
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "times(arg1)",
-  "arrow.core.times"
+    "this.zip(arg1, ::Pair)"
   ),
   DeprecationLevel.WARNING
 )
@@ -156,5 +150,9 @@ operator fun <A, B> Kind<ForSequenceK, A>.times(arg1: Kind<ForSequenceK, B>): Se
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Semigroupal typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.semigroupal(): SequenceKSemigroupal = semigroupal_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/traverse/SequenceKTraverse.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/traverse/SequenceKTraverse.kt
@@ -7,11 +7,6 @@ import arrow.core.SequenceK.Companion
 import arrow.core.extensions.SequenceKTraverse
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Monad
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -28,12 +23,8 @@ internal val traverse_singleton: SequenceKTraverse = object :
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "traverse(arg1, arg2)",
-  "arrow.core.traverse"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated. Replace with traverseEither or traverseValidated from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <G, A, B> Kind<ForSequenceK, A>.traverse(arg1: Applicative<G>, arg2: Function1<A, Kind<G, B>>):
     Kind<G, Kind<ForSequenceK, B>> = arrow.core.SequenceK.traverse().run {
@@ -49,12 +40,8 @@ fun <G, A, B> Kind<ForSequenceK, A>.traverse(arg1: Applicative<G>, arg2: Functio
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "sequence(arg1)",
-  "arrow.core.sequence"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated. Replace with sequenceEither or sequenceValidated from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <G, A> Kind<ForSequenceK, Kind<G, A>>.sequence(arg1: Applicative<G>): Kind<G, Kind<ForSequenceK,
     A>> = arrow.core.SequenceK.traverse().run {
@@ -71,8 +58,7 @@ fun <G, A> Kind<ForSequenceK, Kind<G, A>>.sequence(arg1: Applicative<G>): Kind<G
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "map(arg1)",
-  "arrow.core.map"
+    "this.map(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -89,12 +75,8 @@ fun <A, B> Kind<ForSequenceK, A>.map(arg1: Function1<A, B>): SequenceK<B> =
   "UNUSED_PARAMETER"
 )
 @Deprecated(
-  "@extension kinded projected functions are deprecated",
-  ReplaceWith(
-  "flatTraverse(arg1, arg2, arg3)",
-  "arrow.core.flatTraverse"
-  ),
-  DeprecationLevel.WARNING
+  "@extension kinded projected functions are deprecated. Replace with flatTraverseEither or flatTraverseValidated from arrow.core.*",
+  level = DeprecationLevel.WARNING
 )
 fun <G, A, B> Kind<ForSequenceK, A>.flatTraverse(
   arg1: Monad<ForSequenceK>,
@@ -108,5 +90,9 @@ fun <G, A, B> Kind<ForSequenceK, A>.flatTraverse(
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Traverse typeclass is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.traverse(): SequenceKTraverse = traverse_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/unalign/SequenceKUnalign.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/unalign/SequenceKUnalign.kt
@@ -61,7 +61,7 @@ fun <A, B, C> unalignWith(arg0: Kind<ForSequenceK, C>, arg1: Function1<C, Ior<A,
   "NOTHING_TO_INLINE"
 )
 @Deprecated(
-  "Unalign typeclasses is deprecated. Use concrete methods on Sequence",
+  "Unalign typeclass is deprecated. Use concrete methods on Sequence",
   level = DeprecationLevel.WARNING
 )
 inline fun Companion.unalign(): SequenceKUnalign = unalign_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/unalign/SequenceKUnalign.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/unalign/SequenceKUnalign.kt
@@ -6,11 +6,6 @@ import arrow.core.Ior
 import arrow.core.SequenceK.Companion
 import arrow.core.Tuple2
 import arrow.core.extensions.SequenceKUnalign
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -29,8 +24,8 @@ internal val unalign_singleton: SequenceKUnalign = object : arrow.core.extension
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "unalign(arg0)",
-  "arrow.core.SequenceK.unalign"
+    "arg0.unalign()",
+    "arrow.core.unalign"
   ),
   DeprecationLevel.WARNING
 )
@@ -50,8 +45,8 @@ fun <A, B> unalign(arg0: Kind<ForSequenceK, Ior<A, B>>): Tuple2<Kind<ForSequence
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "unalignWith(arg0, arg1)",
-  "arrow.core.SequenceK.unalignWith"
+    "arg0.unalign(arg1)",
+    "arrow.core.unalign"
   ),
   DeprecationLevel.WARNING
 )
@@ -64,5 +59,9 @@ fun <A, B, C> unalignWith(arg0: Kind<ForSequenceK, C>, arg1: Function1<C, Ior<A,
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Unalign typeclasses is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.unalign(): SequenceKUnalign = unalign_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/unzip/SequenceKUnzip.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/unzip/SequenceKUnzip.kt
@@ -5,11 +5,6 @@ import arrow.core.ForSequenceK
 import arrow.core.SequenceK.Companion
 import arrow.core.Tuple2
 import arrow.core.extensions.SequenceKUnzip
-import kotlin.Deprecated
-import kotlin.Function1
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -27,8 +22,8 @@ internal val unzip_singleton: SequenceKUnzip = object : arrow.core.extensions.Se
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "unzip()",
-  "arrow.core.unzip"
+    "this.unzip()",
+    "arrow.core.unzip"
   ),
   DeprecationLevel.WARNING
 )
@@ -48,8 +43,8 @@ fun <A, B> Kind<ForSequenceK, Tuple2<A, B>>.unzip(): Tuple2<Kind<ForSequenceK, A
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "unzipWith(arg1)",
-  "arrow.core.unzipWith"
+    "this.unzip(arg1.andThen { t -> t.a to t.b })",
+    "arrow.core.andThen", "arrow.core.to", "arrow.core.unzip"
   ),
   DeprecationLevel.WARNING
 )
@@ -62,5 +57,9 @@ fun <A, B, C> Kind<ForSequenceK, C>.unzipWith(arg1: Function1<C, Tuple2<A, B>>):
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Unzip typeclasses is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.unzip(): SequenceKUnzip = unzip_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/unzip/SequenceKUnzip.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/unzip/SequenceKUnzip.kt
@@ -59,7 +59,7 @@ fun <A, B, C> Kind<ForSequenceK, C>.unzipWith(arg1: Function1<C, Tuple2<A, B>>):
   "NOTHING_TO_INLINE"
 )
 @Deprecated(
-  "Unzip typeclasses is deprecated. Use concrete methods on Sequence",
+  "Unzip typeclass is deprecated. Use concrete methods on Sequence",
   level = DeprecationLevel.WARNING
 )
 inline fun Companion.unzip(): SequenceKUnzip = unzip_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/zip/SequenceKZip.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/zip/SequenceKZip.kt
@@ -6,11 +6,6 @@ import arrow.core.SequenceK
 import arrow.core.SequenceK.Companion
 import arrow.core.Tuple2
 import arrow.core.extensions.SequenceKZip
-import kotlin.Deprecated
-import kotlin.Function2
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
 
 /**
  * cached extension
@@ -28,8 +23,7 @@ internal val zip_singleton: SequenceKZip = object : arrow.core.extensions.Sequen
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "zip(arg1)",
-  "arrow.core.zip"
+    "this.zip(arg1)"
   ),
   DeprecationLevel.WARNING
 )
@@ -48,8 +42,7 @@ fun <A, B> Kind<ForSequenceK, A>.zip(arg1: Kind<ForSequenceK, B>): SequenceK<Tup
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-  "zipWith(arg1, arg2)",
-  "arrow.core.zipWith"
+    "this.zip(arg1, arg2)"
   ),
   DeprecationLevel.WARNING
 )
@@ -61,5 +54,9 @@ fun <A, B, C> Kind<ForSequenceK, A>.zipWith(arg1: Kind<ForSequenceK, B>, arg2: F
 @Suppress(
   "UNCHECKED_CAST",
   "NOTHING_TO_INLINE"
+)
+@Deprecated(
+  "Zip typeclasses is deprecated. Use concrete methods on Sequence",
+  level = DeprecationLevel.WARNING
 )
 inline fun Companion.zip(): SequenceKZip = zip_singleton

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/zip/SequenceKZip.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/sequencek/zip/SequenceKZip.kt
@@ -56,7 +56,7 @@ fun <A, B, C> Kind<ForSequenceK, A>.zipWith(arg1: Kind<ForSequenceK, B>, arg2: F
   "NOTHING_TO_INLINE"
 )
 @Deprecated(
-  "Zip typeclasses is deprecated. Use concrete methods on Sequence",
+  "Zip typeclass is deprecated. Use concrete methods on Sequence",
   level = DeprecationLevel.WARNING
 )
 inline fun Companion.zip(): SequenceKZip = zip_singleton


### PR DESCRIPTION
- [x] Align
- [x] Alternative
- [x] Applicative
- [x] Apply
- [x] Crosswalk
- [x] Eq (EqK)
- [x] Foldable
- [x] Functor
- [x] FunctorFilter
- [x] Monad
- [x] MonadCombine
- [x] MonadFilter
- [x] MonadLogic
- [x] MonadPlus
- [x] Monoid (MonoidK)
- [x] Monoidal
- [x] Repeat
- [x] Semialign
- [x] Semigroup (SemigroupK)
- [x] Semigroupal
- [x] Traverse
- [x] Unalign
- [x] Unzip
- [x] Zip