### PR TITLE
Use common message for deprecating higher kinded types

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/AndThen.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/AndThen.kt
@@ -1,39 +1,41 @@
 package arrow.core
 
+import arrow.KindDeprecation
+
 @Deprecated(
-  "Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead",
+  message = KindDeprecation,
   level = DeprecationLevel.WARNING
 )
 class ForAndThen private constructor() { companion object }
 
 @Deprecated(
-  "Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead",
+  message = KindDeprecation,
   level = DeprecationLevel.WARNING
 )
 typealias AndThenOf<A, B> = arrow.Kind2<ForAndThen, A, B>
 
 @Deprecated(
-  "Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead",
+  message = KindDeprecation,
   level = DeprecationLevel.WARNING
 )
 typealias AndThenPartialOf<A> = arrow.Kind<ForAndThen, A>
 
 @Deprecated(
-  "Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead",
+  message = KindDeprecation,
   level = DeprecationLevel.WARNING
 )
 typealias AndThenKindedJ<A, B> = arrow.HkJ2<ForAndThen, A, B>
 
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
 @Deprecated(
-  "Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead",
+  message = KindDeprecation,
   level = DeprecationLevel.WARNING
 )
 inline fun <A, B> AndThenOf<A, B>.fix(): AndThen<A, B> =
   this as AndThen<A, B>
 
 @Deprecated(
-  "Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead",
+  message = KindDeprecation,
   level = DeprecationLevel.WARNING
 )
 operator fun <A, B> AndThenOf<A, B>.invoke(a: A): B = fix().invoke(a)

--- a/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Const.kt
@@ -1,6 +1,7 @@
 package arrow.core
 
 import arrow.Kind
+import arrow.KindDeprecation
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
@@ -8,22 +9,32 @@ import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
 import arrow.typeclasses.ShowDeprecation
 
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-class ForConst private constructor() {
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)class ForConst private constructor() {
   companion object
 }
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-typealias ConstOf<A, T> = arrow.Kind2<ForConst, A, T>
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-typealias ConstPartialOf<A> = arrow.Kind<ForConst, A>
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)typealias ConstOf<A, T> = arrow.Kind2<ForConst, A, T>
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)typealias ConstPartialOf<A> = arrow.Kind<ForConst, A>
 
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-inline fun <A, T> ConstOf<A, T>.fix(): Const<A, T> =
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)inline fun <A, T> ConstOf<A, T>.fix(): Const<A, T> =
   this as Const<A, T>
 
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-fun <A, T> ConstOf<A, T>.value(): A = this.fix().value()
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)fun <A, T> ConstOf<A, T>.value(): A = this.fix().value()
 
 data class Const<A, out T>(private val value: A) : ConstOf<A, T> {
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -1,6 +1,7 @@
 package arrow.core
 
 import arrow.Kind
+import arrow.KindDeprecation
 import arrow.core.Either.Companion.resolve
 import arrow.core.Either.Left
 import arrow.core.Either.Right
@@ -11,18 +12,26 @@ import arrow.typeclasses.Show
 import arrow.typeclasses.ShowDeprecation
 import arrow.typeclasses.hashWithSalt
 
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-class ForEither private constructor() {
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)class ForEither private constructor() {
   companion object
 }
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-typealias EitherOf<A, B> = arrow.Kind2<ForEither, A, B>
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-typealias EitherPartialOf<A> = arrow.Kind<ForEither, A>
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)typealias EitherOf<A, B> = arrow.Kind2<ForEither, A, B>
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)typealias EitherPartialOf<A> = arrow.Kind<ForEither, A>
 
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-inline fun <A, B> EitherOf<A, B>.fix(): Either<A, B> =
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)inline fun <A, B> EitherOf<A, B>.fix(): Either<A, B> =
   this as Either<A, B>
 
 /**

--- a/arrow-core-data/src/main/kotlin/arrow/core/Eval.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Eval.kt
@@ -1,20 +1,31 @@
 package arrow.core
 
+import arrow.KindDeprecation
 import arrow.typeclasses.Monoid
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-class ForEval private constructor() {
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)class ForEval private constructor() {
   companion object
 }
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-typealias EvalOf<A> = arrow.Kind<ForEval, A>
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)typealias EvalOf<A> = arrow.Kind<ForEval, A>
 
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-inline fun <A> EvalOf<A>.fix(): Eval<A> =
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)inline fun <A> EvalOf<A>.fix(): Eval<A> =
   this as Eval<A>
 
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)
 fun <A> EvalOf<A>.value(): A = this.fix().value()
 
 /**

--- a/arrow-core-data/src/main/kotlin/arrow/core/Hashed.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Hashed.kt
@@ -1,11 +1,28 @@
 package arrow.core
 
+import arrow.KindDeprecation
 import arrow.typeclasses.Hash
 
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)
 class ForHashed private constructor() { companion object }
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)
 typealias HashedOf<A> = arrow.Kind<ForHashed, A>
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)
 typealias HashedKindedJ<A> = io.kindedj.Hk<ForHashed, A>
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)
 inline fun <A> HashedOf<A>.fix(): Hashed<A> =
   this as Hashed<A>
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
@@ -1,23 +1,32 @@
 package arrow.core
 
 import arrow.Kind
+import arrow.KindDeprecation
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
 
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-class ForIor private constructor() {
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)class ForIor private constructor() {
   companion object
 }
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-typealias IorOf<A, B> = arrow.Kind2<ForIor, A, B>
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-typealias IorPartialOf<A> = arrow.Kind<ForIor, A>
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)typealias IorOf<A, B> = arrow.Kind2<ForIor, A, B>
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)typealias IorPartialOf<A> = arrow.Kind<ForIor, A>
 
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-inline fun <A, B> IorOf<A, B>.fix(): Ior<A, B> =
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)inline fun <A, B> IorOf<A, B>.fix(): Ior<A, B> =
   this as Ior<A, B>
 
 typealias IorNel<A, B> = Ior<Nel<A>, B>

--- a/arrow-core-data/src/main/kotlin/arrow/core/ListK.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/ListK.kt
@@ -1,16 +1,29 @@
 package arrow.core
 
 import arrow.Kind
+import arrow.KindDeprecation
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Show
 import arrow.typeclasses.ShowDeprecation
 
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)
 class ForListK private constructor() {
   companion object
 }
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)
 typealias ListKOf<A> = arrow.Kind<ForListK, A>
 
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)
 inline fun <A> ListKOf<A>.fix(): ListK<A> =
   this as ListK<A>
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/MapK.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/MapK.kt
@@ -1,20 +1,29 @@
 package arrow.core
 
 import arrow.Kind
+import arrow.KindDeprecation
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Show
 import arrow.typeclasses.ShowDeprecation
 
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-class ForMapK private constructor() { companion object }
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-typealias MapKOf<K, A> = arrow.Kind2<ForMapK, K, A>
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-typealias MapKPartialOf<K> = arrow.Kind<ForMapK, K>
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)class ForMapK private constructor() { companion object }
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)typealias MapKOf<K, A> = arrow.Kind2<ForMapK, K, A>
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)typealias MapKPartialOf<K> = arrow.Kind<ForMapK, K>
 
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-inline fun <K, A> MapKOf<K, A>.fix(): MapK<K, A> = this as MapK<K, A>
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)inline fun <K, A> MapKOf<K, A>.fix(): MapK<K, A> = this as MapK<K, A>
 
 data class MapK<K, out A>(private val map: Map<K, A>) : MapKOf<K, A>, Map<K, A> by map {
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
@@ -1,20 +1,30 @@
 package arrow.core
 
 import arrow.Kind
+import arrow.KindDeprecation
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
 import arrow.typeclasses.ShowDeprecation
 
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-class ForNonEmptyList private constructor() {
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)class ForNonEmptyList private constructor() {
   companion object
 }
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)
 typealias NonEmptyListOf<A> = arrow.Kind<ForNonEmptyList, A>
 
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)
 inline fun <A> NonEmptyListOf<A>.fix(): NonEmptyList<A> =
   this as NonEmptyList<A>
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
@@ -1,25 +1,26 @@
 package arrow.core
 
 import arrow.Kind
+import arrow.KindDeprecation
 import arrow.core.Either.Right
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.Show
 
 @Deprecated(
-  "Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead",
+  message = KindDeprecation,
   level = DeprecationLevel.WARNING
 )
 class ForOption private constructor() { companion object }
 @Deprecated(
-  "Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead",
+  message = KindDeprecation,
   level = DeprecationLevel.WARNING
 )
 typealias OptionOf<A> = arrow.Kind<ForOption, A>
 
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
 @Deprecated(
-  "Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead",
+  message = KindDeprecation,
   level = DeprecationLevel.WARNING
 )
 inline fun <A> OptionOf<A>.fix(): Option<A> = this as Option<A>

--- a/arrow-core-data/src/main/kotlin/arrow/core/SequenceK.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/SequenceK.kt
@@ -1,16 +1,29 @@
 package arrow.core
 
 import arrow.Kind
+import arrow.KindDeprecation
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Show
 import arrow.typeclasses.ShowDeprecation
 
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)
 class ForSequenceK private constructor() {
   companion object
 }
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)
 typealias SequenceKOf<A> = arrow.Kind<ForSequenceK, A>
 
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)
 inline fun <A> SequenceKOf<A>.fix(): SequenceK<A> =
   this as SequenceK<A>
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/SetK.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/SetK.kt
@@ -1,17 +1,24 @@
 package arrow.core
 
+import arrow.KindDeprecation
 import arrow.typeclasses.Show
 import arrow.typeclasses.ShowDeprecation
 
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-class ForSetK private constructor() { companion object }
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)class ForSetK private constructor() { companion object }
 
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-typealias SetKOf<A> = arrow.Kind<ForSetK, A>
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)typealias SetKOf<A> = arrow.Kind<ForSetK, A>
 
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-inline fun <A> SetKOf<A>.fix(): SetK<A> =
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)inline fun <A> SetKOf<A>.fix(): SetK<A> =
   this as SetK<A>
 
 data class SetK<out A>(private val set: Set<A>) : SetKOf<A>, Set<A> by set {

--- a/arrow-core-data/src/main/kotlin/arrow/core/SortedMapK.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/SortedMapK.kt
@@ -1,16 +1,37 @@
 package arrow.core
 
 import arrow.Kind
+import arrow.KindDeprecation
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Show
 import arrow.typeclasses.ShowDeprecation
 import kotlin.collections.flatMap
 
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)
 class ForSortedMapK private constructor() { companion object }
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)
 typealias SortedMapKOf<A, B> = arrow.Kind2<ForSortedMapK, A, B>
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)
 typealias SortedMapKPartialOf<A> = arrow.Kind<ForSortedMapK, A>
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)
 typealias SortedMapKKindedJ<A, B> = arrow.HkJ2<ForSortedMapK, A, B>
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)
 inline fun <A, B> SortedMapKOf<A, B>.fix(): SortedMapK<A, B> where A : kotlin.Comparable<A> =
   this as SortedMapK<A, B>
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -1,6 +1,7 @@
 package arrow.core
 
 import arrow.Kind
+import arrow.KindDeprecation
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Hash
 import arrow.typeclasses.Monoid
@@ -14,18 +15,26 @@ typealias ValidatedNel<E, A> = Validated<Nel<E>, A>
 typealias Valid<A> = Validated.Valid<A>
 typealias Invalid<E> = Validated.Invalid<E>
 
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-class ForValidated private constructor() {
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)class ForValidated private constructor() {
   companion object
 }
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-typealias ValidatedOf<E, A> = arrow.Kind2<ForValidated, E, A>
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-typealias ValidatedPartialOf<E> = arrow.Kind<ForValidated, E>
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)typealias ValidatedOf<E, A> = arrow.Kind2<ForValidated, E, A>
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)typealias ValidatedPartialOf<E> = arrow.Kind<ForValidated, E>
 
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
-@Deprecated("Kind is deprecated, and will be removed in 0.13.0. Please use one of the provided concrete methods instead")
-inline fun <E, A> ValidatedOf<E, A>.fix(): Validated<E, A> =
+@Deprecated(
+  message = KindDeprecation,
+  level = DeprecationLevel.WARNING
+)inline fun <E, A> ValidatedOf<E, A>.fix(): Validated<E, A> =
   this as Validated<E, A>
 
 /**


### PR DESCRIPTION
To keep consistency in all the deprecation messages for Higher Kinded Types, this pull request replaces those messages with the text defined in the value `KindDeprecation`.