### PR TITLE
Publication: disable checksums for maven-metadata.xml

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,6 @@ kapt.incremental.apt=false
 GOOGLE_AUTO_SERVICE_VERSION=1.0-rc7
 GOOGLE_COMPILE_TESTING_VERSION=0.18
 KOTLIN_POET_VERSION=1.5.0
+
+# To disable publishing of sha-512 checksums for maven-metadata.xml files
+systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
Reason: it seems they aren't allowed today:

> Cannot upload checksum for snapshot-maven-metadata.xml. Remote repository doesn't support sha-512. Error: Could not PUT 'https://oss.jfrog.org/artifactory/oss-snapshot-local/io/arrow-kt/arrow-continuations/0.12.0-SNAPSHOT/maven-metadata.xml.sha512'. Received status code 404 from server: 

