### PR TITLE
Unify syntax for extracting inner values

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -1067,7 +1067,11 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
    * The left side of the disjoint union, as opposed to the [Right] side.
    */
   @Suppress("DataClassPrivateConstructor")
-  data class Left<out A> @PublishedApi internal constructor(val a: A) : Either<A, Nothing>() {
+  data class Left<out A> @PublishedApi internal constructor(
+    @Deprecated("Use value instead", ReplaceWith("value"))
+    val a: A
+  ) : Either<A, Nothing>() {
+    val value: A = a
     override val isLeft = true
     override val isRight = false
 
@@ -1082,7 +1086,11 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
    * The right side of the disjoint union, as opposed to the [Left] side.
    */
   @Suppress("DataClassPrivateConstructor")
-  data class Right<out B> @PublishedApi internal constructor(val b: B) : Either<Nothing, B>() {
+  data class Right<out B> @PublishedApi internal constructor(
+    @Deprecated("Use value instead", ReplaceWith("value"))
+    val b: B
+  ) : Either<Nothing, B>() {
+    val value: B = b
     override val isLeft = false
     override val isRight = true
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
@@ -633,7 +633,7 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
     override val isLeft: Boolean get() = false
     override val isBoth: Boolean get() = true
 
-    override fun toString(): String = "Ior.Both($leftValue, rightValue)"
+    override fun toString(): String = "Ior.Both($leftValue, $rightValue)"
   }
 
   @Deprecated(

--- a/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
@@ -977,7 +977,11 @@ object None : Option<Nothing>() {
   override fun toString(): String = "Option.None"
 }
 
-data class Some<out T>(val t: T) : Option<T>() {
+data class Some<out T>(
+  @Deprecated("Use value instead", ReplaceWith("value"))
+  val t: T
+) : Option<T>() {
+  val value: T = t
   override fun isEmpty() = false
 
   override fun toString(): String = "Option.Some($t)"

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple10.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple10.kt
@@ -33,7 +33,7 @@ data class Tuple10<out A, out B, out C, out D, out E, out F, out G, out H, out I
   val f: F,
   @Deprecated("Use seventh instead", ReplaceWith("seventh"))
   val g: G,
-  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  @Deprecated("Use eighth instead", ReplaceWith("eighth"))
   val h: H,
   @Deprecated("Use ninth instead", ReplaceWith("ninth"))
   val i: I,
@@ -166,12 +166,12 @@ operator fun <A : Comparable<A>, B : Comparable<B>, C : Comparable<C>, D : Compa
             if (sixth == 0) {
               val seventh = g.compareTo(other.g)
               if (seventh == 0) {
-                val eigth = h.compareTo(other.h)
-                if (eigth == 0) {
+                val eighth = h.compareTo(other.h)
+                if (eighth == 0) {
                   val ninth = i.compareTo(other.i)
                   if (ninth == 0) j.compareTo(other.j)
                   else ninth
-                } else eigth
+                } else eighth
               } else seventh
             } else sixth
           } else fifth

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple10.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple10.kt
@@ -18,7 +18,39 @@ typealias Tuple10PartialOf<A, B, C, D, E, F, G, H, I> = arrow.Kind9<ForTuple10, 
 inline fun <A, B, C, D, E, F, G, H, I, J> Tuple10Of<A, B, C, D, E, F, G, H, I, J>.fix(): Tuple10<A, B, C, D, E, F, G, H, I, J> =
   this as Tuple10<A, B, C, D, E, F, G, H, I, J>
 
-data class Tuple10<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G, val h: H, val i: I, val j: J) : Tuple10Of<A, B, C, D, E, F, G, H, I, J> {
+data class Tuple10<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J>(
+  @Deprecated("Use first instead", ReplaceWith("first"))
+  val a: A,
+  @Deprecated("Use second instead", ReplaceWith("second"))
+  val b: B,
+  @Deprecated("Use third instead", ReplaceWith("third"))
+  val c: C,
+  @Deprecated("Use fourth instead", ReplaceWith("fourth"))
+  val d: D,
+  @Deprecated("Use fifth instead", ReplaceWith("fifth"))
+  val e: E,
+  @Deprecated("Use sixth instead", ReplaceWith("sixth"))
+  val f: F,
+  @Deprecated("Use seventh instead", ReplaceWith("seventh"))
+  val g: G,
+  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  val h: H,
+  @Deprecated("Use ninth instead", ReplaceWith("ninth"))
+  val i: I,
+  @Deprecated("Use tenth instead", ReplaceWith("tenth"))
+  val j: J
+) : Tuple10Of<A, B, C, D, E, F, G, H, I, J> {
+
+  val first: A = a
+  val second: B = b
+  val third: C = c
+  val fourth: D = d
+  val fifth: E = e
+  val sixth: F = f
+  val seventh: G = g
+  val eight: H = h
+  val ninth: I = i
+  val tenth: J = j
 
   @Deprecated(ShowDeprecation)
   fun show(SA: Show<A>, SB: Show<B>, SC: Show<C>, SD: Show<D>, SE: Show<E>, SF: Show<F>, SG: Show<G>, SH: Show<H>, SI: Show<I>, SJ: Show<J>): String =

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple4.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple4.kt
@@ -18,7 +18,21 @@ typealias Tuple4PartialOf<A, B, C> = arrow.Kind3<ForTuple4, A, B, C>
 inline fun <A, B, C, D> Tuple4Of<A, B, C, D>.fix(): Tuple4<A, B, C, D> =
   this as Tuple4<A, B, C, D>
 
-data class Tuple4<out A, out B, out C, out D>(val a: A, val b: B, val c: C, val d: D) : Tuple4Of<A, B, C, D> {
+data class Tuple4<out A, out B, out C, out D>(
+  @Deprecated("Use first instead", ReplaceWith("first"))
+  val a: A,
+  @Deprecated("Use second instead", ReplaceWith("second"))
+  val b: B,
+  @Deprecated("Use third instead", ReplaceWith("third"))
+  val c: C,
+  @Deprecated("Use fourth instead", ReplaceWith("fourth"))
+  val d: D
+) : Tuple4Of<A, B, C, D> {
+
+  val first: A = a
+  val second: B = b
+  val third: C = c
+  val fourth: D = d
 
   @Deprecated(ShowDeprecation)
   fun show(SA: Show<A>, SB: Show<B>, SC: Show<C>, SD: Show<D>): String =

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple5.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple5.kt
@@ -18,7 +18,24 @@ typealias Tuple5PartialOf<A, B, C, D> = arrow.Kind4<ForTuple5, A, B, C, D>
 inline fun <A, B, C, D, E> Tuple5Of<A, B, C, D, E>.fix(): Tuple5<A, B, C, D, E> =
   this as Tuple5<A, B, C, D, E>
 
-data class Tuple5<out A, out B, out C, out D, out E>(val a: A, val b: B, val c: C, val d: D, val e: E) : Tuple5Of<A, B, C, D, E> {
+data class Tuple5<out A, out B, out C, out D, out E>(
+  @Deprecated("Use first instead", ReplaceWith("first"))
+  val a: A,
+  @Deprecated("Use second instead", ReplaceWith("second"))
+  val b: B,
+  @Deprecated("Use third instead", ReplaceWith("third"))
+  val c: C,
+  @Deprecated("Use fourth instead", ReplaceWith("fourth"))
+  val d: D,
+  @Deprecated("Use fifth instead", ReplaceWith("fifth"))
+  val e: E
+) : Tuple5Of<A, B, C, D, E> {
+
+  val first: A = a
+  val second: B = b
+  val third: C = c
+  val fourth: D = d
+  val fifth: E = e
 
   @Deprecated(ShowDeprecation)
   fun show(SA: Show<A>, SB: Show<B>, SC: Show<C>, SD: Show<D>, SE: Show<E>): String =

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple6.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple6.kt
@@ -18,7 +18,28 @@ typealias Tuple6PartialOf<A, B, C, D, E> = arrow.Kind5<ForTuple6, A, B, C, D, E>
 inline fun <A, B, C, D, E, F> Tuple6Of<A, B, C, D, E, F>.fix(): Tuple6<A, B, C, D, E, F> =
   this as Tuple6<A, B, C, D, E, F>
 
-data class Tuple6<out A, out B, out C, out D, out E, out F>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F) : Tuple6Of<A, B, C, D, E, F> {
+data class Tuple6<out A, out B, out C, out D, out E, out F>(
+  @Deprecated("Use first instead", ReplaceWith("first"))
+  val a: A,
+  @Deprecated("Use second instead", ReplaceWith("second"))
+  val b: B,
+  @Deprecated("Use third instead", ReplaceWith("third"))
+  val c: C,
+  @Deprecated("Use fourth instead", ReplaceWith("fourth"))
+  val d: D,
+  @Deprecated("Use fifth instead", ReplaceWith("fifth"))
+  val e: E,
+  @Deprecated("Use sixth instead", ReplaceWith("sixth"))
+  val f: F
+) : Tuple6Of<A, B, C, D, E, F> {
+
+  val first: A = a
+  val second: B = b
+  val third: C = c
+  val fourth: D = d
+  val fifth: E = e
+  val sixth: F = f
+
   @Deprecated(ShowDeprecation)
   fun show(SA: Show<A>, SB: Show<B>, SC: Show<C>, SD: Show<D>, SE: Show<E>, SF: Show<F>): String =
     "(" + listOf(SA.run { a.show() }, SB.run { b.show() }, SC.run { c.show() }, SD.run { d.show() }, SE.run { e.show() }, SF.run { f.show() }).joinToString(", ") + ")"

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple7.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple7.kt
@@ -18,7 +18,31 @@ typealias Tuple7PartialOf<A, B, C, D, E, F> = arrow.Kind6<ForTuple7, A, B, C, D,
 inline fun <A, B, C, D, E, F, G> Tuple7Of<A, B, C, D, E, F, G>.fix(): Tuple7<A, B, C, D, E, F, G> =
   this as Tuple7<A, B, C, D, E, F, G>
 
-data class Tuple7<out A, out B, out C, out D, out E, out F, out G>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G) : Tuple7Of<A, B, C, D, E, F, G> {
+data class Tuple7<out A, out B, out C, out D, out E, out F, out G>(
+  @Deprecated("Use first instead", ReplaceWith("first"))
+  val a: A,
+  @Deprecated("Use second instead", ReplaceWith("second"))
+  val b: B,
+  @Deprecated("Use third instead", ReplaceWith("third"))
+  val c: C,
+  @Deprecated("Use fourth instead", ReplaceWith("fourth"))
+  val d: D,
+  @Deprecated("Use fifth instead", ReplaceWith("fifth"))
+  val e: E,
+  @Deprecated("Use sixth instead", ReplaceWith("sixth"))
+  val f: F,
+  @Deprecated("Use seventh instead", ReplaceWith("seventh"))
+  val g: G
+) : Tuple7Of<A, B, C, D, E, F, G> {
+
+  val first: A = a
+  val second: B = b
+  val third: C = c
+  val fourth: D = d
+  val fifth: E = e
+  val sixth: F = f
+  val seventh: G = g
+
   @Deprecated(ShowDeprecation)
   fun show(SA: Show<A>, SB: Show<B>, SC: Show<C>, SD: Show<D>, SE: Show<E>, SF: Show<F>, SG: Show<G>): String =
     "(" + listOf(SA.run { a.show() }, SB.run { b.show() }, SC.run { c.show() }, SD.run { d.show() }, SE.run { e.show() }, SF.run { f.show() }, SG.run { g.show() }).joinToString(", ") + ")"

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple8.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple8.kt
@@ -33,7 +33,7 @@ data class Tuple8<out A, out B, out C, out D, out E, out F, out G, out H>(
   val f: F,
   @Deprecated("Use seventh instead", ReplaceWith("seventh"))
   val g: G,
-  @Deprecated("Use eighth instead", ReplaceWith("eigth"))
+  @Deprecated("Use eighth instead", ReplaceWith("eighth"))
   val h: H
 ) : Tuple8Of<A, B, C, D, E, F, G, H> {
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple8.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple8.kt
@@ -33,7 +33,7 @@ data class Tuple8<out A, out B, out C, out D, out E, out F, out G, out H>(
   val f: F,
   @Deprecated("Use seventh instead", ReplaceWith("seventh"))
   val g: G,
-  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  @Deprecated("Use eighth instead", ReplaceWith("eigth"))
   val h: H
 ) : Tuple8Of<A, B, C, D, E, F, G, H> {
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple8.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple8.kt
@@ -18,7 +18,34 @@ typealias Tuple8PartialOf<A, B, C, D, E, F, G> = arrow.Kind7<ForTuple8, A, B, C,
 inline fun <A, B, C, D, E, F, G, H> Tuple8Of<A, B, C, D, E, F, G, H>.fix(): Tuple8<A, B, C, D, E, F, G, H> =
   this as Tuple8<A, B, C, D, E, F, G, H>
 
-data class Tuple8<out A, out B, out C, out D, out E, out F, out G, out H>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G, val h: H) : Tuple8Of<A, B, C, D, E, F, G, H> {
+data class Tuple8<out A, out B, out C, out D, out E, out F, out G, out H>(
+  @Deprecated("Use first instead", ReplaceWith("first"))
+  val a: A,
+  @Deprecated("Use second instead", ReplaceWith("second"))
+  val b: B,
+  @Deprecated("Use third instead", ReplaceWith("third"))
+  val c: C,
+  @Deprecated("Use fourth instead", ReplaceWith("fourth"))
+  val d: D,
+  @Deprecated("Use fifth instead", ReplaceWith("fifth"))
+  val e: E,
+  @Deprecated("Use sixth instead", ReplaceWith("sixth"))
+  val f: F,
+  @Deprecated("Use seventh instead", ReplaceWith("seventh"))
+  val g: G,
+  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  val h: H
+) : Tuple8Of<A, B, C, D, E, F, G, H> {
+
+  val first: A = a
+  val second: B = b
+  val third: C = c
+  val fourth: D = d
+  val fifth: E = e
+  val sixth: F = f
+  val seventh: G = g
+  val eight: H = h
+
   @Deprecated(ShowDeprecation)
   fun show(SA: Show<A>, SB: Show<B>, SC: Show<C>, SD: Show<D>, SE: Show<E>, SF: Show<F>, SG: Show<G>, SH: Show<H>): String =
     "(" + listOf(SA.run { a.show() }, SB.run { b.show() }, SC.run { c.show() }, SD.run { d.show() }, SE.run { e.show() }, SF.run { f.show() }, SG.run { g.show() }, SH.run { h.show() }).joinToString(", ") + ")"

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple9.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple9.kt
@@ -18,7 +18,37 @@ typealias Tuple9PartialOf<A, B, C, D, E, F, G, H> = arrow.Kind8<ForTuple9, A, B,
 inline fun <A, B, C, D, E, F, G, H, I> Tuple9Of<A, B, C, D, E, F, G, H, I>.fix(): Tuple9<A, B, C, D, E, F, G, H, I> =
   this as Tuple9<A, B, C, D, E, F, G, H, I>
 
-data class Tuple9<out A, out B, out C, out D, out E, out F, out G, out H, out I>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G, val h: H, val i: I) : Tuple9Of<A, B, C, D, E, F, G, H, I> {
+data class Tuple9<out A, out B, out C, out D, out E, out F, out G, out H, out I>(
+  @Deprecated("Use first instead", ReplaceWith("first"))
+  val a: A,
+  @Deprecated("Use second instead", ReplaceWith("second"))
+  val b: B,
+  @Deprecated("Use third instead", ReplaceWith("third"))
+  val c: C,
+  @Deprecated("Use fourth instead", ReplaceWith("fourth"))
+  val d: D,
+  @Deprecated("Use fifth instead", ReplaceWith("fifth"))
+  val e: E,
+  @Deprecated("Use sixth instead", ReplaceWith("sixth"))
+  val f: F,
+  @Deprecated("Use seventh instead", ReplaceWith("seventh"))
+  val g: G,
+  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  val h: H,
+  @Deprecated("Use ninth instead", ReplaceWith("ninth"))
+  val i: I
+) : Tuple9Of<A, B, C, D, E, F, G, H, I> {
+
+  val first: A = a
+  val second: B = b
+  val third: C = c
+  val fourth: D = d
+  val fifth: E = e
+  val sixth: F = f
+  val seventh: G = g
+  val eight: H = h
+  val ninth: I = i
+
   @Deprecated(ShowDeprecation)
   fun show(SA: Show<A>, SB: Show<B>, SC: Show<C>, SD: Show<D>, SE: Show<E>, SF: Show<F>, SG: Show<G>, SH: Show<H>, SI: Show<I>): String =
     "(" + listOf(SA.run { a.show() }, SB.run { b.show() }, SC.run { c.show() }, SD.run { d.show() }, SE.run { e.show() }, SF.run { f.show() }, SG.run { g.show() }, SH.run { h.show() }, SI.run { i.show() }).joinToString(", ") + ")"

--- a/arrow-core-data/src/main/kotlin/arrow/core/Tuple9.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Tuple9.kt
@@ -33,7 +33,7 @@ data class Tuple9<out A, out B, out C, out D, out E, out F, out G, out H, out I>
   val f: F,
   @Deprecated("Use seventh instead", ReplaceWith("seventh"))
   val g: G,
-  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  @Deprecated("Use eighth instead", ReplaceWith("eighth"))
   val h: H,
   @Deprecated("Use ninth instead", ReplaceWith("ninth"))
   val i: I
@@ -156,9 +156,9 @@ operator fun <A : Comparable<A>, B : Comparable<B>, C : Comparable<C>, D : Compa
             if (sixth == 0) {
               val seventh = g.compareTo(other.g)
               if (seventh == 0) {
-                val eigth = h.compareTo(other.h)
-                if (eigth == 0) i.compareTo(other.i)
-                else eigth
+                val eighth = h.compareTo(other.h)
+                if (eighth == 0) i.compareTo(other.i)
+                else eighth
               } else seventh
             } else sixth
           } else fifth

--- a/arrow-core-data/src/main/kotlin/arrow/core/TupleN.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/TupleN.kt
@@ -6,7 +6,9 @@ package arrow.core
 import java.util.Collections
 import kotlin.collections.LinkedHashMap
 
-class ForTuple11 private constructor() { companion object }
+class ForTuple11 private constructor() {
+  companion object
+}
 typealias Tuple11Of<A, B, C, D, E, F, G, H, I, J, K> = arrow.Kind11<ForTuple11, A, B, C, D, E, F, G, H, I, J, K>
 typealias Tuple11PartialOf<A, B, C, D, E, F, G, H, I, J> = arrow.Kind10<ForTuple11, A, B, C, D, E, F, G, H, I, J>
 
@@ -14,11 +16,48 @@ typealias Tuple11PartialOf<A, B, C, D, E, F, G, H, I, J> = arrow.Kind10<ForTuple
 inline fun <A, B, C, D, E, F, G, H, I, J, K> Tuple11Of<A, B, C, D, E, F, G, H, I, J, K>.fix(): Tuple11<A, B, C, D, E, F, G, H, I, J, K> =
   this as Tuple11<A, B, C, D, E, F, G, H, I, J, K>
 
-data class Tuple11<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J, out K>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G, val h: H, val i: I, val j: J, val k: K) : Tuple11Of<A, B, C, D, E, F, G, H, I, J, K> {
+data class Tuple11<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J, out K>(
+  @Deprecated("Use first instead", ReplaceWith("first"))
+  val a: A,
+  @Deprecated("Use second instead", ReplaceWith("second"))
+  val b: B,
+  @Deprecated("Use third instead", ReplaceWith("third"))
+  val c: C,
+  @Deprecated("Use fourth instead", ReplaceWith("fourth"))
+  val d: D,
+  @Deprecated("Use fifth instead", ReplaceWith("fifth"))
+  val e: E,
+  @Deprecated("Use sixth instead", ReplaceWith("sixth"))
+  val f: F,
+  @Deprecated("Use seventh instead", ReplaceWith("seventh"))
+  val g: G,
+  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  val h: H,
+  @Deprecated("Use ninth instead", ReplaceWith("ninth"))
+  val i: I,
+  @Deprecated("Use tenth instead", ReplaceWith("tenth"))
+  val j: J,
+  @Deprecated("Use eleventh instead", ReplaceWith("eleventh"))
+  val k: K
+) : Tuple11Of<A, B, C, D, E, F, G, H, I, J, K> {
+  val first: A = a
+  val second: B = b
+  val third: C = c
+  val fourth: D = d
+  val fifth: E = e
+  val sixth: F = f
+  val seventh: G = g
+  val eight: H = h
+  val ninth: I = i
+  val tenth: J = j
+  val eleventh: K = k
+
   companion object
 }
 
-class ForTuple12 private constructor() { companion object }
+class ForTuple12 private constructor() {
+  companion object
+}
 typealias Tuple12Of<A, B, C, D, E, F, G, H, I, J, K, L> = arrow.Kind12<ForTuple12, A, B, C, D, E, F, G, H, I, J, K, L>
 typealias Tuple12PartialOf<A, B, C, D, E, F, G, H, I, J, K> = arrow.Kind11<ForTuple12, A, B, C, D, E, F, G, H, I, J, K>
 
@@ -26,11 +65,51 @@ typealias Tuple12PartialOf<A, B, C, D, E, F, G, H, I, J, K> = arrow.Kind11<ForTu
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L> Tuple12Of<A, B, C, D, E, F, G, H, I, J, K, L>.fix(): Tuple12<A, B, C, D, E, F, G, H, I, J, K, L> =
   this as Tuple12<A, B, C, D, E, F, G, H, I, J, K, L>
 
-data class Tuple12<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J, out K, out L>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G, val h: H, val i: I, val j: J, val k: K, val l: L) : Tuple12Of<A, B, C, D, E, F, G, H, I, J, K, L> {
+data class Tuple12<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J, out K, out L>(
+  @Deprecated("Use first instead", ReplaceWith("first"))
+  val a: A,
+  @Deprecated("Use second instead", ReplaceWith("second"))
+  val b: B,
+  @Deprecated("Use third instead", ReplaceWith("third"))
+  val c: C,
+  @Deprecated("Use fourth instead", ReplaceWith("fourth"))
+  val d: D,
+  @Deprecated("Use fifth instead", ReplaceWith("fifth"))
+  val e: E,
+  @Deprecated("Use sixth instead", ReplaceWith("sixth"))
+  val f: F,
+  @Deprecated("Use seventh instead", ReplaceWith("seventh"))
+  val g: G,
+  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  val h: H,
+  @Deprecated("Use ninth instead", ReplaceWith("ninth"))
+  val i: I,
+  @Deprecated("Use tenth instead", ReplaceWith("tenth"))
+  val j: J,
+  @Deprecated("Use eleventh instead", ReplaceWith("eleventh"))
+  val k: K,
+  @Deprecated("Use twelfth instead", ReplaceWith("twelfth"))
+  val l: L
+) : Tuple12Of<A, B, C, D, E, F, G, H, I, J, K, L> {
+  val first: A = a
+  val second: B = b
+  val third: C = c
+  val fourth: D = d
+  val fifth: E = e
+  val sixth: F = f
+  val seventh: G = g
+  val eight: H = h
+  val ninth: I = i
+  val tenth: J = j
+  val eleventh: K = k
+  val twelfth: L = l
+
   companion object
 }
 
-class ForTuple13 private constructor() { companion object }
+class ForTuple13 private constructor() {
+  companion object
+}
 typealias Tuple13Of<A, B, C, D, E, F, G, H, I, J, K, L, M> = arrow.Kind13<ForTuple13, A, B, C, D, E, F, G, H, I, J, K, L, M>
 typealias Tuple13PartialOf<A, B, C, D, E, F, G, H, I, J, K, L> = arrow.Kind12<ForTuple13, A, B, C, D, E, F, G, H, I, J, K, L>
 
@@ -38,11 +117,54 @@ typealias Tuple13PartialOf<A, B, C, D, E, F, G, H, I, J, K, L> = arrow.Kind12<Fo
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M> Tuple13Of<A, B, C, D, E, F, G, H, I, J, K, L, M>.fix(): Tuple13<A, B, C, D, E, F, G, H, I, J, K, L, M> =
   this as Tuple13<A, B, C, D, E, F, G, H, I, J, K, L, M>
 
-data class Tuple13<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J, out K, out L, out M>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G, val h: H, val i: I, val j: J, val k: K, val l: L, val m: M) : Tuple13Of<A, B, C, D, E, F, G, H, I, J, K, L, M> {
+data class Tuple13<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J, out K, out L, out M>(
+  @Deprecated("Use first instead", ReplaceWith("first"))
+  val a: A,
+  @Deprecated("Use second instead", ReplaceWith("second"))
+  val b: B,
+  @Deprecated("Use third instead", ReplaceWith("third"))
+  val c: C,
+  @Deprecated("Use fourth instead", ReplaceWith("fourth"))
+  val d: D,
+  @Deprecated("Use fifth instead", ReplaceWith("fifth"))
+  val e: E,
+  @Deprecated("Use sixth instead", ReplaceWith("sixth"))
+  val f: F,
+  @Deprecated("Use seventh instead", ReplaceWith("seventh"))
+  val g: G,
+  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  val h: H,
+  @Deprecated("Use ninth instead", ReplaceWith("ninth"))
+  val i: I,
+  @Deprecated("Use tenth instead", ReplaceWith("tenth"))
+  val j: J,
+  @Deprecated("Use eleventh instead", ReplaceWith("eleventh"))
+  val k: K,
+  @Deprecated("Use twelfth instead", ReplaceWith("twelfth"))
+  val l: L,
+  @Deprecated("Use thirteenth instead", ReplaceWith("thirteenth"))
+  val m: M
+) : Tuple13Of<A, B, C, D, E, F, G, H, I, J, K, L, M> {
+  val first: A = a
+  val second: B = b
+  val third: C = c
+  val fourth: D = d
+  val fifth: E = e
+  val sixth: F = f
+  val seventh: G = g
+  val eight: H = h
+  val ninth: I = i
+  val tenth: J = j
+  val eleventh: K = k
+  val twelfth: L = l
+  val thirteenth: M = m
+
   companion object
 }
 
-class ForTuple14 private constructor() { companion object }
+class ForTuple14 private constructor() {
+  companion object
+}
 typealias Tuple14Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N> = arrow.Kind14<ForTuple14, A, B, C, D, E, F, G, H, I, J, K, L, M, N>
 typealias Tuple14PartialOf<A, B, C, D, E, F, G, H, I, J, K, L, M> = arrow.Kind13<ForTuple14, A, B, C, D, E, F, G, H, I, J, K, L, M>
 
@@ -50,11 +172,57 @@ typealias Tuple14PartialOf<A, B, C, D, E, F, G, H, I, J, K, L, M> = arrow.Kind13
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N> Tuple14Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N>.fix(): Tuple14<A, B, C, D, E, F, G, H, I, J, K, L, M, N> =
   this as Tuple14<A, B, C, D, E, F, G, H, I, J, K, L, M, N>
 
-data class Tuple14<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J, out K, out L, out M, out N>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G, val h: H, val i: I, val j: J, val k: K, val l: L, val m: M, val n: N) : Tuple14Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N> {
+data class Tuple14<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J, out K, out L, out M, out N>(
+  @Deprecated("Use first instead", ReplaceWith("first"))
+  val a: A,
+  @Deprecated("Use second instead", ReplaceWith("second"))
+  val b: B,
+  @Deprecated("Use third instead", ReplaceWith("third"))
+  val c: C,
+  @Deprecated("Use fourth instead", ReplaceWith("fourth"))
+  val d: D,
+  @Deprecated("Use fifth instead", ReplaceWith("fifth"))
+  val e: E,
+  @Deprecated("Use sixth instead", ReplaceWith("sixth"))
+  val f: F,
+  @Deprecated("Use seventh instead", ReplaceWith("seventh"))
+  val g: G,
+  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  val h: H,
+  @Deprecated("Use ninth instead", ReplaceWith("ninth"))
+  val i: I,
+  @Deprecated("Use tenth instead", ReplaceWith("tenth"))
+  val j: J,
+  @Deprecated("Use eleventh instead", ReplaceWith("eleventh"))
+  val k: K,
+  @Deprecated("Use twelfth instead", ReplaceWith("twelfth"))
+  val l: L,
+  @Deprecated("Use thirteenth instead", ReplaceWith("thirteenth"))
+  val m: M,
+  @Deprecated("Use fourteenth instead", ReplaceWith("fourteenth"))
+  val n: N
+) : Tuple14Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N> {
+  val first: A = a
+  val second: B = b
+  val third: C = c
+  val fourth: D = d
+  val fifth: E = e
+  val sixth: F = f
+  val seventh: G = g
+  val eight: H = h
+  val ninth: I = i
+  val tenth: J = j
+  val eleventh: K = k
+  val twelfth: L = l
+  val thirteenth: M = m
+  val fourteenth: N = n
+
   companion object
 }
 
-class ForTuple15 private constructor() { companion object }
+class ForTuple15 private constructor() {
+  companion object
+}
 typealias Tuple15Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> = arrow.Kind15<ForTuple15, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>
 typealias Tuple15PartialOf<A, B, C, D, E, F, G, H, I, J, K, L, M, N> = arrow.Kind14<ForTuple15, A, B, C, D, E, F, G, H, I, J, K, L, M, N>
 
@@ -62,11 +230,60 @@ typealias Tuple15PartialOf<A, B, C, D, E, F, G, H, I, J, K, L, M, N> = arrow.Kin
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> Tuple15Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>.fix(): Tuple15<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> =
   this as Tuple15<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>
 
-data class Tuple15<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J, out K, out L, out M, out N, out O>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G, val h: H, val i: I, val j: J, val k: K, val l: L, val m: M, val n: N, val o: O) : Tuple15Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> {
+data class Tuple15<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J, out K, out L, out M, out N, out O>(
+  @Deprecated("Use first instead", ReplaceWith("first"))
+  val a: A,
+  @Deprecated("Use second instead", ReplaceWith("second"))
+  val b: B,
+  @Deprecated("Use third instead", ReplaceWith("third"))
+  val c: C,
+  @Deprecated("Use fourth instead", ReplaceWith("fourth"))
+  val d: D,
+  @Deprecated("Use fifth instead", ReplaceWith("fifth"))
+  val e: E,
+  @Deprecated("Use sixth instead", ReplaceWith("sixth"))
+  val f: F,
+  @Deprecated("Use seventh instead", ReplaceWith("seventh"))
+  val g: G,
+  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  val h: H,
+  @Deprecated("Use ninth instead", ReplaceWith("ninth"))
+  val i: I,
+  @Deprecated("Use tenth instead", ReplaceWith("tenth"))
+  val j: J,
+  @Deprecated("Use eleventh instead", ReplaceWith("eleventh"))
+  val k: K,
+  @Deprecated("Use twelfth instead", ReplaceWith("twelfth"))
+  val l: L,
+  @Deprecated("Use thirteenth instead", ReplaceWith("thirteenth"))
+  val m: M,
+  @Deprecated("Use fourteenth instead", ReplaceWith("fourteenth"))
+  val n: N,
+  @Deprecated("Use fifteenth instead", ReplaceWith("fifteenth"))
+  val o: O
+) : Tuple15Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> {
+  val first: A = a
+  val second: B = b
+  val third: C = c
+  val fourth: D = d
+  val fifth: E = e
+  val sixth: F = f
+  val seventh: G = g
+  val eight: H = h
+  val ninth: I = i
+  val tenth: J = j
+  val eleventh: K = k
+  val twelfth: L = l
+  val thirteenth: M = m
+  val fourteenth: N = n
+  val fifteenth: O = o
+
   companion object
 }
 
-class ForTuple16 private constructor() { companion object }
+class ForTuple16 private constructor() {
+  companion object
+}
 typealias Tuple16Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> = arrow.Kind16<ForTuple16, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>
 typealias Tuple16PartialOf<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> = arrow.Kind15<ForTuple16, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>
 
@@ -74,11 +291,63 @@ typealias Tuple16PartialOf<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> = arrow.
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> Tuple16Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>.fix(): Tuple16<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> =
   this as Tuple16<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>
 
-data class Tuple16<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J, out K, out L, out M, out N, out O, out P>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G, val h: H, val i: I, val j: J, val k: K, val l: L, val m: M, val n: N, val o: O, val p: P) : Tuple16Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> {
+data class Tuple16<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J, out K, out L, out M, out N, out O, out P>(
+  @Deprecated("Use first instead", ReplaceWith("first"))
+  val a: A,
+  @Deprecated("Use second instead", ReplaceWith("second"))
+  val b: B,
+  @Deprecated("Use third instead", ReplaceWith("third"))
+  val c: C,
+  @Deprecated("Use fourth instead", ReplaceWith("fourth"))
+  val d: D,
+  @Deprecated("Use fifth instead", ReplaceWith("fifth"))
+  val e: E,
+  @Deprecated("Use sixth instead", ReplaceWith("sixth"))
+  val f: F,
+  @Deprecated("Use seventh instead", ReplaceWith("seventh"))
+  val g: G,
+  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  val h: H,
+  @Deprecated("Use ninth instead", ReplaceWith("ninth"))
+  val i: I,
+  @Deprecated("Use tenth instead", ReplaceWith("tenth"))
+  val j: J,
+  @Deprecated("Use eleventh instead", ReplaceWith("eleventh"))
+  val k: K,
+  @Deprecated("Use twelfth instead", ReplaceWith("twelfth"))
+  val l: L,
+  @Deprecated("Use thirteenth instead", ReplaceWith("thirteenth"))
+  val m: M,
+  @Deprecated("Use fourteenth instead", ReplaceWith("fourteenth"))
+  val n: N,
+  @Deprecated("Use fifteenth instead", ReplaceWith("fifteenth"))
+  val o: O,
+  @Deprecated("Use sixteenth instead", ReplaceWith("sixteenth"))
+  val p: P
+) : Tuple16Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> {
+  val first: A = a
+  val second: B = b
+  val third: C = c
+  val fourth: D = d
+  val fifth: E = e
+  val sixth: F = f
+  val seventh: G = g
+  val eight: H = h
+  val ninth: I = i
+  val tenth: J = j
+  val eleventh: K = k
+  val twelfth: L = l
+  val thirteenth: M = m
+  val fourteenth: N = n
+  val fifteenth: O = o
+  val sixteenth: P = p
+
   companion object
 }
 
-class ForTuple17 private constructor() { companion object }
+class ForTuple17 private constructor() {
+  companion object
+}
 typealias Tuple17Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> = arrow.Kind17<ForTuple17, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>
 typealias Tuple17PartialOf<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> = arrow.Kind16<ForTuple17, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>
 
@@ -86,11 +355,66 @@ typealias Tuple17PartialOf<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> = arr
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> Tuple17Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>.fix(): Tuple17<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> =
   this as Tuple17<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>
 
-data class Tuple17<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J, out K, out L, out M, out N, out O, out P, out Q>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G, val h: H, val i: I, val j: J, val k: K, val l: L, val m: M, val n: N, val o: O, val p: P, val q: Q) : Tuple17Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> {
+data class Tuple17<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J, out K, out L, out M, out N, out O, out P, out Q>(
+  @Deprecated("Use first instead", ReplaceWith("first"))
+  val a: A,
+  @Deprecated("Use second instead", ReplaceWith("second"))
+  val b: B,
+  @Deprecated("Use third instead", ReplaceWith("third"))
+  val c: C,
+  @Deprecated("Use fourth instead", ReplaceWith("fourth"))
+  val d: D,
+  @Deprecated("Use fifth instead", ReplaceWith("fifth"))
+  val e: E,
+  @Deprecated("Use sixth instead", ReplaceWith("sixth"))
+  val f: F,
+  @Deprecated("Use seventh instead", ReplaceWith("seventh"))
+  val g: G,
+  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  val h: H,
+  @Deprecated("Use ninth instead", ReplaceWith("ninth"))
+  val i: I,
+  @Deprecated("Use tenth instead", ReplaceWith("tenth"))
+  val j: J,
+  @Deprecated("Use eleventh instead", ReplaceWith("eleventh"))
+  val k: K,
+  @Deprecated("Use twelfth instead", ReplaceWith("twelfth"))
+  val l: L,
+  @Deprecated("Use thirteenth instead", ReplaceWith("thirteenth"))
+  val m: M,
+  @Deprecated("Use fourteenth instead", ReplaceWith("fourteenth"))
+  val n: N,
+  @Deprecated("Use fifteenth instead", ReplaceWith("fifteenth"))
+  val o: O,
+  @Deprecated("Use sixteenth instead", ReplaceWith("sixteenth"))
+  val p: P,
+  @Deprecated("Use seventeenth instead", ReplaceWith("seventeenth"))
+  val q: Q
+) : Tuple17Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> {
+  val first: A = a
+  val second: B = b
+  val third: C = c
+  val fourth: D = d
+  val fifth: E = e
+  val sixth: F = f
+  val seventh: G = g
+  val eight: H = h
+  val ninth: I = i
+  val tenth: J = j
+  val eleventh: K = k
+  val twelfth: L = l
+  val thirteenth: M = m
+  val fourteenth: N = n
+  val fifteenth: O = o
+  val sixteenth: P = p
+  val seventeenth: Q = q
+
   companion object
 }
 
-class ForTuple18 private constructor() { companion object }
+class ForTuple18 private constructor() {
+  companion object
+}
 typealias Tuple18Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> = arrow.Kind18<ForTuple18, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>
 typealias Tuple18PartialOf<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> = arrow.Kind17<ForTuple18, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>
 
@@ -98,11 +422,69 @@ typealias Tuple18PartialOf<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> = 
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> Tuple18Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>.fix(): Tuple18<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> =
   this as Tuple18<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>
 
-data class Tuple18<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J, out K, out L, out M, out N, out O, out P, out Q, out R>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G, val h: H, val i: I, val j: J, val k: K, val l: L, val m: M, val n: N, val o: O, val p: P, val q: Q, val r: R) : Tuple18Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> {
+data class Tuple18<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J, out K, out L, out M, out N, out O, out P, out Q, out R>(
+  @Deprecated("Use first instead", ReplaceWith("first"))
+  val a: A,
+  @Deprecated("Use second instead", ReplaceWith("second"))
+  val b: B,
+  @Deprecated("Use third instead", ReplaceWith("third"))
+  val c: C,
+  @Deprecated("Use fourth instead", ReplaceWith("fourth"))
+  val d: D,
+  @Deprecated("Use fifth instead", ReplaceWith("fifth"))
+  val e: E,
+  @Deprecated("Use sixth instead", ReplaceWith("sixth"))
+  val f: F,
+  @Deprecated("Use seventh instead", ReplaceWith("seventh"))
+  val g: G,
+  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  val h: H,
+  @Deprecated("Use ninth instead", ReplaceWith("ninth"))
+  val i: I,
+  @Deprecated("Use tenth instead", ReplaceWith("tenth"))
+  val j: J,
+  @Deprecated("Use eleventh instead", ReplaceWith("eleventh"))
+  val k: K,
+  @Deprecated("Use twelfth instead", ReplaceWith("twelfth"))
+  val l: L,
+  @Deprecated("Use thirteenth instead", ReplaceWith("thirteenth"))
+  val m: M,
+  @Deprecated("Use fourteenth instead", ReplaceWith("fourteenth"))
+  val n: N,
+  @Deprecated("Use fifteenth instead", ReplaceWith("fifteenth"))
+  val o: O,
+  @Deprecated("Use sixteenth instead", ReplaceWith("sixteenth"))
+  val p: P,
+  @Deprecated("Use seventeenth instead", ReplaceWith("seventeenth"))
+  val q: Q,
+  @Deprecated("Use eighteenth instead", ReplaceWith("eighteenth"))
+  val r: R
+) : Tuple18Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> {
+  val first: A = a
+  val second: B = b
+  val third: C = c
+  val fourth: D = d
+  val fifth: E = e
+  val sixth: F = f
+  val seventh: G = g
+  val eight: H = h
+  val ninth: I = i
+  val tenth: J = j
+  val eleventh: K = k
+  val twelfth: L = l
+  val thirteenth: M = m
+  val fourteenth: N = n
+  val fifteenth: O = o
+  val sixteenth: P = p
+  val seventeenth: Q = q
+  val eighteenth: R = r
+
   companion object
 }
 
-class ForTuple19 private constructor() { companion object }
+class ForTuple19 private constructor() {
+  companion object
+}
 typealias Tuple19Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> = arrow.Kind19<ForTuple19, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>
 typealias Tuple19PartialOf<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> = arrow.Kind18<ForTuple19, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>
 
@@ -110,11 +492,72 @@ typealias Tuple19PartialOf<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> Tuple19Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>.fix(): Tuple19<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> =
   this as Tuple19<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>
 
-data class Tuple19<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J, out K, out L, out M, out N, out O, out P, out Q, out R, out S>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G, val h: H, val i: I, val j: J, val k: K, val l: L, val m: M, val n: N, val o: O, val p: P, val q: Q, val r: R, val s: S) : Tuple19Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> {
+data class Tuple19<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J, out K, out L, out M, out N, out O, out P, out Q, out R, out S>(
+  @Deprecated("Use first instead", ReplaceWith("first"))
+  val a: A,
+  @Deprecated("Use second instead", ReplaceWith("second"))
+  val b: B,
+  @Deprecated("Use third instead", ReplaceWith("third"))
+  val c: C,
+  @Deprecated("Use fourth instead", ReplaceWith("fourth"))
+  val d: D,
+  @Deprecated("Use fifth instead", ReplaceWith("fifth"))
+  val e: E,
+  @Deprecated("Use sixth instead", ReplaceWith("sixth"))
+  val f: F,
+  @Deprecated("Use seventh instead", ReplaceWith("seventh"))
+  val g: G,
+  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  val h: H,
+  @Deprecated("Use ninth instead", ReplaceWith("ninth"))
+  val i: I,
+  @Deprecated("Use tenth instead", ReplaceWith("tenth"))
+  val j: J,
+  @Deprecated("Use eleventh instead", ReplaceWith("eleventh"))
+  val k: K,
+  @Deprecated("Use twelfth instead", ReplaceWith("twelfth"))
+  val l: L,
+  @Deprecated("Use thirteenth instead", ReplaceWith("thirteenth"))
+  val m: M,
+  @Deprecated("Use fourteenth instead", ReplaceWith("fourteenth"))
+  val n: N,
+  @Deprecated("Use fifteenth instead", ReplaceWith("fifteenth"))
+  val o: O,
+  @Deprecated("Use sixteenth instead", ReplaceWith("sixteenth"))
+  val p: P,
+  @Deprecated("Use seventeenth instead", ReplaceWith("seventeenth"))
+  val q: Q,
+  @Deprecated("Use eighteenth instead", ReplaceWith("eighteenth"))
+  val r: R,
+  @Deprecated("Use nineteenth instead", ReplaceWith("nineteenth"))
+  val s: S
+) : Tuple19Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> {
+  val first: A = a
+  val second: B = b
+  val third: C = c
+  val fourth: D = d
+  val fifth: E = e
+  val sixth: F = f
+  val seventh: G = g
+  val eight: H = h
+  val ninth: I = i
+  val tenth: J = j
+  val eleventh: K = k
+  val twelfth: L = l
+  val thirteenth: M = m
+  val fourteenth: N = n
+  val fifteenth: O = o
+  val sixteenth: P = p
+  val seventeenth: Q = q
+  val eighteenth: R = r
+  val nineteenth: S = s
+
   companion object
 }
 
-class ForTuple20 private constructor() { companion object }
+class ForTuple20 private constructor() {
+  companion object
+}
 typealias Tuple20Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> = arrow.Kind20<ForTuple20, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>
 typealias Tuple20PartialOf<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> = arrow.Kind19<ForTuple20, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>
 
@@ -122,11 +565,75 @@ typealias Tuple20PartialOf<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R,
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> Tuple20Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>.fix(): Tuple20<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> =
   this as Tuple20<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>
 
-data class Tuple20<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J, out K, out L, out M, out N, out O, out P, out Q, out R, out S, out T>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G, val h: H, val i: I, val j: J, val k: K, val l: L, val m: M, val n: N, val o: O, val p: P, val q: Q, val r: R, val s: S, val t: T) : Tuple20Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> {
+data class Tuple20<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J, out K, out L, out M, out N, out O, out P, out Q, out R, out S, out T>(
+  @Deprecated("Use first instead", ReplaceWith("first"))
+  val a: A,
+  @Deprecated("Use second instead", ReplaceWith("second"))
+  val b: B,
+  @Deprecated("Use third instead", ReplaceWith("third"))
+  val c: C,
+  @Deprecated("Use fourth instead", ReplaceWith("fourth"))
+  val d: D,
+  @Deprecated("Use fifth instead", ReplaceWith("fifth"))
+  val e: E,
+  @Deprecated("Use sixth instead", ReplaceWith("sixth"))
+  val f: F,
+  @Deprecated("Use seventh instead", ReplaceWith("seventh"))
+  val g: G,
+  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  val h: H,
+  @Deprecated("Use ninth instead", ReplaceWith("ninth"))
+  val i: I,
+  @Deprecated("Use tenth instead", ReplaceWith("tenth"))
+  val j: J,
+  @Deprecated("Use eleventh instead", ReplaceWith("eleventh"))
+  val k: K,
+  @Deprecated("Use twelfth instead", ReplaceWith("twelfth"))
+  val l: L,
+  @Deprecated("Use thirteenth instead", ReplaceWith("thirteenth"))
+  val m: M,
+  @Deprecated("Use fourteenth instead", ReplaceWith("fourteenth"))
+  val n: N,
+  @Deprecated("Use fifteenth instead", ReplaceWith("fifteenth"))
+  val o: O,
+  @Deprecated("Use sixteenth instead", ReplaceWith("sixteenth"))
+  val p: P,
+  @Deprecated("Use seventeenth instead", ReplaceWith("seventeenth"))
+  val q: Q,
+  @Deprecated("Use eighteenth instead", ReplaceWith("eighteenth"))
+  val r: R,
+  @Deprecated("Use nineteenth instead", ReplaceWith("nineteenth"))
+  val s: S,
+  @Deprecated("Use twentieth instead", ReplaceWith("twentieth"))
+  val t: T
+) : Tuple20Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> {
+  val first: A = a
+  val second: B = b
+  val third: C = c
+  val fourth: D = d
+  val fifth: E = e
+  val sixth: F = f
+  val seventh: G = g
+  val eight: H = h
+  val ninth: I = i
+  val tenth: J = j
+  val eleventh: K = k
+  val twelfth: L = l
+  val thirteenth: M = m
+  val fourteenth: N = n
+  val fifteenth: O = o
+  val sixteenth: P = p
+  val seventeenth: Q = q
+  val eighteenth: R = r
+  val nineteenth: S = s
+  val twentieth: T = t
+
   companion object
 }
 
-class ForTuple21 private constructor() { companion object }
+class ForTuple21 private constructor() {
+  companion object
+}
 typealias Tuple21Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> = arrow.Kind21<ForTuple21, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>
 typealias Tuple21PartialOf<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> = arrow.Kind20<ForTuple21, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>
 
@@ -134,11 +641,77 @@ typealias Tuple21PartialOf<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R,
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> Tuple21Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>.fix(): Tuple21<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> =
   this as Tuple21<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>
 
-data class Tuple21<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J, out K, out L, out M, out N, out O, out P, out Q, out R, out S, out T, out U>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G, val h: H, val i: I, val j: J, val k: K, val l: L, val m: M, val n: N, val o: O, val p: P, val q: Q, val r: R, val s: S, val t: T, val u: U) : Tuple21Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> {
+data class Tuple21<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J, out K, out L, out M, out N, out O, out P, out Q, out R, out S, out T, out U>(
+  @Deprecated("Use first instead", ReplaceWith("first"))
+  val a: A,
+  @Deprecated("Use second instead", ReplaceWith("second"))
+  val b: B,
+  @Deprecated("Use third instead", ReplaceWith("third"))
+  val c: C,
+  @Deprecated("Use fourth instead", ReplaceWith("fourth"))
+  val d: D,
+  @Deprecated("Use fifth instead", ReplaceWith("fifth"))
+  val e: E,
+  @Deprecated("Use sixth instead", ReplaceWith("sixth"))
+  val f: F,
+  @Deprecated("Use seventh instead", ReplaceWith("seventh"))
+  val g: G,
+  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  val h: H,
+  @Deprecated("Use ninth instead", ReplaceWith("ninth"))
+  val i: I,
+  @Deprecated("Use tenth instead", ReplaceWith("tenth"))
+  val j: J,
+  @Deprecated("Use eleventh instead", ReplaceWith("eleventh"))
+  val k: K,
+  @Deprecated("Use twelfth instead", ReplaceWith("twelfth"))
+  val l: L,
+  @Deprecated("Use thirteenth instead", ReplaceWith("thirteenth"))
+  val m: M,
+  @Deprecated("Use fourteenth instead", ReplaceWith("fourteenth"))
+  val n: N,
+  @Deprecated("Use fifteenth instead", ReplaceWith("fifteenth"))
+  val o: O,
+  @Deprecated("Use sixteenth instead", ReplaceWith("sixteenth"))
+  val p: P,
+  @Deprecated("Use seventeenth instead", ReplaceWith("seventeenth"))
+  val q: Q,
+  @Deprecated("Use eighteenth instead", ReplaceWith("eighteenth"))
+  val r: R,
+  @Deprecated("Use nineteenth instead", ReplaceWith("nineteenth"))
+  val s: S,
+  @Deprecated("Use twentieth instead", ReplaceWith("twentieth"))
+  val t: T,
+  @Deprecated("Use twentyFirst instead", ReplaceWith("twentyFirst"))
+  val u: U
+) : Tuple21Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> {
+  val first: A = a
+  val second: B = b
+  val third: C = c
+  val fourth: D = d
+  val fifth: E = e
+  val sixth: F = f
+  val seventh: G = g
+  val eight: H = h
+  val ninth: I = i
+  val tenth: J = j
+  val eleventh: K = k
+  val twelfth: L = l
+  val thirteenth: M = m
+  val fourteenth: N = n
+  val fifteenth: O = o
+  val sixteenth: P = p
+  val seventeenth: Q = q
+  val eighteenth: R = r
+  val nineteenth: S = s
+  val twentyFirst: U = u
+
   companion object
 }
 
-class ForTuple22 private constructor() { companion object }
+class ForTuple22 private constructor() {
+  companion object
+}
 typealias Tuple22Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> = arrow.Kind22<ForTuple22, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V>
 typealias Tuple22PartialOf<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> = arrow.Kind21<ForTuple22, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>
 
@@ -146,7 +719,74 @@ typealias Tuple22PartialOf<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R,
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> Tuple22Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V>.fix(): Tuple22<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> =
   this as Tuple22<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V>
 
-data class Tuple22<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J, out K, out L, out M, out N, out O, out P, out Q, out R, out S, out T, out U, out V>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G, val h: H, val i: I, val j: J, val k: K, val l: L, val m: M, val n: N, val o: O, val p: P, val q: Q, val r: R, val s: S, val t: T, val u: U, val v: V) : Tuple22Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> {
+data class Tuple22<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J, out K, out L, out M, out N, out O, out P, out Q, out R, out S, out T, out U, out V>(
+  @Deprecated("Use first instead", ReplaceWith("first"))
+  val a: A,
+  @Deprecated("Use second instead", ReplaceWith("second"))
+  val b: B,
+  @Deprecated("Use third instead", ReplaceWith("third"))
+  val c: C,
+  @Deprecated("Use fourth instead", ReplaceWith("fourth"))
+  val d: D,
+  @Deprecated("Use fifth instead", ReplaceWith("fifth"))
+  val e: E,
+  @Deprecated("Use sixth instead", ReplaceWith("sixth"))
+  val f: F,
+  @Deprecated("Use seventh instead", ReplaceWith("seventh"))
+  val g: G,
+  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  val h: H,
+  @Deprecated("Use ninth instead", ReplaceWith("ninth"))
+  val i: I,
+  @Deprecated("Use tenth instead", ReplaceWith("tenth"))
+  val j: J,
+  @Deprecated("Use eleventh instead", ReplaceWith("eleventh"))
+  val k: K,
+  @Deprecated("Use twelfth instead", ReplaceWith("twelfth"))
+  val l: L,
+  @Deprecated("Use thirteenth instead", ReplaceWith("thirteenth"))
+  val m: M,
+  @Deprecated("Use fourteenth instead", ReplaceWith("fourteenth"))
+  val n: N,
+  @Deprecated("Use fifteenth instead", ReplaceWith("fifteenth"))
+  val o: O,
+  @Deprecated("Use sixteenth instead", ReplaceWith("sixteenth"))
+  val p: P,
+  @Deprecated("Use seventeenth instead", ReplaceWith("seventeenth"))
+  val q: Q,
+  @Deprecated("Use eighteenth instead", ReplaceWith("eighteenth"))
+  val r: R,
+  @Deprecated("Use nineteenth instead", ReplaceWith("nineteenth"))
+  val s: S,
+  @Deprecated("Use twentieth instead", ReplaceWith("twentieth"))
+  val t: T,
+  @Deprecated("Use twentyFirst instead", ReplaceWith("twentyFirst"))
+  val u: U,
+  @Deprecated("Use twentySecond instead", ReplaceWith("twentySecond"))
+  val v: V
+) : Tuple22Of<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> {
+  val first: A = a
+  val second: B = b
+  val third: C = c
+  val fourth: D = d
+  val fifth: E = e
+  val sixth: F = f
+  val seventh: G = g
+  val eight: H = h
+  val ninth: I = i
+  val tenth: J = j
+  val eleventh: K = k
+  val twelfth: L = l
+  val thirteenth: M = m
+  val fourteenth: N = n
+  val fifteenth: O = o
+  val sixteenth: P = p
+  val seventeenth: Q = q
+  val eighteenth: R = r
+  val nineteenth: S = s
+  val twentyFirst: U = u
+  val twentySecond: V = v
+
   companion object
 }
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/TupleN.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/TupleN.kt
@@ -31,7 +31,7 @@ data class Tuple11<out A, out B, out C, out D, out E, out F, out G, out H, out I
   val f: F,
   @Deprecated("Use seventh instead", ReplaceWith("seventh"))
   val g: G,
-  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  @Deprecated("Use eighth instead", ReplaceWith("eighth"))
   val h: H,
   @Deprecated("Use ninth instead", ReplaceWith("ninth"))
   val i: I,
@@ -80,7 +80,7 @@ data class Tuple12<out A, out B, out C, out D, out E, out F, out G, out H, out I
   val f: F,
   @Deprecated("Use seventh instead", ReplaceWith("seventh"))
   val g: G,
-  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  @Deprecated("Use eighth instead", ReplaceWith("eighth"))
   val h: H,
   @Deprecated("Use ninth instead", ReplaceWith("ninth"))
   val i: I,
@@ -132,7 +132,7 @@ data class Tuple13<out A, out B, out C, out D, out E, out F, out G, out H, out I
   val f: F,
   @Deprecated("Use seventh instead", ReplaceWith("seventh"))
   val g: G,
-  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  @Deprecated("Use eighth instead", ReplaceWith("eighth"))
   val h: H,
   @Deprecated("Use ninth instead", ReplaceWith("ninth"))
   val i: I,
@@ -187,7 +187,7 @@ data class Tuple14<out A, out B, out C, out D, out E, out F, out G, out H, out I
   val f: F,
   @Deprecated("Use seventh instead", ReplaceWith("seventh"))
   val g: G,
-  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  @Deprecated("Use eighth instead", ReplaceWith("eighth"))
   val h: H,
   @Deprecated("Use ninth instead", ReplaceWith("ninth"))
   val i: I,
@@ -245,7 +245,7 @@ data class Tuple15<out A, out B, out C, out D, out E, out F, out G, out H, out I
   val f: F,
   @Deprecated("Use seventh instead", ReplaceWith("seventh"))
   val g: G,
-  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  @Deprecated("Use eighth instead", ReplaceWith("eighth"))
   val h: H,
   @Deprecated("Use ninth instead", ReplaceWith("ninth"))
   val i: I,
@@ -306,7 +306,7 @@ data class Tuple16<out A, out B, out C, out D, out E, out F, out G, out H, out I
   val f: F,
   @Deprecated("Use seventh instead", ReplaceWith("seventh"))
   val g: G,
-  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  @Deprecated("Use eighth instead", ReplaceWith("eighth"))
   val h: H,
   @Deprecated("Use ninth instead", ReplaceWith("ninth"))
   val i: I,
@@ -370,7 +370,7 @@ data class Tuple17<out A, out B, out C, out D, out E, out F, out G, out H, out I
   val f: F,
   @Deprecated("Use seventh instead", ReplaceWith("seventh"))
   val g: G,
-  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  @Deprecated("Use eighth instead", ReplaceWith("eighth"))
   val h: H,
   @Deprecated("Use ninth instead", ReplaceWith("ninth"))
   val i: I,
@@ -437,7 +437,7 @@ data class Tuple18<out A, out B, out C, out D, out E, out F, out G, out H, out I
   val f: F,
   @Deprecated("Use seventh instead", ReplaceWith("seventh"))
   val g: G,
-  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  @Deprecated("Use eighth instead", ReplaceWith("eighth"))
   val h: H,
   @Deprecated("Use ninth instead", ReplaceWith("ninth"))
   val i: I,
@@ -507,7 +507,7 @@ data class Tuple19<out A, out B, out C, out D, out E, out F, out G, out H, out I
   val f: F,
   @Deprecated("Use seventh instead", ReplaceWith("seventh"))
   val g: G,
-  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  @Deprecated("Use eighth instead", ReplaceWith("eighth"))
   val h: H,
   @Deprecated("Use ninth instead", ReplaceWith("ninth"))
   val i: I,
@@ -580,7 +580,7 @@ data class Tuple20<out A, out B, out C, out D, out E, out F, out G, out H, out I
   val f: F,
   @Deprecated("Use seventh instead", ReplaceWith("seventh"))
   val g: G,
-  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  @Deprecated("Use eighth instead", ReplaceWith("eighth"))
   val h: H,
   @Deprecated("Use ninth instead", ReplaceWith("ninth"))
   val i: I,
@@ -656,7 +656,7 @@ data class Tuple21<out A, out B, out C, out D, out E, out F, out G, out H, out I
   val f: F,
   @Deprecated("Use seventh instead", ReplaceWith("seventh"))
   val g: G,
-  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  @Deprecated("Use eighth instead", ReplaceWith("eighth"))
   val h: H,
   @Deprecated("Use ninth instead", ReplaceWith("ninth"))
   val i: I,
@@ -734,7 +734,7 @@ data class Tuple22<out A, out B, out C, out D, out E, out F, out G, out H, out I
   val f: F,
   @Deprecated("Use seventh instead", ReplaceWith("seventh"))
   val g: G,
-  @Deprecated("Use eigth instead", ReplaceWith("eigth"))
+  @Deprecated("Use eighth instead", ReplaceWith("eighth"))
   val h: H,
   @Deprecated("Use ninth instead", ReplaceWith("ninth"))
   val i: I,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -848,11 +848,19 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
     { a -> HR.run { a.hashWithSalt(salt.hashWithSalt(1)) } }
   )
 
-  data class Valid<out A>(val a: A) : Validated<Nothing, A>() {
+  data class Valid<out A>(
+    @Deprecated("Use value instead", ReplaceWith("value"))
+    val a: A
+  ) : Validated<Nothing, A>() {
+    val value: A = a
     override fun toString(): String = "Validated.Valid($a)"
   }
 
-  data class Invalid<out E>(val e: E) : Validated<E, Nothing>() {
+  data class Invalid<out E>(
+    @Deprecated("Use value instead", ReplaceWith("value"))
+    val e: E
+  ) : Validated<E, Nothing>() {
+    val value: E = e
     override fun toString(): String = "Validated.Invalid($e)"
   }
 


### PR DESCRIPTION
Related to an old ticket which we want to clear up while moving towards 1.0.0

https://github.com/arrow-kt/arrow-core/issues/20

> Many nested values have their own identifiers:
>```
>Some.t
>Left.l
>Right.r
>...
>```
>
> This issue is to track the creation of extension syntax for all those datatypes that bring a unified access to the inner property through property extension.
> Ex taken from slack where @hastebrot proposed: