### PR TITLE
Fix typo in deprecation messages for Const data type

### DIFF
--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/apply/ConstApply.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/apply/ConstApply.kt
@@ -100,8 +100,8 @@ fun <A, B, Z> Kind<Kind<ForConst, A>, A>.map2Eval(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1) { a, b -> arg2(Tuple2(a,b)) }",
-    "arrow.core.Cons",
+    "Const.mapN(MA, arg0, arg1) { a, b -> arg2(Tuple2(a,b)) }",
+    "arrow.core.Const",
     "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
@@ -125,8 +125,8 @@ fun <A, B, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1) { a, b -> arg2(Tuple2(a,b)) }",
-    "arrow.core.Cons",
+    "Const.mapN(MA, arg0, arg1) { a, b -> arg2(Tuple2(a,b)) }",
+    "arrow.core.Const",
     "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
@@ -150,8 +150,8 @@ fun <A, B, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2) { a, b, c -> arg3(Tuple3(a, b, c)) }",
-    "arrow.core.Cons",
+    "Const.mapN(MA, arg0, arg1, arg2) { a, b, c -> arg3(Tuple3(a, b, c)) }",
+    "arrow.core.Const",
     "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
@@ -176,8 +176,8 @@ fun <A, B, C, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2) { a, b, c -> arg3(Tuple3(a, b, c)) }",
-    "arrow.core.Cons",
+    "Const.mapN(MA, arg0, arg1, arg2) { a, b, c -> arg3(Tuple3(a, b, c)) }",
+    "arrow.core.Const",
     "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
@@ -202,8 +202,8 @@ fun <A, B, C, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }",
-    "arrow.core.Cons",
+    "Const.mapN(MA, arg0, arg1, arg2, arg3) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }",
+    "arrow.core.Const",
     "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
@@ -229,8 +229,8 @@ fun <A, B, C, D, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }",
-    "arrow.core.Cons",
+    "Const.mapN(MA, arg0, arg1, arg2, arg3) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }",
+    "arrow.core.Const",
     "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
@@ -256,8 +256,8 @@ fun <A, B, C, D, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }",
-    "arrow.core.Cons",
+    "Const.mapN(MA, arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }",
+    "arrow.core.Const",
     "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
@@ -284,8 +284,8 @@ fun <A, B, C, D, E, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }",
-    "arrow.core.Cons",
+    "Const.mapN(MA, arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }",
+    "arrow.core.Const",
     "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
@@ -312,8 +312,8 @@ fun <A, B, C, D, E, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> arg6(Tuple6(a, b, c, d, e, f)) }",
-    "arrow.core.Cons",
+    "Const.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> arg6(Tuple6(a, b, c, d, e, f)) }",
+    "arrow.core.Const",
     "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
@@ -341,8 +341,8 @@ fun <A, B, C, D, E, FF, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> arg6(Tuple6(a, b, c, d, e, f)) }",
-    "arrow.core.Cons",
+    "Const.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> arg6(Tuple6(a, b, c, d, e, f)) }",
+    "arrow.core.Const",
     "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
@@ -370,8 +370,8 @@ fun <A, B, C, D, E, FF, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> arg7(Tuple7(a, b, c, d, e, f, g)) }",
-    "arrow.core.Cons",
+    "Const.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> arg7(Tuple7(a, b, c, d, e, f, g)) }",
+    "arrow.core.Const",
     "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
@@ -401,8 +401,8 @@ fun <A, B, C, D, E, FF, G, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> arg7(Tuple7(a, b, c, d, e, f, g)) }",
-    "arrow.core.Cons",
+    "Const.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> arg7(Tuple7(a, b, c, d, e, f, g)) }",
+    "arrow.core.Const",
     "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
@@ -432,8 +432,8 @@ fun <A, B, C, D, E, FF, G, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> arg8(Tuple8(a, b, c, d, e, f, g, h)) }",
-    "arrow.core.Cons",
+    "Const.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> arg8(Tuple8(a, b, c, d, e, f, g, h)) }",
+    "arrow.core.Const",
     "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
@@ -464,8 +464,8 @@ fun <A, B, C, D, E, FF, G, H, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> arg8(Tuple8(a, b, c, d, e, f, g, h)) }",
-    "arrow.core.Cons",
+    "Const.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> arg8(Tuple8(a, b, c, d, e, f, g, h)) }",
+    "arrow.core.Const",
     "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
@@ -496,9 +496,9 @@ fun <A, B, C, D, E, FF, G, H, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)\n" +
+    "Const.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)\n" +
       "{ a, b, c, d, e, f, g, h, i -> arg9(Tuple9(a, b, c, d, e, f, g, h, i)) }",
-    "arrow.core.Cons",
+    "arrow.core.Const",
     "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
@@ -530,9 +530,9 @@ fun <A, B, C, D, E, FF, G, H, I, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)\n" +
+    "Const.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)\n" +
       "{ a, b, c, d, e, f, g, h, i -> arg9(Tuple9(a, b, c, d, e, f, g, h, i)) }",
-    "arrow.core.Cons",
+    "arrow.core.Const",
     "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
@@ -564,9 +564,9 @@ fun <A, B, C, D, E, FF, G, H, I, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)\n" +
+    "Const.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)\n" +
       "{ a, b, c, d, e, f, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, f, g, h, i, j)) }",
-    "arrow.core.Cons",
+    "arrow.core.Const",
     "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
@@ -599,9 +599,9 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> map(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)\n" +
+    "Const.mapN(MA, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)\n" +
       "{ a, b, c, d, e, f, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, f, g, h, i, j)) }",
-    "arrow.core.Cons",
+    "arrow.core.Const",
     "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
@@ -633,8 +633,8 @@ fun <A, B, C, D, E, FF, G, H, I, J, Z> mapN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, this, arg1).map(arg2)",
-    "arrow.core.Cons"
+    "Const.mapN(MA, this, arg1).map(arg2)",
+    "arrow.core.Const"
   ),
   DeprecationLevel.WARNING
 )
@@ -656,8 +656,8 @@ fun <A, B, Z> Kind<Kind<ForConst, A>, A>.map2(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, this, arg1) { a, b -> Tuple2(a, b) }",
-    "arrow.core.Cons"
+    "Const.mapN(MA, this, arg1) { a, b -> Tuple2(a, b) }",
+    "arrow.core.Const"
   ),
   DeprecationLevel.WARNING
 )
@@ -676,8 +676,8 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.product(MA: Monoid<A>, arg1: Kind<Kind<For
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, this, arg1).map { ab, c -> Tuple3(ab.a, ab.b, c) }",
-    "arrow.core.Cons",
+    "Const.mapN(MA, this, arg1).map { ab, c -> Tuple3(ab.a, ab.b, c) }",
+    "arrow.core.Const",
     "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
@@ -699,8 +699,8 @@ fun <A, B, Z> Kind<Kind<ForConst, A>, Tuple2<A, B>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, this, arg1).map { abc, d -> Tuple4(abc.a, abc.b, abc.c, d) }",
-    "arrow.core.Cons",
+    "Const.mapN(MA, this, arg1).map { abc, d -> Tuple4(abc.a, abc.b, abc.c, d) }",
+    "arrow.core.Const",
     "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
@@ -723,8 +723,8 @@ fun <A, B, C, Z> Kind<Kind<ForConst, A>, Tuple3<A, B, C>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, this, arg1).map { abcd, e -> Tuple5(abcd.a, abcd.b, abcd.c, abcd.d, e) }",
-    "arrow.core.Cons",
+    "Const.mapN(MA, this, arg1).map { abcd, e -> Tuple5(abcd.a, abcd.b, abcd.c, abcd.d, e) }",
+    "arrow.core.Const",
     "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
@@ -747,8 +747,8 @@ fun <A, B, C, D, Z> Kind<Kind<ForConst, A>, Tuple4<A, B, C, D>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, this, arg1).map { abcde, f -> Tuple6(abcde.a, abcde.b, abcde.c, abcde.d, abcde.e, f) }",
-    "arrow.core.Cons",
+    "Const.mapN(MA, this, arg1).map { abcde, f -> Tuple6(abcde.a, abcde.b, abcde.c, abcde.d, abcde.e, f) }",
+    "arrow.core.Const",
     "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
@@ -771,9 +771,9 @@ fun <A, B, C, D, E, Z> Kind<Kind<ForConst, A>, Tuple5<A, B, C, D, E>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, this, arg1)\n" +
+    "Const.mapN(MA, this, arg1)\n" +
       ".map { abcdef, g -> Tuple7(abcdef.a, abcdef.b, abcdef.c, abcdef.d, abcdef.e, abcdef.f, g) }",
-    "arrow.core.Cons",
+    "arrow.core.Const",
     "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
@@ -796,9 +796,9 @@ fun <A, B, C, D, E, FF, Z> Kind<Kind<ForConst, A>, Tuple6<A, B, C, D, E, FF>>.pr
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, this, arg1)\n" +
+    "Const.mapN(MA, this, arg1)\n" +
       ".map { abcdefg, h -> Tuple8(abcdefg.a, abcdefg.b, abcdefg.c, abcdefg.d, abcdefg.e, abcdefg.f, abcdefg.g, h) }",
-    "arrow.core.Cons",
+    "arrow.core.Const",
     "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
@@ -822,9 +822,9 @@ fun <A, B, C, D, E, FF, G, Z> Kind<Kind<ForConst, A>, Tuple7<A, B, C, D, E, FF, 
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, this, arg1)\n" +
+    "Const.mapN(MA, this, arg1)\n" +
       ".map { abcdefgh, i -> Tuple9(abcdefgh.a, abcdefgh.b, abcdefgh.c, abcdefgh.d, abcdefgh.e, abcdefgh.f, abcdefgh.g, abcdefgh.h, i) }",
-    "arrow.core.Cons",
+    "arrow.core.Const",
     "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
@@ -848,9 +848,9 @@ fun <A, B, C, D, E, FF, G, H, Z> Kind<Kind<ForConst, A>, Tuple8<A, B, C, D, E, F
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MA, this, arg1)\n" +
+    "Const.mapN(MA, this, arg1)\n" +
       ".map { abcdefghi, j -> Tuple10(abcdefghi.a, abcdefghi.b, abcdefghi.c, abcdefghi.d, abcdefghi.e, abcdefghi.f, abcdefghi.g, abcdefghi.h, abcdefghi.i, j) }",
-    "arrow.core.Cons",
+    "arrow.core.Const",
     "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
@@ -874,8 +874,8 @@ fun <A, B, C, D, E, FF, G, H, I, Z> Kind<Kind<ForConst, A>, Tuple9<A, B, C, D, E
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(SG, arg0, arg1) { a, b -> Tuple2(a, b) }",
-    "arrow.core.Cons"
+    "Const.mapN(SG, arg0, arg1) { a, b -> Tuple2(a, b) }",
+    "arrow.core.Const"
   ),
   DeprecationLevel.WARNING
 )
@@ -897,8 +897,8 @@ fun <A, B> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(SG, arg0, arg1) { a, b -> Tuple2(a, b) }",
-    "arrow.core.Cons"
+    "Const.mapN(SG, arg0, arg1) { a, b -> Tuple2(a, b) }",
+    "arrow.core.Const"
   ),
   DeprecationLevel.WARNING
 )
@@ -920,8 +920,8 @@ fun <A, B> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(SG, arg0, arg1, arg2) { a, b, c -> Tuple3(a, b, c) }",
-    "arrow.core.Cons"
+    "Const.mapN(SG, arg0, arg1, arg2) { a, b, c -> Tuple3(a, b, c) }",
+    "arrow.core.Const"
   ),
   DeprecationLevel.WARNING
 )
@@ -944,8 +944,8 @@ fun <A, B, C> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(SG, arg0, arg1, arg2) { a, b, c -> Tuple3(a, b, c) }",
-    "arrow.core.Cons"
+    "Const.mapN(SG, arg0, arg1, arg2) { a, b, c -> Tuple3(a, b, c) }",
+    "arrow.core.Const"
   ),
   DeprecationLevel.WARNING
 )
@@ -968,8 +968,8 @@ fun <A, B, C> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(SG, arg0, arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }",
-    "arrow.core.Cons"
+    "Const.mapN(SG, arg0, arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }",
+    "arrow.core.Const"
   ),
   DeprecationLevel.WARNING
 )
@@ -993,8 +993,8 @@ fun <A, B, C, D> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(SG, arg0, arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }",
-    "arrow.core.Cons"
+    "Const.mapN(SG, arg0, arg1, arg2, arg3) { a, b, c, d -> Tuple4(a, b, c, d) }",
+    "arrow.core.Const"
   ),
   DeprecationLevel.WARNING
 )
@@ -1018,8 +1018,8 @@ fun <A, B, C, D> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(SG, arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }",
-    "arrow.core.Cons"
+    "Const.mapN(SG, arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }",
+    "arrow.core.Const"
   ),
   DeprecationLevel.WARNING
 )
@@ -1045,8 +1045,8 @@ fun <A, B, C, D, E> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(SG, arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }",
-    "arrow.core.Cons"
+    "Const.mapN(SG, arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> Tuple5(a, b, c, d, e) }",
+    "arrow.core.Const"
   ),
   DeprecationLevel.WARNING
 )
@@ -1072,8 +1072,8 @@ fun <A, B, C, D, E> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, ff -> Tuple6(a, b, c, d, e, ff) }",
-    "arrow.core.Cons"
+    "Const.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, ff -> Tuple6(a, b, c, d, e, ff) }",
+    "arrow.core.Const"
   ),
   DeprecationLevel.WARNING
 )
@@ -1100,8 +1100,8 @@ fun <A, B, C, D, E, FF> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, ff -> Tuple6(a, b, c, d, e, ff) }",
-    "arrow.core.Cons"
+    "Const.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, ff -> Tuple6(a, b, c, d, e, ff) }",
+    "arrow.core.Const"
   ),
   DeprecationLevel.WARNING
 )
@@ -1129,8 +1129,8 @@ fun <A, B, C, D, E, FF> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, ff, g -> Tuple7(a, b, c, d, e, ff, g) }",
-    "arrow.core.Cons"
+    "Const.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, ff, g -> Tuple7(a, b, c, d, e, ff, g) }",
+    "arrow.core.Const"
   ),
   DeprecationLevel.WARNING
 )
@@ -1158,8 +1158,8 @@ fun <A, B, C, D, E, FF, G> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, ff, g -> Tuple7(a, b, c, d, e, ff, g) }",
-    "arrow.core.Cons"
+    "Const.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, ff, g -> Tuple7(a, b, c, d, e, ff, g) }",
+    "arrow.core.Const"
   ),
   DeprecationLevel.WARNING
 )
@@ -1187,8 +1187,8 @@ fun <A, B, C, D, E, FF, G> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, ff, g, h -> Tuple8(a, b, c, d, e, ff, g, h) }",
-    "arrow.core.Cons"
+    "Const.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, ff, g, h -> Tuple8(a, b, c, d, e, ff, g, h) }",
+    "arrow.core.Const"
   ),
   DeprecationLevel.WARNING
 )
@@ -1217,8 +1217,8 @@ fun <A, B, C, D, E, FF, G, H> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, ff, g, h -> Tuple8(a, b, c, d, e, ff, g, h) }",
-    "arrow.core.Cons"
+    "Const.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, ff, g, h -> Tuple8(a, b, c, d, e, ff, g, h) }",
+    "arrow.core.Const"
   ),
   DeprecationLevel.WARNING
 )
@@ -1247,9 +1247,9 @@ fun <A, B, C, D, E, FF, G, H> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, ff, g, h, i -> \n" +
+    "Const.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, ff, g, h, i -> \n" +
       "Tuple9(a, b, c, d, e, ff, g, h, i) }",
-    "arrow.core.Cons"
+    "arrow.core.Const"
   ),
   DeprecationLevel.WARNING
 )
@@ -1279,9 +1279,9 @@ fun <A, B, C, D, E, FF, G, H, I> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, ff, g, h, i -> \n" +
+    "Const.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) { a, b, c, d, e, ff, g, h, i -> \n" +
       "Tuple9(a, b, c, d, e, ff, g, h, i) }",
-    "arrow.core.Cons"
+    "arrow.core.Const"
   ),
   DeprecationLevel.WARNING
 )
@@ -1311,9 +1311,9 @@ fun <A, B, C, D, E, FF, G, H, I> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, ff, g, h, i, j -> \n" +
+    "Const.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, ff, g, h, i, j -> \n" +
       "Tuple10(a, b, c, d, e, ff, g, h, i, j) }",
-    "arrow.core.Cons"
+    "arrow.core.Const"
   ),
   DeprecationLevel.WARNING
 )
@@ -1345,9 +1345,9 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupled(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, ff, g, h, i, j -> \n" +
+    "Const.mapN(SG, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) { a, b, c, d, e, ff, g, h, i, j -> \n" +
       "Tuple10(a, b, c, d, e, ff, g, h, i, j) }",
-    "arrow.core.Cons"
+    "arrow.core.Const"
   ),
   DeprecationLevel.WARNING
 )
@@ -1379,8 +1379,8 @@ fun <A, B, C, D, E, FF, G, H, I, J> tupledN(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(SG, this, arg1) { (_, right) -> right }",
-    "arrow.core.Cons"
+    "Const.mapN(SG, this, arg1) { (_, right) -> right }",
+    "arrow.core.Const"
   ),
   DeprecationLevel.WARNING
 )
@@ -1402,8 +1402,8 @@ fun <A, B> Kind<Kind<ForConst, A>, A>.followedBy(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(SG, this, arg1) { (left, _) -> left }",
-    "arrow.core.Cons"
+    "Const.mapN(SG, this, arg1) { (left, _) -> left }",
+    "arrow.core.Const"
   ),
   DeprecationLevel.WARNING
 )

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/const/divide/ConstDivideInstance.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/const/divide/ConstDivideInstance.kt
@@ -26,8 +26,8 @@ import arrow.typeclasses.Monoid
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, arg0, arg1) { a, b -> arg2(Tuple2(a,b)) }",
-    "arrow.core.Cons",
+    "Const.mapN(MO, arg0, arg1) { a, b -> arg2(Tuple2(a,b)) }",
+    "arrow.core.Const",
     "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
@@ -51,8 +51,8 @@ fun <O, A, B, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, arg0, arg1, arg2) { a, b, c -> arg3(Tuple3(a, b, c)) }",
-    "arrow.core.Cons",
+    "Const.mapN(MO, arg0, arg1, arg2) { a, b, c -> arg3(Tuple3(a, b, c)) }",
+    "arrow.core.Const",
     "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
@@ -77,8 +77,8 @@ fun <O, A, B, C, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, arg0, arg1, arg2, arg3) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }",
-    "arrow.core.Cons",
+    "Const.mapN(MO, arg0, arg1, arg2, arg3) { a, b, c, d -> arg4(Tuple4(a, b, c, d)) }",
+    "arrow.core.Const",
     "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
@@ -104,8 +104,8 @@ fun <O, A, B, C, D, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }",
-    "arrow.core.Cons",
+    "Const.mapN(MO, arg0, arg1, arg2, arg3, arg4) { a, b, c, d, e -> arg5(Tuple5(a, b, c, d, e)) }",
+    "arrow.core.Const",
     "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
@@ -132,8 +132,8 @@ fun <O, A, B, C, D, E, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> arg6(Tuple6(a, b, c, d, e, f)) }",
-    "arrow.core.Cons",
+    "Const.mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5) { a, b, c, d, e, f -> arg6(Tuple6(a, b, c, d, e, f)) }",
+    "arrow.core.Const",
     "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
@@ -161,8 +161,8 @@ fun <O, A, B, C, D, E, FF, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> arg7(Tuple7(a, b, c, d, e, f, g)) }",
-    "arrow.core.Cons",
+    "Const.mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6) { a, b, c, d, e, f, g -> arg7(Tuple7(a, b, c, d, e, f, g)) }",
+    "arrow.core.Const",
     "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
@@ -192,8 +192,8 @@ fun <O, A, B, C, D, E, FF, G, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> arg8(Tuple8(a, b, c, d, e, f, g, h)) }",
-    "arrow.core.Cons",
+    "Const.mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) { a, b, c, d, e, f, g, h -> arg8(Tuple8(a, b, c, d, e, f, g, h)) }",
+    "arrow.core.Const",
     "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
@@ -224,9 +224,9 @@ fun <O, A, B, C, D, E, FF, G, H, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)\n" +
+    "Const.mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)\n" +
       "{ a, b, c, d, e, f, g, h, i -> arg9(Tuple9(a, b, c, d, e, f, g, h, i)) }",
-    "arrow.core.Cons",
+    "arrow.core.Const",
     "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
@@ -258,9 +258,9 @@ fun <O, A, B, C, D, E, FF, G, H, I, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)\n" +
+    "Const.mapN(MO, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)\n" +
       "{ a, b, c, d, e, f, g, h, i, j -> arg10(Tuple10(a, b, c, d, e, f, g, h, i, j)) }",
-    "arrow.core.Cons",
+    "arrow.core.Const",
     "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING
@@ -293,8 +293,8 @@ fun <O, A, B, C, D, E, FF, G, H, I, J, Z> divide(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, this, arg1) { a, b -> Tuple2(a, b) }",
-    "arrow.core.Cons",
+    "Const.mapN(MO, this, arg1) { a, b -> Tuple2(a, b) }",
+    "arrow.core.Const",
     "arrow.core.Tuple2"
   ),
   DeprecationLevel.WARNING
@@ -314,8 +314,8 @@ fun <O, A, B> Kind<Kind<ForConst, O>, A>.product(MO: Monoid<O>, arg1: Kind<Kind<
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, this, arg1).map { ab, c -> Tuple3(ab.a, ab.b, c) }",
-    "arrow.core.Cons",
+    "Const.mapN(MO, this, arg1).map { ab, c -> Tuple3(ab.a, ab.b, c) }",
+    "arrow.core.Const",
     "arrow.core.Tuple3"
   ),
   DeprecationLevel.WARNING
@@ -338,8 +338,8 @@ fun <O, A, B, C> Kind<Kind<ForConst, O>, Tuple2<A, B>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, this, arg1).map { abc, d -> Tuple4(abc.a, abc.b, abc.c, d) }",
-    "arrow.core.Cons",
+    "Const.mapN(MO, this, arg1).map { abc, d -> Tuple4(abc.a, abc.b, abc.c, d) }",
+    "arrow.core.Const",
     "arrow.core.Tuple4"
   ),
   DeprecationLevel.WARNING
@@ -362,8 +362,8 @@ fun <O, A, B, C, D> Kind<Kind<ForConst, O>, Tuple3<A, B, C>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, this, arg1).map { abcd, e -> Tuple5(abcd.a, abcd.b, abcd.c, abcd.d, e) }",
-    "arrow.core.Cons",
+    "Const.mapN(MO, this, arg1).map { abcd, e -> Tuple5(abcd.a, abcd.b, abcd.c, abcd.d, e) }",
+    "arrow.core.Const",
     "arrow.core.Tuple5"
   ),
   DeprecationLevel.WARNING
@@ -386,8 +386,8 @@ fun <O, A, B, C, D, E> Kind<Kind<ForConst, O>, Tuple4<A, B, C, D>>.product(
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, this, arg1).map { abcde, f -> Tuple6(abcde.a, abcde.b, abcde.c, abcde.d, abcde.e, f) }",
-    "arrow.core.Cons",
+    "Const.mapN(MO, this, arg1).map { abcde, f -> Tuple6(abcde.a, abcde.b, abcde.c, abcde.d, abcde.e, f) }",
+    "arrow.core.Const",
     "arrow.core.Tuple6"
   ),
   DeprecationLevel.WARNING
@@ -411,9 +411,9 @@ fun <O, A, B, C, D, E, FF> Kind<Kind<ForConst, O>, Tuple5<A, B, C, D, E>>.produc
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, this, arg1)\n" +
+    "Const.mapN(MO, this, arg1)\n" +
       ".map { abcdef, g -> Tuple7(abcdef.a, abcdef.b, abcdef.c, abcdef.d, abcdef.e, abcdef.f, g) }",
-    "arrow.core.Cons",
+    "arrow.core.Const",
     "arrow.core.Tuple7"
   ),
   DeprecationLevel.WARNING
@@ -435,9 +435,9 @@ fun <O, A, B, C, D, E, FF, G> Kind<Kind<ForConst, O>, Tuple6<A, B, C, D, E,
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, this, arg1)\n" +
+    "Const.mapN(MO, this, arg1)\n" +
       ".map { abcdefg, h -> Tuple8(abcdefg.a, abcdefg.b, abcdefg.c, abcdefg.d, abcdefg.e, abcdefg.f, abcdefg.g, h) }",
-    "arrow.core.Cons",
+    "arrow.core.Const",
     "arrow.core.Tuple8"
   ),
   DeprecationLevel.WARNING
@@ -459,9 +459,9 @@ fun <O, A, B, C, D, E, FF, G, H> Kind<Kind<ForConst, O>, Tuple7<A, B, C, D, E, F
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, this, arg1)\n" +
+    "Const.mapN(MO, this, arg1)\n" +
       ".map { abcdefgh, i -> Tuple9(abcdefgh.a, abcdefgh.b, abcdefgh.c, abcdefgh.d, abcdefgh.e, abcdefgh.f, abcdefgh.g, abcdefgh.h, i) }",
-    "arrow.core.Cons",
+    "arrow.core.Const",
     "arrow.core.Tuple9"
   ),
   DeprecationLevel.WARNING
@@ -483,9 +483,9 @@ fun <O, A, B, C, D, E, FF, G, H, I> Kind<Kind<ForConst, O>, Tuple8<A, B, C, D, E
 @Deprecated(
   "@extension kinded projected functions are deprecated",
   ReplaceWith(
-    "Cons.mapN(MO, this, arg1)\n" +
+    "Const.mapN(MO, this, arg1)\n" +
       ".map { abcdefghi, j -> Tuple10(abcdefghi.a, abcdefghi.b, abcdefghi.c, abcdefghi.d, abcdefghi.e, abcdefghi.f, abcdefghi.g, abcdefghi.h, abcdefghi.i, j) }",
-    "arrow.core.Cons",
+    "arrow.core.Const",
     "arrow.core.Tuple10"
   ),
   DeprecationLevel.WARNING


### PR DESCRIPTION
There was a typo in several deprecation messages for the `Const` data type, where we were using `Cons` instead of `Const`.