### PR TITLE
Clean up constructors Arrow Core Datatypes.

### DIFF
--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -1065,7 +1065,7 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
    * The left side of the disjoint union, as opposed to the [Right] side.
    */
   @Suppress("DataClassPrivateConstructor")
-  data class Left<out A> @PublishedApi internal constructor(
+  data class Left<out A> constructor(
     @Deprecated("Use value instead", ReplaceWith("value"))
     val a: A
   ) : Either<A, Nothing>() {
@@ -1076,6 +1076,7 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
     override fun toString(): String = "Either.Left($a)"
 
     companion object {
+      @Deprecated("Deprecated, use the constructor instead", ReplaceWith("Either.Left(a)", "arrow.core.Either"))
       operator fun <A> invoke(a: A): Either<A, Nothing> = Left(a)
     }
   }
@@ -1084,7 +1085,7 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
    * The right side of the disjoint union, as opposed to the [Left] side.
    */
   @Suppress("DataClassPrivateConstructor")
-  data class Right<out B> @PublishedApi internal constructor(
+  data class Right<out B> constructor(
     @Deprecated("Use value instead", ReplaceWith("value"))
     val b: B
   ) : Either<Nothing, B>() {
@@ -1095,6 +1096,7 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
     override fun toString(): String = "Either.Right($b)"
 
     companion object {
+      @Deprecated("Deprecated, use the constructor instead", ReplaceWith("Either.Right(b)", "arrow.core.Either"))
       operator fun <B> invoke(b: B): Either<Nothing, B> = Right(b)
     }
   }

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -13,23 +13,27 @@ import arrow.typeclasses.ShowDeprecation
 @Deprecated(
   message = KindDeprecation,
   level = DeprecationLevel.WARNING
-)class ForEither private constructor() {
+)
+class ForEither private constructor() {
   companion object
 }
 @Deprecated(
   message = KindDeprecation,
   level = DeprecationLevel.WARNING
-)typealias EitherOf<A, B> = arrow.Kind2<ForEither, A, B>
+)
+typealias EitherOf<A, B> = arrow.Kind2<ForEither, A, B>
 @Deprecated(
   message = KindDeprecation,
   level = DeprecationLevel.WARNING
-)typealias EitherPartialOf<A> = arrow.Kind<ForEither, A>
+)
+typealias EitherPartialOf<A> = arrow.Kind<ForEither, A>
 
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
 @Deprecated(
   message = KindDeprecation,
   level = DeprecationLevel.WARNING
-)inline fun <A, B> EitherOf<A, B>.fix(): Either<A, B> =
+)
+inline fun <A, B> EitherOf<A, B>.fix(): Either<A, B> =
   this as Either<A, B>
 
 /**
@@ -1064,7 +1068,6 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
   /**
    * The left side of the disjoint union, as opposed to the [Right] side.
    */
-  @Suppress("DataClassPrivateConstructor")
   data class Left<out A> constructor(
     @Deprecated("Use value instead", ReplaceWith("value"))
     val a: A
@@ -1084,7 +1087,6 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
   /**
    * The right side of the disjoint union, as opposed to the [Left] side.
    */
-  @Suppress("DataClassPrivateConstructor")
   data class Right<out B> constructor(
     @Deprecated("Use value instead", ReplaceWith("value"))
     val b: B
@@ -1132,11 +1134,12 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
     )
     fun <R> right(right: R): Either<Nothing, R> = Right(right)
 
-    val leftUnit: Either<Unit, Nothing> = left(Unit)
+    @PublishedApi
+    internal val leftUnit: Either<Unit, Nothing> =
+      left(Unit)
 
-    val unit: Either<Nothing, Unit> = right(Unit)
-
-    fun <L> unit(): Either<L, Unit> = unit
+    @PublishedApi
+    internal val unit: Either<Nothing, Unit> = right(Unit)
 
     fun <A> fromNullable(a: A?): Either<Unit, A> = a?.right() ?: Unit.left()
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Either.kt
@@ -1118,8 +1118,16 @@ sealed class Either<out A, out B> : EitherOf<A, B> {
 
   companion object {
 
+    @Deprecated(
+      "This constructor is duplicated with Either.Left. Use Either.Left instead.",
+      ReplaceWith("Either.Left(left)", "arrow.core.Either")
+    )
     fun <L> left(left: L): Either<L, Nothing> = Left(left)
 
+    @Deprecated(
+      "This constructor is duplicated with Either.Right. Use Either.Right instead.",
+      ReplaceWith("Either.Right(right)", "arrow.core.Either")
+    )
     fun <R> right(right: R): Either<Nothing, R> = Right(right)
 
     val leftUnit: Either<Unit, Nothing> = left(Unit)

--- a/arrow-core-data/src/main/kotlin/arrow/core/Eval.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Eval.kt
@@ -183,7 +183,7 @@ sealed class Eval<out A> : EvalOf<A> {
     fun raise(t: Throwable): Eval<Nothing> =
       defer { throw t }
 
-    val unit: Eval<Unit> = Now(kotlin.Unit)
+    val Unit: Eval<Unit> = Now(kotlin.Unit)
 
     val True: Eval<Boolean> = Now(true)
 
@@ -284,7 +284,7 @@ sealed class Eval<out A> : EvalOf<A> {
       b: Eval<B>,
       map: (A, B) -> C
     ): Eval<C> =
-      mapN(a, b, unit, unit, unit, unit, unit, unit, unit) { aa, bb, _, _, _, _, _, _, _ -> map(aa, bb) }
+      mapN(a, b, Unit, Unit, Unit, Unit, Unit, Unit, Unit) { aa, bb, _, _, _, _, _, _, _ -> map(aa, bb) }
 
     fun <A, B, C, D> mapN(
       a: Eval<A>,
@@ -292,7 +292,7 @@ sealed class Eval<out A> : EvalOf<A> {
       c: Eval<C>,
       map: (A, B, C) -> D
     ): Eval<D> =
-      mapN(a, b, c, unit, unit, unit, unit, unit, unit, unit) { aa, bb, cc, _, _, _, _, _, _, _ -> map(aa, bb, cc) }
+      mapN(a, b, c, Unit, Unit, Unit, Unit, Unit, Unit, Unit) { aa, bb, cc, _, _, _, _, _, _, _ -> map(aa, bb, cc) }
 
     fun <A, B, C, D, E> mapN(
       a: Eval<A>,
@@ -301,7 +301,7 @@ sealed class Eval<out A> : EvalOf<A> {
       d: Eval<D>,
       map: (A, B, C, D) -> E
     ): Eval<E> =
-      mapN(a, b, c, d, unit, unit, unit, unit, unit, unit) { aa, bb, cc, dd, _, _, _, _, _, _ -> map(aa, bb, cc, dd) }
+      mapN(a, b, c, d, Unit, Unit, Unit, Unit, Unit, Unit) { aa, bb, cc, dd, _, _, _, _, _, _ -> map(aa, bb, cc, dd) }
 
     fun <A, B, C, D, E, F> mapN(
       a: Eval<A>,
@@ -311,7 +311,7 @@ sealed class Eval<out A> : EvalOf<A> {
       e: Eval<E>,
       map: (A, B, C, D, E) -> F
     ): Eval<F> =
-      mapN(a, b, c, d, e, unit, unit, unit, unit, unit) { aa, bb, cc, dd, ee, _, _, _, _, _ -> map(aa, bb, cc, dd, ee) }
+      mapN(a, b, c, d, e, Unit, Unit, Unit, Unit, Unit) { aa, bb, cc, dd, ee, _, _, _, _, _ -> map(aa, bb, cc, dd, ee) }
 
     fun <A, B, C, D, E, F, G> mapN(
       a: Eval<A>,
@@ -322,7 +322,7 @@ sealed class Eval<out A> : EvalOf<A> {
       f: Eval<F>,
       map: (A, B, C, D, E, F) -> G
     ): Eval<G> =
-      mapN(a, b, c, d, e, f, unit, unit, unit, unit) { aa, bb, cc, dd, ee, ff, _, _, _, _ -> map(aa, bb, cc, dd, ee, ff) }
+      mapN(a, b, c, d, e, f, Unit, Unit, Unit, Unit) { aa, bb, cc, dd, ee, ff, _, _, _, _ -> map(aa, bb, cc, dd, ee, ff) }
 
     fun <A, B, C, D, E, F, G, H> mapN(
       a: Eval<A>,
@@ -334,7 +334,7 @@ sealed class Eval<out A> : EvalOf<A> {
       g: Eval<G>,
       map: (A, B, C, D, E, F, G) -> H
     ): Eval<H> =
-      mapN(a, b, c, d, e, f, g, unit, unit, unit) { aa, bb, cc, dd, ee, ff, gg, _, _, _ -> map(aa, bb, cc, dd, ee, ff, gg) }
+      mapN(a, b, c, d, e, f, g, Unit, Unit, Unit) { aa, bb, cc, dd, ee, ff, gg, _, _, _ -> map(aa, bb, cc, dd, ee, ff, gg) }
 
     fun <A, B, C, D, E, F, G, H, I> mapN(
       a: Eval<A>,
@@ -347,7 +347,7 @@ sealed class Eval<out A> : EvalOf<A> {
       h: Eval<H>,
       map: (A, B, C, D, E, F, G, H) -> I
     ): Eval<I> =
-      mapN(a, b, c, d, e, f, g, h, unit, unit) { aa, bb, cc, dd, ee, ff, gg, hh, _, _ -> map(aa, bb, cc, dd, ee, ff, gg, hh) }
+      mapN(a, b, c, d, e, f, g, h, Unit, Unit) { aa, bb, cc, dd, ee, ff, gg, hh, _, _ -> map(aa, bb, cc, dd, ee, ff, gg, hh) }
 
     fun <A, B, C, D, E, F, G, H, I, J> mapN(
       a: Eval<A>,
@@ -361,7 +361,7 @@ sealed class Eval<out A> : EvalOf<A> {
       i: Eval<I>,
       map: (A, B, C, D, E, F, G, H, I) -> J
     ): Eval<J> =
-      mapN(a, b, c, d, e, f, g, h, i, unit) { aa, bb, cc, dd, ee, ff, gg, hh, ii, _ -> map(aa, bb, cc, dd, ee, ff, gg, hh, ii) }
+      mapN(a, b, c, d, e, f, g, h, i, Unit) { aa, bb, cc, dd, ee, ff, gg, hh, ii, _ -> map(aa, bb, cc, dd, ee, ff, gg, hh, ii) }
 
     fun <A, B, C, D, E, F, G, H, I, J, K> mapN(
       a: Eval<A>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Eval.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Eval.kt
@@ -7,19 +7,22 @@ import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 @Deprecated(
   message = KindDeprecation,
   level = DeprecationLevel.WARNING
-)class ForEval private constructor() {
+)
+class ForEval private constructor() {
   companion object
 }
 @Deprecated(
   message = KindDeprecation,
   level = DeprecationLevel.WARNING
-)typealias EvalOf<A> = arrow.Kind<ForEval, A>
+)
+typealias EvalOf<A> = arrow.Kind<ForEval, A>
 
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
 @Deprecated(
   message = KindDeprecation,
   level = DeprecationLevel.WARNING
-)inline fun <A> EvalOf<A>.fix(): Eval<A> =
+)
+inline fun <A> EvalOf<A>.fix(): Eval<A> =
   this as Eval<A>
 
 @Deprecated(
@@ -183,14 +186,34 @@ sealed class Eval<out A> : EvalOf<A> {
     fun raise(t: Throwable): Eval<Nothing> =
       defer { throw t }
 
+    @Deprecated(
+      "This constructor is deprecated in favor of the Now constructor",
+      ReplaceWith("Eval.now(kotlin.Unit)", "arrow.core.Eval")
+    )
     val Unit: Eval<Unit> = Now(kotlin.Unit)
 
+    @Deprecated(
+      "This constructor is deprecated in favor of the Now constructor",
+      ReplaceWith("Eval.now(true)", "arrow.core.Eval")
+    )
     val True: Eval<Boolean> = Now(true)
 
+    @Deprecated(
+      "This constructor is deprecated in favor of the Now constructor",
+      ReplaceWith("Eval.now(false)", "arrow.core.Eval")
+    )
     val False: Eval<Boolean> = Now(false)
 
+    @Deprecated(
+      "This constructor is deprecated in favor of the Now constructor",
+      ReplaceWith("Eval.now(0)", "arrow.core.Eval")
+    )
     val Zero: Eval<Int> = Now(0)
 
+    @Deprecated(
+      "This constructor is deprecated in favor of the Now constructor",
+      ReplaceWith("Eval.now(1)", "arrow.core.Eval")
+    )
     val One: Eval<Int> = Now(1)
 
     /**

--- a/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Ior.kt
@@ -610,7 +610,7 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
     override fun toString(): String = "Ior.Left($value)"
 
     companion object {
-      @Deprecated("Deprecated, use the constructor instead", ReplaceWith("Left(a)"))
+      @Deprecated("Deprecated, use the constructor instead", ReplaceWith("Ior.Left(a)", "arrow.core.Ior"))
       operator fun <A> invoke(a: A): Ior<A, Nothing> = Left(a)
     }
   }
@@ -623,7 +623,7 @@ sealed class Ior<out A, out B> : IorOf<A, B> {
     override fun toString(): String = "Ior.Right($value)"
 
     companion object {
-      @Deprecated("Deprecated, use the constructor instead", ReplaceWith("Right(a)"))
+      @Deprecated("Deprecated, use the constructor instead", ReplaceWith("Ior.Right(a)", "arrow.core.Right"))
       operator fun <B> invoke(b: B): Ior<Nothing, B> = Right(b)
     }
   }

--- a/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
@@ -359,7 +359,7 @@ class NonEmptyList<out A>(
     @Deprecated(
       "just is deprecated, and will be removed in 0.13.0. Please use NonEmptyList.of instead.",
       ReplaceWith(
-        "NonEmptyList.of(a)",
+        "nonEmptyListOf(a)",
         "arrow.core.NonEmptyList"
       ),
       DeprecationLevel.WARNING

--- a/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
@@ -346,6 +346,14 @@ class NonEmptyList<out A>(
     fun <A> fromListUnsafe(l: List<A>): NonEmptyList<A> =
       NonEmptyList(l)
 
+    @Deprecated(
+      "just is deprecated, and will be removed in 0.13.0. Please use NonEmptyList.of instead.",
+      ReplaceWith(
+        "NonEmptyList.of(a)",
+        "arrow.core.NonEmptyList"
+      ),
+      DeprecationLevel.WARNING
+    )
     fun <A> just(a: A): NonEmptyList<A> =
       of(a)
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/NonEmptyList.kt
@@ -10,7 +10,8 @@ import arrow.typeclasses.ShowDeprecation
 @Deprecated(
   message = KindDeprecation,
   level = DeprecationLevel.WARNING
-)class ForNonEmptyList private constructor() {
+)
+class ForNonEmptyList private constructor() {
   companion object
 }
 @Deprecated(
@@ -334,9 +335,18 @@ class NonEmptyList<out A>(
     NonEmptyList(head to other.head, tail.padZip(other.tail))
 
   companion object {
+
+    @Deprecated(
+      "Renamed to nonEmptyListOf to align with Kotlin Std standards",
+      ReplaceWith("nonEmptyListOf(head, t)", "arrow.core.nonEmptyListOf")
+    )
     operator fun <A> invoke(head: A, vararg t: A): NonEmptyList<A> =
       NonEmptyList(head, t.asList())
 
+    @Deprecated(
+      "Renamed to nonEmptyListOf to align with Kotlin Std standards",
+      ReplaceWith("nonEmptyListOf(head, t)", "arrow.core.nonEmptyListOf")
+    )
     fun <A> of(head: A, vararg t: A): NonEmptyList<A> =
       NonEmptyList(head, t.asList())
 
@@ -357,7 +367,8 @@ class NonEmptyList<out A>(
     fun <A> just(a: A): NonEmptyList<A> =
       of(a)
 
-    val unit: NonEmptyList<Unit> =
+    @PublishedApi
+    internal val unit: NonEmptyList<Unit> =
       of(Unit)
 
     inline fun <B, C, D> mapN(
@@ -510,6 +521,9 @@ class NonEmptyList<out A>(
   }
 }
 
+fun <A> nonEmptyListOf(head: A, vararg t: A): NonEmptyList<A> =
+  NonEmptyList(head, t.asList())
+
 inline fun <A> A.nel(): NonEmptyList<A> =
   NonEmptyList.of(this)
 
@@ -543,7 +557,7 @@ fun <A, B, C> NonEmptyList<C>.unzip(f: (C) -> Pair<A, B>): Pair<NonEmptyList<A>,
   this.map(f).let { nel ->
     nel.tail.unzip().let {
       NonEmptyList(nel.head.first, it.first) to
-      NonEmptyList(nel.head.second, it.second)
+        NonEmptyList(nel.head.second, it.second)
     }
   }
 

--- a/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
@@ -441,7 +441,8 @@ sealed class Option<out A> : OptionOf<A> {
     )
     fun <A> empty(): Option<A> = None
 
-    val unit: Option<Unit> = Some(Unit)
+    @PublishedApi
+    internal val unit: Option<Unit> = Some(Unit)
 
     inline fun <A, B, C> mapN(
       a: Option<A>,

--- a/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Option.kt
@@ -431,6 +431,14 @@ sealed class Option<out A> : OptionOf<A> {
         None
       }
 
+    @Deprecated(
+      "empty is deprecated, and will be removed in 0.13.0. Please use None instead.",
+      ReplaceWith(
+        "None",
+        "arrow.core.None"
+      ),
+      DeprecationLevel.WARNING
+    )
     fun <A> empty(): Option<A> = None
 
     val unit: Option<Unit> = Some(Unit)

--- a/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
+++ b/arrow-core-data/src/main/kotlin/arrow/core/Validated.kt
@@ -544,9 +544,9 @@ sealed class Validated<out E, out A> : ValidatedOf<E, A> {
 
     val s = 1.inc()
 
-    val unit: Validated<Nothing, Unit> = Unit.valid()
-
-    fun <E> unit(): Validated<E, Unit> = unit
+    @PublishedApi
+    internal val unit: Validated<Nothing, Unit> =
+      Validated.Valid(Unit)
 
     inline fun <E, A, B, Z> mapN(
       SE: Semigroup<E>,

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/either/applicative/EitherApplicative.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/either/applicative/EitherApplicative.kt
@@ -31,7 +31,7 @@ internal val applicative_singleton: EitherApplicative<Any?> = object : EitherApp
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("this.right()", "arrow.core.right"))
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.Right(this)", "arrow.core.Either"))
 fun <L, A> A.just(): Either<L, A> =
   right()
 
@@ -42,9 +42,9 @@ fun <L, A> A.just(): Either<L, A> =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.unit()", "arrow.core.unit"))
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Either.Right(Unit)", "arrow.core.Either"))
 fun <L> unit(): Either<L, Unit> =
-  Either.unit()
+  Either.Right(Unit)
 
 @JvmName("map")
 @Suppress(

--- a/arrow-core/src/main/kotlin/arrow/core/extensions/validated/applicative/ValidatedApplicative.kt
+++ b/arrow-core/src/main/kotlin/arrow/core/extensions/validated/applicative/ValidatedApplicative.kt
@@ -24,7 +24,7 @@ import kotlin.jvm.JvmName
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("valid<A>()", "arrow.core.valid"))
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.Valid(this)", "arrow.core.Validated"))
 fun <E, A> A.just(SE: Semigroup<E>): Validated<E, A> =
   valid()
 
@@ -35,9 +35,9 @@ fun <E, A> A.just(SE: Semigroup<E>): Validated<E, A> =
   "EXTENSION_SHADOWED_BY_MEMBER",
   "UNUSED_PARAMETER"
 )
-@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.unit<E>()", "arrow.core.Validated"))
+@Deprecated("@extension kinded projected functions are deprecated", ReplaceWith("Validated.Valid(Unit)", "arrow.core.Validated"))
 fun <E> unit(SE: Semigroup<E>): Validated<E, Unit> =
-  Validated.unit()
+  Validated.Valid(Unit)
 
 @JvmName("map")
 @Suppress(


### PR DESCRIPTION
This PR deprecates up all duplicated constructors, and deprecates all `just` constructors.

This leaves behind only the actual constructors, and the extension constructors.

All constructors of Either after removal of deprecated methods:

```
val x: Either<String, Int> = Either.Right(1)
val y: Either<String, Int> = Either.Left("one")
val x2: Either<String, Int> = 1.right()
val y2: Either<String, Int> = "one".left()
```