### PR TITLE
CU-bezf1h deprecate Arrow Annotations

### DIFF
--- a/arrow-annotations/src/main/java/arrow/autofold.kt
+++ b/arrow-annotations/src/main/java/arrow/autofold.kt
@@ -3,4 +3,5 @@ package arrow
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)
 @MustBeDocumented
+@Deprecated("kapt generation of autofold will no longer be supported in the future. Prefer using when directly in code, or manually implement fold")
 annotation class autofold

--- a/arrow-annotations/src/main/java/arrow/coproduct.kt
+++ b/arrow-annotations/src/main/java/arrow/coproduct.kt
@@ -1,3 +1,4 @@
 package arrow
 
+@Deprecated("The coproduct kapt generator will no longer be supported.")
 annotation class coproduct

--- a/arrow-annotations/src/main/java/arrow/documented.kt
+++ b/arrow-annotations/src/main/java/arrow/documented.kt
@@ -5,4 +5,5 @@ import kotlin.annotation.AnnotationTarget.CLASS
 
 @Retention(SOURCE)
 @Target(CLASS)
+@Deprecated("documented was meant to document polymorphic interfaces with @extension implementations. This annotation is deprecated along with @extensions")
 annotation class documented

--- a/arrow-annotations/src/main/java/arrow/extension.kt
+++ b/arrow-annotations/src/main/java/arrow/extension.kt
@@ -7,6 +7,7 @@ package arrow
   AnnotationTarget.FUNCTION
 )
 @MustBeDocumented
+@Deprecated(KindDeprecation)
 annotation class extension
 
 val given: Nothing

--- a/arrow-annotations/src/main/java/arrow/higherkind.kt
+++ b/arrow-annotations/src/main/java/arrow/higherkind.kt
@@ -5,4 +5,5 @@ package arrow
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)
 @MustBeDocumented
+@Deprecated(KindDeprecation)
 annotation class higherkind

--- a/arrow-annotations/src/main/java/arrow/hkjs.kt
+++ b/arrow-annotations/src/main/java/arrow/hkjs.kt
@@ -4,12 +4,17 @@ package arrow
 
 import io.kindedj.Hk as HK_J
 
+@Deprecated(KindDeprecation)
 typealias HkJ<F, A> = HK_J<F, A>
 
+@Deprecated(KindDeprecation)
 typealias HkJ2<F, A, B> = HK_J<HK_J<F, A>, B>
 
+@Deprecated(KindDeprecation)
 typealias HkJ3<F, A, B, C> = HK_J<HkJ2<F, A, B>, C>
 
+@Deprecated(KindDeprecation)
 typealias HkJ4<F, A, B, C, D> = HK_J<HkJ3<F, A, B, C>, D>
 
+@Deprecated(KindDeprecation)
 typealias HkJ5<F, A, B, C, D, E> = HK_J<HkJ4<F, A, B, C, D>, E>

--- a/arrow-annotations/src/main/java/arrow/product.kt
+++ b/arrow-annotations/src/main/java/arrow/product.kt
@@ -8,6 +8,7 @@ import kotlin.annotation.AnnotationTarget.CLASS
 /**
  * Empty arrays means "Everything that matches annotated class"
  */
+@Deprecated("The product kapt generator will no longer be supported.")
 annotation class product(val deriving: Array<DerivingTarget> = [])
 
 enum class DerivingTarget {

--- a/arrow-annotations/src/main/java/arrow/synthetic.kt
+++ b/arrow-annotations/src/main/java/arrow/synthetic.kt
@@ -31,5 +31,4 @@ package arrow
   AnnotationTarget.TYPEALIAS
 )
 @MustBeDocumented
-@Deprecated("This annotation is deprecated along with the deprecation of the Arrow-meta kapt implementation.")
 annotation class synthetic

--- a/arrow-annotations/src/main/java/arrow/synthetic.kt
+++ b/arrow-annotations/src/main/java/arrow/synthetic.kt
@@ -31,4 +31,5 @@ package arrow
   AnnotationTarget.TYPEALIAS
 )
 @MustBeDocumented
+@Deprecated("This annotation is deprecated along with the deprecation of the Arrow-meta kapt implementation.")
 annotation class synthetic

--- a/arrow-annotations/src/main/java/arrow/undocumented.kt
+++ b/arrow-annotations/src/main/java/arrow/undocumented.kt
@@ -5,4 +5,5 @@ import kotlin.annotation.AnnotationTarget.CLASS
 
 @Retention(SOURCE)
 @Target(CLASS)
+@Deprecated("undocumented was meant to document polymorphic interfaces with @extension implementations. This annotation is deprecated along with @extensions")
 annotation class undocumented


### PR DESCRIPTION
This PR deprecates some of the annotations in Arrow that will no longer be supported, most of them relating to higher kinded types.